### PR TITLE
Updates to the schema: token amount and subgraph versioning

### DIFF
--- a/schema-common.graphql
+++ b/schema-common.graphql
@@ -12,7 +12,7 @@
 #   - hash/address: String
 #   - block height: BigInt
 #   - timestamp: unix timestamp in BigInt
-#   - token amount: All token amounts should be BigDecimal after normalizing according to its decimals
+#   - token amount: All token amounts should be BigInt to preserve precision (i.e. in wei)
 #   - dollar amount: All USD amounts (including prices) should be BigDecimal
 # - Certain prefixes may be used to indicate a particular type of value.
 #   * total - indicates this is a cumulative value (e.g. totalSharesMinted, totalGrossReturns)
@@ -82,7 +82,7 @@ type RewardToken @entity {
   symbol: String!
   decimals: Int!
 
-  type: RewardTokenType
+  type: RewardTokenType!
 }
 
 #############################
@@ -98,6 +98,9 @@ interface Protocol {
 
   " Slug of protocol, including version. e.g. uniswap-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -204,10 +207,10 @@ interface Pool {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -242,16 +245,16 @@ interface PoolDailySnapshot {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: BigDecimal!
+  inputTokenBalances: BigInt!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
 
   " Total amount of reward token emissions in a day, in token's native amount "
-  rewardTokenEmissionsAmount: [BigDecimal!]
+  rewardTokenEmissionsAmount: [BigInt!]
 
   " Total amount of reward token emissions in a day, normalized to USD "
   rewardTokenEmissionsUSD: [BigDecimal!]
@@ -326,7 +329,7 @@ type Deposit implements Event @entity {
   asset: Token!
 
   " Amount of token deposited in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token deposited in USD "
   amountUSD: BigDecimal!
@@ -362,7 +365,7 @@ type Withdraw implements Event @entity {
   asset: Token!
 
   " Amount of token withdrawn in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token withdrawn in USD "
   amountUSD: BigDecimal!
@@ -384,6 +387,9 @@ type DexAmmProtocol implements Protocol @entity {
 
   " Slug of protocol, including version. e.g. uniswap-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -423,10 +429,10 @@ type LiquidityPool implements Pool @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -533,6 +539,9 @@ type LendingProtocol implements Protocol @entity {
   " Slug of protocol, including version. e.g. aave-v2 "
   slug: String!
 
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
+
   network: Network!
 
   type: ProtocolType!
@@ -580,10 +589,10 @@ type Market implements Pool @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the market. The ordering should be the same as the market's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -650,19 +659,19 @@ type MarketDailySnapshot implements PoolDailySnapshot @entity {
   totalValueLockedUSD: BigDecimal!
 
   " Amount of input tokens in the market. The ordering should be the same as the market's `inputTokens` field. "
-  inputTokenBalances: BigDecimal!
+  inputTokenBalances: BigInt!
 
   " Price per share of input token in USD "
   inputTokenPricesUSD: [BigDecimal!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
 
   " Total amount of reward token emissions in a day, in token's native amount "
-  rewardTokenEmissionsAmount: [BigDecimal!]
+  rewardTokenEmissionsAmount: [BigInt!]
 
   " Total amount of reward token emissions in a day, normalized to USD "
   rewardTokenEmissionsUSD: [BigDecimal!]
@@ -717,7 +726,7 @@ type Borrow implements Event @entity {
   asset: Token!
 
   " Amount of token borrowed in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token borrowed in USD "
   amountUSD: BigDecimal
@@ -755,7 +764,7 @@ type Repay implements Event @entity {
   asset: Token!
 
   " Amount of token repaid in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token repaid in USD "
   amountUSD: BigDecimal
@@ -793,7 +802,7 @@ type Liquidation implements Event @entity {
   asset: Token!
 
   " Amount of token liquidated in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token liquidated in USD "
   amountUSD: BigDecimal
@@ -815,6 +824,9 @@ type YieldAggregator implements Protocol @entity {
 
   " Slug of protocol, including version. e.g. yearn-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -880,10 +892,10 @@ type Vault implements Pool @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the vault. The ordering should be the same as the vault's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -928,16 +940,16 @@ type VaultDailySnapshot implements PoolDailySnapshot @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: BigDecimal!
+  inputTokenBalances: BigInt!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
 
   " Total amount of reward token emissions in a day, in token's native amount "
-  rewardTokenEmissionsAmount: [BigDecimal!]
+  rewardTokenEmissionsAmount: [BigInt!]
 
   " Total amount of reward token emissions in a day, normalized to USD "
   rewardTokenEmissionsUSD: [BigDecimal!]
@@ -966,6 +978,9 @@ type GenericProtocol implements Protocol @entity {
 
   " Slug of protocol, including version. e.g. uniswap-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -1003,10 +1018,10 @@ type GenericPool implements Pool @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!

--- a/schema-dex-amm.graphql
+++ b/schema-dex-amm.graphql
@@ -156,7 +156,7 @@ interface Pool {
   inputTokens: [Token!]!
 
   " Token that is minted to track ownership of position in protocol "
-  outputToken: Token
+  outputToken: Token!
 
   " Aditional tokens that are given as reward for position in a protocol "
   rewardTokens: [RewardToken!]
@@ -267,7 +267,7 @@ type LiquidityPool @entity {
   inputTokens: [Token!]!
 
   " Token that is minted to track ownership of position in protocol "
-  outputToken: Token
+  outputToken: Token!
 
   " Aditional tokens that are given as reward for position in a protocol "
   rewardTokens: [RewardToken!]
@@ -375,13 +375,13 @@ type Deposit implements Event @entity {
   inputTokens: [Token!]!
 
   " Output tokens of the transaction. E.g. the UNI-LP token "
-  outputTokens: [Token!]!
+  outputTokens: Token!
 
   " Amount of input tokens in the token's native unit "
   inputTokenAmounts: [BigDecimal!]!
 
   " Amount of output tokens in the token's native unit "
-  outputTokenAmounts: [BigDecimal!]!
+  outputTokenAmount: BigDecimal!
 
   " USD-normalized value of the transaction of the underlying (e.g. sum of tokens deposited into a pool) "
   amountUSD: BigDecimal!
@@ -419,13 +419,13 @@ type Withdraw implements Event @entity {
   inputTokens: [Token!]!
 
   " Output tokens of the transaction. E.g. WETH and USDC from a WETH-USDC pool "
-  outputTokens: [Token!]!
+  outputTokens: Token!
 
   " Amount of input tokens in the token's native unit "
   inputTokenAmounts: [BigDecimal!]!
 
   " Amount of output tokens in the token's native unit "
-  outputTokenAmounts: [BigDecimal!]!
+  outputTokenAmount: BigDecimal!
 
   " USD-normalized value of the transaction of the underlying (e.g. sum of tokens withdrawn from a pool) "
   amountUSD: BigDecimal!

--- a/schema-dex-amm.graphql
+++ b/schema-dex-amm.graphql
@@ -47,7 +47,7 @@ type RewardToken @entity {
   symbol: String!
   decimals: Int!
 
-  type: RewardTokenType
+  type: RewardTokenType!
 }
 
 #############################
@@ -63,6 +63,9 @@ interface Protocol {
 
   " Slug of protocol, including version. e.g. uniswap-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -169,10 +172,10 @@ interface Pool {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -207,16 +210,16 @@ type PoolDailySnapshot @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
 
   " Total amount of reward token emissions in a day, in token's native amount "
-  rewardTokenEmissionsAmount: [BigDecimal!]
+  rewardTokenEmissionsAmount: [BigInt!]
 
   " Total amount of reward token emissions in a day, normalized to USD "
   rewardTokenEmissionsUSD: [BigDecimal!]
@@ -241,6 +244,9 @@ type DexAmmProtocol implements Protocol @entity {
 
   " Slug of protocol, including version. e.g. uniswap-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -280,10 +286,10 @@ type LiquidityPool @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -378,10 +384,10 @@ type Deposit implements Event @entity {
   outputTokens: Token!
 
   " Amount of input tokens in the token's native unit "
-  inputTokenAmounts: [BigDecimal!]!
+  inputTokenAmounts: [BigInt!]!
 
   " Amount of output tokens in the token's native unit "
-  outputTokenAmount: BigDecimal!
+  outputTokenAmount: BigInt!
 
   " USD-normalized value of the transaction of the underlying (e.g. sum of tokens deposited into a pool) "
   amountUSD: BigDecimal!
@@ -422,10 +428,10 @@ type Withdraw implements Event @entity {
   outputTokens: Token!
 
   " Amount of input tokens in the token's native unit "
-  inputTokenAmounts: [BigDecimal!]!
+  inputTokenAmounts: [BigInt!]!
 
   " Amount of output tokens in the token's native unit "
-  outputTokenAmount: BigDecimal!
+  outputTokenAmount: BigInt!
 
   " USD-normalized value of the transaction of the underlying (e.g. sum of tokens withdrawn from a pool) "
   amountUSD: BigDecimal!

--- a/schema-lending.graphql
+++ b/schema-lending.graphql
@@ -47,7 +47,7 @@ type RewardToken @entity {
   symbol: String!
   decimals: Int!
 
-  type: RewardTokenType
+  type: RewardTokenType!
 }
 
 #############################
@@ -63,6 +63,9 @@ interface Protocol {
 
   " Slug of protocol, including version. e.g. uniswap-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -163,10 +166,10 @@ interface Pool {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -201,16 +204,16 @@ interface PoolDailySnapshot {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: BigDecimal!
+  inputTokenBalances: BigInt!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
 
   " Total amount of reward token emissions in a day, in token's native amount "
-  rewardTokenEmissionsAmount: [BigDecimal!]
+  rewardTokenEmissionsAmount: [BigInt!]
 
   " Total amount of reward token emissions in a day, normalized to USD "
   rewardTokenEmissionsUSD: [BigDecimal!]
@@ -247,6 +250,9 @@ type LendingProtocol implements Protocol @entity {
 
   " Slug of protocol, including version. e.g. aave-v2 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -295,10 +301,10 @@ type Market @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the market. The ordering should be the same as the market's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -365,19 +371,19 @@ type MarketDailySnapshot @entity {
   totalValueLockedUSD: BigDecimal!
 
   " Amount of input tokens in the market. The ordering should be the same as the market's `inputTokens` field. "
-  inputTokenBalances: BigDecimal!
+  inputTokenBalances: BigInt!
 
   " Price per share of input token in USD "
   inputTokenPricesUSD: [BigDecimal!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
 
   " Total amount of reward token emissions in a day, in token's native amount "
-  rewardTokenEmissionsAmount: [BigDecimal!]
+  rewardTokenEmissionsAmount: [BigInt!]
 
   " Total amount of reward token emissions in a day, normalized to USD "
   rewardTokenEmissionsUSD: [BigDecimal!]
@@ -468,7 +474,7 @@ type Deposit implements Event @entity {
   asset: Token!
 
   " Amount of token deposited in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token deposited in USD "
   amountUSD: BigDecimal!
@@ -506,7 +512,7 @@ type Withdraw implements Event @entity {
   asset: Token!
 
   " Amount of token withdrawn in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token withdrawn in USD "
   amountUSD: BigDecimal!
@@ -544,7 +550,7 @@ type Borrow implements Event @entity {
   asset: Token!
 
   " Amount of token borrowed in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token borrowed in USD "
   amountUSD: BigDecimal
@@ -582,7 +588,7 @@ type Repay implements Event @entity {
   asset: Token!
 
   " Amount of token repaid in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token repaid in USD "
   amountUSD: BigDecimal
@@ -620,7 +626,7 @@ type Liquidation implements Event @entity {
   asset: Token!
 
   " Amount of token liquidated in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token liquidated in USD "
   amountUSD: BigDecimal

--- a/schema-yield.graphql
+++ b/schema-yield.graphql
@@ -47,7 +47,7 @@ type RewardToken @entity {
   symbol: String!
   decimals: Int!
 
-  type: RewardTokenType
+  type: RewardTokenType!
 }
 
 #############################
@@ -63,6 +63,9 @@ interface Protocol {
 
   " Slug of protocol, including version. e.g. uniswap-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -82,6 +85,9 @@ type YieldAggregator implements Protocol @entity {
 
   " Slug of protocol, including version. e.g. yearn-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -193,10 +199,10 @@ interface Pool {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -231,16 +237,16 @@ interface PoolDailySnapshot {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: BigDecimal!
+  inputTokenBalances: BigInt!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
 
   " Total amount of reward token emissions in a day, in token's native amount "
-  rewardTokenEmissionsAmount: [BigDecimal!]
+  rewardTokenEmissionsAmount: [BigInt!]
 
   " Total amount of reward token emissions in a day, normalized to USD "
   rewardTokenEmissionsUSD: [BigDecimal!]
@@ -302,10 +308,10 @@ type Vault @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the vault. The ordering should be the same as the vault's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -350,16 +356,16 @@ type VaultDailySnapshot @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: BigDecimal!
+  inputTokenBalances: BigInt!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
 
   " Total amount of reward token emissions in a day, in token's native amount "
-  rewardTokenEmissionsAmount: [BigDecimal!]
+  rewardTokenEmissionsAmount: [BigInt!]
 
   " Total amount of reward token emissions in a day, normalized to USD "
   rewardTokenEmissionsUSD: [BigDecimal!]
@@ -434,7 +440,7 @@ type Deposit implements Event @entity {
   asset: Token!
 
   " Amount of token deposited in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token deposited in USD "
   amountUSD: BigDecimal!
@@ -472,7 +478,7 @@ type Withdraw implements Event @entity {
   asset: Token!
 
   " Amount of token withdrawn in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token withdrawn in USD "
   amountUSD: BigDecimal!

--- a/subgraphs/yearn-v2/schema.graphql
+++ b/subgraphs/yearn-v2/schema.graphql
@@ -47,7 +47,7 @@ type RewardToken @entity {
   symbol: String!
   decimals: Int!
 
-  type: RewardTokenType
+  type: RewardTokenType!
 }
 
 #############################
@@ -63,6 +63,9 @@ interface Protocol {
 
   " Slug of protocol, including version. e.g. uniswap-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -82,6 +85,9 @@ type YieldAggregator implements Protocol @entity {
 
   " Slug of protocol, including version. e.g. yearn-v3 "
   slug: String!
+
+  " Version of the subgraph implementation, in the format { schema ver }.{ major ver }.{ minor ver }. Start at 1.0.0 "
+  version: String!
 
   network: Network!
 
@@ -197,10 +203,10 @@ interface Pool {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -235,16 +241,16 @@ interface PoolDailySnapshot {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: BigDecimal!
+  inputTokenBalances: BigInt!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
 
   " Total amount of reward token emissions in a day, in token's native amount "
-  rewardTokenEmissionsAmount: [BigDecimal!]
+  rewardTokenEmissionsAmount: [BigInt!]
 
   " Total amount of reward token emissions in a day, normalized to USD "
   rewardTokenEmissionsUSD: [BigDecimal!]
@@ -306,10 +312,10 @@ type Vault @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the vault. The ordering should be the same as the vault's `inputTokens` field. "
-  inputTokenBalances: [BigDecimal!]!
+  inputTokenBalances: [BigInt!]!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
@@ -354,16 +360,16 @@ type VaultDailySnapshot @entity {
   totalVolumeUSD: BigDecimal!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
-  inputTokenBalances: BigDecimal!
+  inputTokenBalances: BigInt!
 
   " Total supply of output token "
-  outputTokenSupply: BigDecimal!
+  outputTokenSupply: BigInt!
 
   " Price per share of output token in USD "
   outputTokenPriceUSD: BigDecimal!
 
   " Total amount of reward token emissions in a day, in token's native amount "
-  rewardTokenEmissionsAmount: [BigDecimal!]
+  rewardTokenEmissionsAmount: [BigInt!]
 
   " Total amount of reward token emissions in a day, normalized to USD "
   rewardTokenEmissionsUSD: [BigDecimal!]
@@ -438,7 +444,7 @@ type Deposit implements Event @entity {
   asset: Token!
 
   " Amount of token deposited in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token deposited in USD "
   amountUSD: BigDecimal!
@@ -476,7 +482,7 @@ type Withdraw implements Event @entity {
   asset: Token!
 
   " Amount of token withdrawn in native units "
-  amount: BigDecimal!
+  amount: BigInt!
 
   " Amount of token withdrawn in USD "
   amountUSD: BigDecimal!


### PR DESCRIPTION
This PR introduces two changes to the schema:

- Added a subgraph `version` to the `Protocol` interface/entities. This makes it easier on the client side to identify the version of the subgraphs and handle cases accordingly.
- Changed token amount from `BigDecimal` to `BigInt`, also preserve full token precision (i.e. no need to handle decimals in the subgraph implementation). Here are the reasoning:
  1. Performance boost. BigInt is faster to process and index.
  2. Easier to implement. No need for convert from native EVM types.
  3. Preserves precision.