### PR TITLE
fix handleNewLiquidationIncentive

### DIFF
--- a/subgraphs/compound-forks/bastion-protocol/src/mapping.ts
+++ b/subgraphs/compound-forks/bastion-protocol/src/mapping.ts
@@ -173,7 +173,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Bastion Protocol",
     "bastion-protocol",
     "1.2.1",
-    "1.0.2",
+    "1.0.3",
     "1.0.0",
     Network.AURORA,
     comptroller.try_liquidationIncentiveMantissa()

--- a/subgraphs/compound-forks/benqi/src/mapping.ts
+++ b/subgraphs/compound-forks/benqi/src/mapping.ts
@@ -214,7 +214,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "BENQI",
     "benqi",
     "1.2.1",
-    "1.0.0",
+    "1.0.1",
     "1.0.0",
     Network.AVALANCHE,
     comptroller.try_liquidationIncentiveMantissa()

--- a/subgraphs/compound-forks/benqi/subgraph.yaml
+++ b/subgraphs/compound-forks/benqi/subgraph.yaml
@@ -31,8 +31,8 @@ dataSources:
           handler: handleNewPriceOracle
         - event: NewCollateralFactor(address,uint256,uint256)
           handler: handleNewCollateralFactor
-        # - event: NewLiquidationIncentive(uint256,uint256)
-        #   handler: handleNewLiquidationIncentive
+        - event: NewLiquidationIncentive(uint256,uint256)
+          handler: handleNewLiquidationIncentive
       file: ./src/mapping.ts
 templates:
   - name: CToken

--- a/subgraphs/compound-forks/iron-bank/src/mapping.ts
+++ b/subgraphs/compound-forks/iron-bank/src/mapping.ts
@@ -158,7 +158,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Iron Bank",
     "iron-bank",
     "1.2.1",
-    "1.0.0",
+    "1.0.1",
     "1.0.0",
     network,
     comptroller.try_liquidationIncentiveMantissa()

--- a/subgraphs/compound-forks/moonwell/src/mapping.ts
+++ b/subgraphs/compound-forks/moonwell/src/mapping.ts
@@ -212,7 +212,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Moonwell",
     "moonwell",
     "1.2.1",
-    "1.0.2",
+    "1.0.3",
     "1.0.0",
     Network.MOONRIVER,
     comptroller.try_liquidationIncentiveMantissa()

--- a/subgraphs/compound-forks/src/mapping.ts
+++ b/subgraphs/compound-forks/src/mapping.ts
@@ -244,10 +244,10 @@ export function _handleNewLiquidationIncentive(
   protocol.save();
 
   for (let i = 0; i < protocol._marketIDs.length; i++) {
-    let market = Market.load(protocol.markets[i]);
+    let market = Market.load(protocol._marketIDs[i]);
     if (!market) {
       log.warning("[handleNewLiquidationIncentive] Market not found: {}", [
-        protocol.markets[i],
+        protocol._marketIDs[i],
       ]);
       // best effort
       continue;


### PR DESCRIPTION
> Using a derivedFrom field in the graph code gives no compile time issues but fails when the graph syncs with error unexpected null wasm

https://github.com/messari/subgraphs/blob/master/docs/Mapping.md#subgraph-issues

made this mistake again :(