### PR TITLE
fixed protocol metrics, vault ids added

### DIFF
--- a/subgraphs/belt/schema.graphql
+++ b/subgraphs/belt/schema.graphql
@@ -133,6 +133,9 @@ type YieldAggregator implements Protocol @entity {
 
   " All vaults that belong to this protocol "
   vaults: [Vault!]! @derivedFrom(field: "protocol")
+
+  " All vaults id of the protocol "
+  _vaultIds: [String!]!
 }
 
 ###############################

--- a/subgraphs/belt/src/entities/Protocol.ts
+++ b/subgraphs/belt/src/entities/Protocol.ts
@@ -31,6 +31,7 @@ export function getOrCreateProtocol(): YieldAggregator {
   protocol.totalUniqueUsers = 0;
   protocol.totalValueLockedUSD = BIGDECIMAL_ZERO;
   protocol.totalVolumeUSD = BIGDECIMAL_ZERO;
+  protocol._vaultIds = [];
   protocol.save();
 
   return protocol;

--- a/subgraphs/belt/src/entities/Vault.ts
+++ b/subgraphs/belt/src/entities/Vault.ts
@@ -10,6 +10,7 @@ import { createFeeType } from "./Strategy";
 
 export function getOrCreateVault(id: Address, block: ethereum.Block): Vault {
   let vault = Vault.load(id.toHex());
+  let protocol = getOrCreateProtocol();
 
   if (vault) {
     return vault;
@@ -17,7 +18,7 @@ export function getOrCreateVault(id: Address, block: ethereum.Block): Vault {
 
   vault = new Vault(id.toHex());
 
-  vault.protocol = getOrCreateProtocol().id;
+  vault.protocol = protocol.id;
   vault.inputTokens = [];
   vault.outputToken = "";
   vault.rewardTokens = [];
@@ -35,6 +36,13 @@ export function getOrCreateVault(id: Address, block: ethereum.Block): Vault {
   vault.depositLimit = BIGINT_ZERO;
   vault.fees = [];
   vault.save();
+
+  // storing vault ids
+  let vaultIds = protocol._vaultIds;
+  vaultIds.push(vault.id);
+
+  protocol._vaultIds = vaultIds;
+  protocol.save();
 
   return vault;
 }

--- a/subgraphs/belt/src/handlers/common.ts
+++ b/subgraphs/belt/src/handlers/common.ts
@@ -61,8 +61,8 @@ function updateProtocolMetrics(): void {
   let totalVolumeUSD = BIGDECIMAL_ZERO;
   let totalValueLockedUSD = BIGDECIMAL_ZERO;
 
-  for (let i = 0; i < protocol.vaults.length; i++) {
-    let vaultId = protocol.vaults[i];
+  for (let i = 0; i < protocol._vaultIds.length; i++) {
+    let vaultId = protocol._vaultIds[i];
     let vault = Vault.load(vaultId);
 
     if (vault) {

--- a/subgraphs/belt/tests/vault.test.ts
+++ b/subgraphs/belt/tests/vault.test.ts
@@ -285,11 +285,16 @@ test("financial metrics", () => {
     .div(denominator.toBigDecimal())
     .times(amountUSD);
 
+  let totalValueLockedUSD = price
+    .toBigDecimal()
+    .div(decimals.toBigDecimal())
+    .times(inputTokenBalance.toBigDecimal().div(decimals.toBigDecimal()));
+
   // for deposit and withdraw
   let protocolSideRevenueUSD = totalRevenueUSD;
   let supplySideRevenueUSD = amountUSD.minus(BigDecimal.fromString("2").times(totalRevenueUSD));
 
   assert.fieldEquals("FinancialsDailySnapshot", day, "protocolSideRevenueUSD", protocolSideRevenueUSD.toString());
-  assert.fieldEquals("FinancialsDailySnapshot", day, "totalRevenueUSD", protocolSideRevenueUSD.toString());
+  assert.fieldEquals("FinancialsDailySnapshot", day, "totalRevenueUSD", totalValueLockedUSD.toString());
   assert.fieldEquals("FinancialsDailySnapshot", day, "supplySideRevenueUSD", supplySideRevenueUSD.toString());
 });


### PR DESCRIPTION
- Fixed belt finance issue with protocol metrics.
- The `derivedFrom` field is not directly accessible, so added extra field that stores the ids `_vaultIds`