### PR TITLE
compound - fix apy calcs

### DIFF
--- a/subgraphs/compound-v2/src/common/utils/constants.ts
+++ b/subgraphs/compound-v2/src/common/utils/constants.ts
@@ -102,7 +102,8 @@ export const SECONDS_PER_DAY = 60 * 60 * 24; // 86400
 export const MS_PER_DAY = new BigDecimal(BigInt.fromI32(24 * 60 * 60 * 1000));
 export const DAYS_PER_YEAR = new BigDecimal(BigInt.fromI32(365));
 export const MS_PER_YEAR = DAYS_PER_YEAR.times(new BigDecimal(BigInt.fromI32(24 * 60 * 60 * 1000)));
-export const BLOCKS_PER_YEAR = BigDecimal.fromString("2102400");
+export const BLOCKS_PER_DAY = BigDecimal.fromString("6570"); // blocks every 13.15 seconds
+export const BLOCKS_PER_YEAR = BLOCKS_PER_DAY.times(DAYS_PER_YEAR);
 
 /////////////////////////////
 ///// Protocol Specific /////
@@ -114,7 +115,7 @@ export const LENDING_TYPE = LendingType.POOLED;
 export const PROTOCOL_RISK_TYPE = RiskType.ISOLATED;
 export const PROTOCOL_NAME = "Compound v2";
 export const PROTOCOL_SLUG = "compound-v2";
-export const SUBGRAPH_VERSION = "1.4.13";
+export const SUBGRAPH_VERSION = "1.4.16";
 export const SCHEMA_VERSION = "1.1.0";
 export const METHODOLOGY_VERSION = "1.0.0";
 export const COMPOUND_DECIMALS = 8;

--- a/subgraphs/compound-v2/src/mappings/helpers.ts
+++ b/subgraphs/compound-v2/src/mappings/helpers.ts
@@ -10,6 +10,9 @@ import {
   BIGDECIMAL_ZERO,
   BIGINT_ZERO,
   BIGDECIMAL_ONE,
+  BLOCKS_PER_DAY,
+  DAYS_PER_YEAR,
+  BIGINT_ONE,
 } from "../common/utils/constants";
 import {
   getOrCreateLendingProtcol,
@@ -77,12 +80,6 @@ export function createDeposit(event: ethereum.Event, amount: BigInt, mintTokens:
   inputBalance = [inputBalance[0].plus(amount)];
   market.inputTokenBalances = inputBalance;
 
-  // update totalDepositUSD
-  market.totalDepositUSD = market.inputTokenBalances[0]
-    .toBigDecimal()
-    .div(exponentToBigDecimal(underlyingDecimals))
-    .times(market.inputTokenPricesUSD[0]);
-
   // update protocol totalDepositUSD
   updateTotalDepositUSD(event);
 
@@ -142,12 +139,6 @@ export function createWithdraw(
   inputBalance = [inputBalance[0].minus(underlyingAmount)];
   market.inputTokenBalances = inputBalance;
 
-  // update totalDepositUSD
-  market.totalDepositUSD = market.inputTokenBalances[0]
-    .toBigDecimal()
-    .div(exponentToBigDecimal(underlyingDecimals))
-    .times(market.inputTokenPricesUSD[0]);
-
   // update outputTokenSupply
   market.outputTokenSupply = market.outputTokenSupply.minus(cTokenAmount);
 
@@ -201,10 +192,6 @@ export function createBorrow(event: ethereum.Event, borrower: Address, amount: B
   }
   let underlyingDecimals = getOrCreateToken(market.inputTokens[0]).decimals;
   market._totalBorrowNative = market._totalBorrowNative.plus(amount); // must be after revenue updates
-  market.totalBorrowUSD = market._totalBorrowNative
-    .toBigDecimal()
-    .div(exponentToBigDecimal(underlyingDecimals))
-    .times(market.inputTokenPricesUSD[0]);
   let decimalAmount = amount.toBigDecimal().div(exponentToBigDecimal(underlyingDecimals));
   borrow.amountUSD = market.inputTokenPricesUSD[0].times(decimalAmount);
 
@@ -261,10 +248,6 @@ export function createRepay(event: ethereum.Event, payer: Address, amount: BigIn
   }
   let underlyingDecimals = getOrCreateToken(market.inputTokens[0]).decimals;
   market._totalBorrowNative = market._totalBorrowNative.minus(amount); // must be after revenue updates
-  market.totalBorrowUSD = market._totalBorrowNative
-    .toBigDecimal()
-    .div(exponentToBigDecimal(underlyingDecimals))
-    .times(market.inputTokenPricesUSD[0]);
   let decimalAmount = amount.toBigDecimal().div(exponentToBigDecimal(underlyingDecimals));
   repay.amountUSD = market.inputTokenPricesUSD[0].times(decimalAmount);
 
@@ -460,7 +443,8 @@ export function updateTotalBorrowUSD(event: ethereum.Event): void {
     market.totalBorrowUSD = market._totalBorrowNative
       .toBigDecimal()
       .div(exponentToBigDecimal(underlyingDecimals))
-      .times(market.inputTokenPricesUSD[0]);
+      .times(market.inputTokenPricesUSD[0])
+      .truncate(DEFAULT_DECIMALS);
     totalBorrowUSD = totalBorrowUSD.plus(market.totalBorrowUSD);
     market.save();
   }
@@ -481,7 +465,8 @@ export function updateTotalDepositUSD(event: ethereum.Event): void {
     market.totalDepositUSD = market.inputTokenBalances[0]
       .toBigDecimal()
       .div(exponentToBigDecimal(underlyingDecimals))
-      .times(market.inputTokenPricesUSD[0]);
+      .times(market.inputTokenPricesUSD[0])
+      .truncate(DEFAULT_DECIMALS);
     totalDepositUSD = totalDepositUSD.plus(market.totalDepositUSD);
     market.save();
   }
@@ -552,30 +537,45 @@ export function updateRewards(event: ethereum.Event, market: Market): void {
 export function updateMarketRates(market: Market): void {
   // This fails on only the first call to cZRX. It is unclear why, but otherwise it works.
   // So we handle it like this.
+
+  // APY rate calculation explained here: https://compound.finance/docs#protocol-math
   let contract = CToken.bind(Address.fromString(market.id));
   let mantissaFactorBD = exponentToBigDecimal(DEFAULT_DECIMALS);
   let trySupplyRatePerBlock = contract.try_supplyRatePerBlock();
-  market.depositRate = trySupplyRatePerBlock.reverted
-    ? BIGDECIMAL_ZERO
-    : trySupplyRatePerBlock.value
-        .toBigDecimal()
-        .times(BLOCKS_PER_YEAR)
-        .div(mantissaFactorBD)
-        .truncate(DEFAULT_DECIMALS);
+  let supplyRatePerBlock = trySupplyRatePerBlock.reverted ? BIGINT_ZERO : trySupplyRatePerBlock.value;
+  let supplyRateCalc = supplyRatePerBlock
+    .toBigDecimal()
+    .div(mantissaFactorBD)
+    .times(BLOCKS_PER_DAY)
+    .plus(BIGDECIMAL_ONE);
+  let supplyRatePow = supplyRateCalc; // used to calculate BigDecimal power
 
   // update borrow rates
   // Compound doesn't have "stable borrow rates" so the two equal each other
   // Must convert to BigDecimal, and remove 10^18 that is used for Exp in Compound Solidity
   let tryBorrowRatePerBlock = contract.try_borrowRatePerBlock();
-  let borrowRate = tryBorrowRatePerBlock.reverted
-    ? BIGDECIMAL_ZERO
-    : tryBorrowRatePerBlock.value
-        .toBigDecimal()
-        .times(BLOCKS_PER_YEAR)
-        .div(mantissaFactorBD)
-        .truncate(DEFAULT_DECIMALS);
-  market.stableBorrowRate = borrowRate;
-  market.variableBorrowRate = borrowRate;
+  let borrowRatePerBlock = tryBorrowRatePerBlock.reverted ? BIGINT_ZERO : tryBorrowRatePerBlock.value;
+  let borrowRateCalc = borrowRatePerBlock
+    .toBigDecimal()
+    .div(mantissaFactorBD)
+    .times(BLOCKS_PER_DAY)
+    .plus(BIGDECIMAL_ONE);
+  let borrowRatePow = borrowRateCalc; // used to calculate BigDecimal power
+
+  // take the rate calcs to the power of DAYS_PER_YEAR
+  let daysInYear = 365;
+  for (let i = 0; i < daysInYear; i++) {
+    borrowRateCalc = borrowRateCalc.times(borrowRatePow);
+    supplyRateCalc = supplyRateCalc.times(supplyRatePow);
+  }
+
+  // finish APY calculation
+  borrowRateCalc = borrowRateCalc.minus(BIGDECIMAL_ONE).times(BigDecimal.fromString("100")).truncate(DEFAULT_DECIMALS);
+  supplyRateCalc = supplyRateCalc.minus(BIGDECIMAL_ONE).times(BigDecimal.fromString("100")).truncate(DEFAULT_DECIMALS);
+
+  market.depositRate = supplyRateCalc;
+  market.stableBorrowRate = borrowRateCalc;
+  market.variableBorrowRate = borrowRateCalc;
 
   market.save();
 }


### PR DESCRIPTION
Fix APY rate calcs and removed unnecessary totalDepositUSD/totalBorrowUSD calcs

See APY math here: https://compound.finance/docs#protocol-math