### PR TITLE
rename enum values of LiquidityPoolFeeType

### DIFF
--- a/schema-common.graphql
+++ b/schema-common.graphql
@@ -1,5 +1,5 @@
 ##### SCHEMA GUIDELINES
-### Version: 1.0.0
+### Version: 1.0.1
 #
 ### Usage
 # - This schema is intended to be a "master" document for standardization work. It includes all possible protocol
@@ -431,16 +431,16 @@ type DexAmmProtocol implements Protocol @entity {
 
 enum LiquidityPoolFeeType {
   " Total fixed fee paid by the user per trade, as a percentage of the traded amount. e.g. 0.3% for Uniswap v2, 0.3% for Sushiswap, 0.04% for Curve v1. "
-  TRADING_FEE
+  FIXED_TRADING_FEE
+
+  " Some protocols use tiered fees instead of fixed fee (e.g. DYDX, DODO). Set `feePercentage` as 0 but handle the tiered fees in the mapping code. "
+  TIERED_TRADING_FEE
+
+  " Some protocols use dynamic fees instead of fixed fee (e.g. Balancer v2). Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
+  DYNAMIC_TRADING_FEE
 
   " Fixed fee that's paid to the protocol, as a percentage of the traded amount. e.g. 0.05% for Sushiswap, 0.02% for Curve v1. "
   PROTOCOL_FEE
-
-  " Some protocols use tiered fees instead of fixed fee (e.g. DYDX, DODO). Set `feePercentage` as 0 but handle the tiered fees in the mapping code. "
-  TIERED_FEE
-
-  " Some protocols use dynamic fees instead of fixed fee (e.g. Balancer v2). Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
-  DYNAMIC_FEE
 }
 
 type LiquidityPoolFee @entity {

--- a/schema-dex-amm.graphql
+++ b/schema-dex-amm.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: DEX AMM
-# Version: 1.0.1
+# Version: 1.0.2
 
 enum Network {
   ARBITRUM
@@ -290,16 +290,16 @@ type DexAmmProtocol implements Protocol @entity {
 
 enum LiquidityPoolFeeType {
   " Total fixed fee paid by the user per trade, as a percentage of the traded amount. e.g. 0.3% for Uniswap v2, 0.3% for Sushiswap, 0.04% for Curve v1. "
-  TRADING_FEE
+  FIXED_TRADING_FEE
+
+  " Some protocols use tiered fees instead of fixed fee (e.g. DYDX, DODO). Set `feePercentage` as 0 but handle the tiered fees in the mapping code. "
+  TIERED_TRADING_FEE
+
+  " Some protocols use dynamic fees instead of fixed fee (e.g. Balancer v2). Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
+  DYNAMIC_TRADING_FEE
 
   " Fixed fee that's paid to the protocol, as a percentage of the traded amount. e.g. 0.05% for Sushiswap, 0.02% for Curve v1. "
   PROTOCOL_FEE
-
-  " Some protocols use tiered fees instead of fixed fee (e.g. DYDX, DODO). Set `feePercentage` as 0 but handle the tiered fees in the mapping code. "
-  TIERED_FEE
-
-  " Some protocols use dynamic fees instead of fixed fee (e.g. Balancer v2). Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
-  DYNAMIC_FEE
 }
 
 type LiquidityPoolFee @entity {

--- a/subgraphs/_reference_/schema.graphql
+++ b/subgraphs/_reference_/schema.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: DEX AMM
-# Version: 1.0.1
+# Version: 1.0.2
 
 enum Network {
   AVALANCHE
@@ -289,16 +289,16 @@ type DexAmmProtocol implements Protocol @entity {
 
 enum LiquidityPoolFeeType {
   " Total fixed fee paid by the user per trade, as a percentage of the traded amount. e.g. 0.3% for Uniswap v2, 0.3% for Sushiswap, 0.04% for Curve v1. "
-  TRADING_FEE
+  FIXED_TRADING_FEE
+
+  " Some protocols use tiered fees instead of fixed fee (e.g. DYDX, DODO). Set `feePercentage` as 0 but handle the tiered fees in the mapping code. "
+  TIERED_TRADING_FEE
+
+  " Some protocols use dynamic fees instead of fixed fee (e.g. Balancer v2). Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
+  DYNAMIC_TRADING_FEE
 
   " Fixed fee that's paid to the protocol, as a percentage of the traded amount. e.g. 0.05% for Sushiswap, 0.02% for Curve v1. "
   PROTOCOL_FEE
-
-  " Some protocols use tiered fees instead of fixed fee (e.g. DYDX, DODO). Set `feePercentage` as 0 but handle the tiered fees in the mapping code. "
-  TIERED_FEE
-
-  " Some protocols use dynamic fees instead of fixed fee (e.g. Balancer v2). Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
-  DYNAMIC_FEE
 }
 
 type LiquidityPoolFee @entity {

--- a/subgraphs/_reference_/src/common/constants.ts
+++ b/subgraphs/_reference_/src/common/constants.ts
@@ -39,10 +39,10 @@ export namespace VaultFeeType {
 }
 
 export namespace LiquidityPoolFeeType {
-  export const TRADING_FEE = "TRADING_FEE";
+  export const FIXED_TRADING_FEE = "FIXED_TRADING_FEE";
+  export const TIERED_TRADING_FEE = "TIERED_TRADING_FEE";
+  export const DYNAMIC_TRADING_FEE = "DYNAMIC_TRADING_FEE";
   export const PROTOCOL_FEE = "PROTOCOL_FEE";
-  export const TIERED_FEE = "TIERED_FEE";
-  export const DYNAMIC_FEE = "DYNAMIC_FEE";
 }
 
 export namespace RewardTokenType {

--- a/subgraphs/uniswap-v2/schema.graphql
+++ b/subgraphs/uniswap-v2/schema.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: DEX AMM
-# Version: 1.0.1
+# Version: 1.0.2
 
 enum Network {
   ARBITRUM
@@ -278,16 +278,16 @@ type DexAmmProtocol implements Protocol @entity {
 
 enum LiquidityPoolFeeType {
   " Total fixed fee paid by the user per trade, as a percentage of the traded amount. e.g. 0.3% for Uniswap v2, 0.3% for Sushiswap, 0.04% for Curve v1. "
-  TRADING_FEE
+  FIXED_TRADING_FEE
+
+  " Some protocols use tiered fees instead of fixed fee (e.g. DYDX, DODO). Set `feePercentage` as 0 but handle the tiered fees in the mapping code. "
+  TIERED_TRADING_FEE
+
+  " Some protocols use dynamic fees instead of fixed fee (e.g. Balancer v2). Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
+  DYNAMIC_TRADING_FEE
 
   " Fixed fee that's paid to the protocol, as a percentage of the traded amount. e.g. 0.05% for Sushiswap, 0.02% for Curve v1. "
   PROTOCOL_FEE
-
-  " Some protocols use tiered fees instead of fixed fee (e.g. DYDX, DODO). Set `feePercentage` as 0 but handle the tiered fees in the mapping code. "
-  TIERED_FEE
-
-  " Some protocols use dynamic fees instead of fixed fee (e.g. Balancer v2). Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
-  DYNAMIC_FEE
 }
 
 type LiquidityPoolFee @entity {

--- a/subgraphs/uniswap-v2/src/common/constants.ts
+++ b/subgraphs/uniswap-v2/src/common/constants.ts
@@ -30,10 +30,10 @@ export namespace ProtocolType {
 }
 
 export namespace LiquidityPoolFeeType {
-  export const TRADING_FEE = "TRADING_FEE"
-  export const PROTOCOL_FEE = "PROTOCOL_FEE"
-  export const TIERED_FEE = "TIERED_FEE"
-  export const DYNAMIC_FEE = "DYNAMIC_FEE"
+  export const FIXED_TRADING_FEE = "FIXED_TRADING_FEE";
+  export const TIERED_TRADING_FEE = "TIERED_TRADING_FEE";
+  export const DYNAMIC_TRADING_FEE = "DYNAMIC_TRADING_FEE";
+  export const PROTOCOL_FEE = "PROTOCOL_FEE";
 }
 
 export namespace RewardTokenType {

--- a/subgraphs/uniswap-v2/src/common/helpers.ts
+++ b/subgraphs/uniswap-v2/src/common/helpers.ts
@@ -29,7 +29,7 @@ export let UNTRACKED_PAIRS: string[] = ['0x9ea3b5b4ec044b70375236a281986106457b2
 
 function createPoolFees(poolAddressString: string): string[] {
   let poolTradingFee = new LiquidityPoolFee('trading-fee-'+poolAddressString)
-  poolTradingFee.feeType = LiquidityPoolFeeType.TRADING_FEE
+  poolTradingFee.feeType = LiquidityPoolFeeType.FIXED_TRADING_FEE
   poolTradingFee.feePercentage = TRADING_FEE_TO_OFF
 
   let poolProtocolFee = new LiquidityPoolFee('protocol-fee-'+poolAddressString)


### PR DESCRIPTION
TRADING_FEE actually means FIXED_TRADING_FEE, while TIERED_FEE and DYNAMIC_FEE actually mean TIERED_TRADING_FEE and DYNAMIC_TRADING_FEE

PROTOCOL_FEE is different from X_TRADING_FEE since it is paid to the protocol

Rename should make it more clearer