### PR TITLE
Fixed bugs in market metrics; Updated README

### DIFF
--- a/subgraphs/inverse-finance/README.md
+++ b/subgraphs/inverse-finance/README.md
@@ -6,28 +6,44 @@
 
 Sum across all Markets:
 
-`CToken.get_cash() * priceOracle.getUnderlyingPrice(CToken)`
+`Sum of Deposits on Anchor`
+
+`= CToken.get_cash() * priceOracle.getUnderlyingPrice(CToken)`
 
 `CToken.get_cash()` returns the deposits (inputTokenBalance), which is then converted to USD by
 multiplying with the underlying token price (including ETH) returned from the price Oracle contract.
 
 ### Total Revenue USD
 
-Sum across all Markets: `AccrueInterest.interestAccumulated * priceOracle.getUnderlyingPrice(CToken)`
+Sum across all Markets:
+
+`Sum of Interest paid by borrowers + Fees earned by Stabilizer`
+
+`= AccrueInterest.interestAccumulated * priceOracle.getUnderlyingPrice(CToken) + Buy/Sell fees on Stablizer`
 
 The `AccrueInterest` event is emitted when interest (revenue) is accrued in the underlying token. The interest (revenue) is converted to USD by multiplying with the underlying token price (including ETH) returned from the price Oracle contract.
 
+Currenltly borrowing is paused after an exploit. Stabilizer is a backstop for DOLA peg that takes 0.4% for buying and 0.1% for selling DOLA.
+
 ### Protocol-Side Revenue USD
 
-Portion of the Total Revenue allocated to the Protocol. The total interest (revenue) is split between depositors (supply-side) and the protocol based on the value of the `reserveFactor`. 
+Portion of the Total Revenue allocated to the Protocol. The total interest (revenue) is split between depositors (supply-side) and the protocol based on the value of the `reserveFactor`.
 
-Sum across all Markets: `total revenue * reserveFactorMantissa / 10 ^ MANTISSA`
+Sum across all Markets:
+
+`(Sum of Interest paid by borrowers) * Protocol Share + Fees earned by Stabilizer`
+
+`= total revenue * reserveFactorMantissa / 10 ^ MANTISSA + Buy/Sell fees on Stablizer`
 
 ### Supply-Side Revenue USD
 
-Portion of the Total Revenue allocated to the Supply-Side. The total interest (revenue) is split between depositors (supply-side) and the protocol based on the value of the `reserveFactor`. 
+Portion of the Total Revenue allocated to the Supply-Side. The total interest (revenue) is split between depositors (supply-side) and the protocol based on the value of the `reserveFactor`.
 
-Sum across all Markets:`total revenue - Protocol-Side Revenue`
+Sum across all Markets:
+
+`Sum of Interest paid by borrowers * (1 - Protocol Share)`
+
+`= Total Revenue USD - Protocol-Side Revenue USD`
 
 ### Total Unique Users
 
@@ -45,7 +61,7 @@ Count of Unique Addresses which have interacted with the protocol via any transa
 
 ### Reward Token Emissions Amount
 
-The inverse-finance comptroller computes the rewards emissions to lenders and borrowers when users interacts with the contracts, and emit `DistributedSupplierComp` and `DistributedBorrowerComp` event when emissions are rewarded. The event paramater `compDelta` contains the amount of emissions. Since the emissions happen irregularly, to normalize the emssions to a daily amount, a HelperStore entity keeps tract the block number of the last emissions, and is used to computed `deltaBlocks` between two emissions. The normalized daily emissions = `compDelta / deltaBlock * BLOCKS_PER_DAY`. 
+The inverse-finance comptroller computes the rewards emissions to lenders and borrowers when users interacts with the contracts, and emit `DistributedSupplierComp` and `DistributedBorrowerComp` event when emissions are rewarded. The event paramater `compDelta` contains the amount of emissions. Since the emissions happen irregularly, to normalize the emssions to a daily amount, a HelperStore entity keeps tract the block number of the last emissions, and is used to computed `deltaBlocks` between two emissions. The normalized daily emissions = `compDelta / deltaBlock * BLOCKS_PER_DAY`.
 
 Reward emissions for lenders: `DistributedSupplierComp.compDelta * priceOracle.getUnderlyingPrice(CToken) * BLOCKS_PER_DAY / deltaBlocks`
 
@@ -54,7 +70,6 @@ Reward emissions for borrowers: `DistributedBorrowerComp.compDelta * priceOracle
 ### Protocol Controlled Value
 
 Not applicable.
-
 
 ## Links
 
@@ -101,6 +116,6 @@ The Inverse Finance Lending Protocol is controled by a [comptroller contract](ht
 
 ## DOLA stablecoin and the Fed
 
-The Inverse DAO also manages the DOLA stablecoin. The DOLA's peg to \$1 is maintained through [the Fed contract](https://etherscan.io/address/0x5e075e40d01c82b6bf0b0ecdb4eb1d6984357ef7) and through [the stablizer](https://etherscan.io/address/0x7ec0d931affba01b77711c2cd07c76b970795cdd), an exhange allowing users to arbitrage the differential between DAI and DOLA by swapping between them. When the demand for DOLA is high (price is above \$1), the Fed contract expands (increases) the DOLA supply by minting more DOLA and anDOLA tokens; vice versa, it contracts (reduces) the DOLA supply by burning the DOLA and anDOLA tokens. During expansion, the Fed contract is the supplier of liquidity in the anDOLA/DOLA market and earns a profit (interest) from its deposit. 
+The Inverse DAO also manages the DOLA stablecoin. The DOLA's peg to \$1 is maintained through [the Fed contract](https://etherscan.io/address/0x5e075e40d01c82b6bf0b0ecdb4eb1d6984357ef7) and through [the stablizer](https://etherscan.io/address/0x7ec0d931affba01b77711c2cd07c76b970795cdd), an exhange allowing users to arbitrage the differential between DAI and DOLA by swapping between them. When the demand for DOLA is high (price is above \$1), the Fed contract expands (increases) the DOLA supply by minting more DOLA and anDOLA tokens; vice versa, it contracts (reduces) the DOLA supply by burning the DOLA and anDOLA tokens. During expansion, the Fed contract is the supplier of liquidity in the anDOLA/DOLA market and earns a profit (interest) from its deposit.
 
 Besides the Anchor Fed, separate Fed contracts also supplies DOLA to the lending pools of serval lending partners, including Yearn, Bagder, 0xb1, Fuse, and Scream (Fantom). The Fed contract behaves similar to Anchor Fed, with customization to make it work with the contract of each lending partner.

--- a/subgraphs/inverse-finance/src/common/helpers.ts
+++ b/subgraphs/inverse-finance/src/common/helpers.ts
@@ -120,7 +120,7 @@ export function updateDeposit(event: Mint): void {
   //      - cumulativeDepositUSD
   let marketDaily = getOrCreateMarketDailySnapshot(event);
   marketDaily.dailyDepositUSD = marketDaily.dailyDepositUSD.plus(depositAmountUSD);
-  marketDaily.cumulativeDepositUSD = protocol.cumulativeDepositUSD;
+  marketDaily.cumulativeDepositUSD = market.cumulativeDepositUSD;
   marketDaily.blockNumber = event.block.number;
   marketDaily.timestamp = event.block.timestamp;
   marketDaily.save();
@@ -130,7 +130,7 @@ export function updateDeposit(event: Mint): void {
   //      - cumulativeDepositUSD
   let marketHourly = getOrCreateMarketHourlySnapshot(event);
   marketHourly.hourlyDepositUSD = marketDaily.dailyDepositUSD.plus(depositAmountUSD);
-  marketHourly.cumulativeDepositUSD = protocol.cumulativeDepositUSD;
+  marketHourly.cumulativeDepositUSD = market.cumulativeDepositUSD;
   marketHourly.blockNumber = event.block.number;
   marketHourly.timestamp = event.block.timestamp;
   marketHourly.save();
@@ -236,7 +236,7 @@ export function updateBorrow(event: Borrow): void {
   //      - cumulativeBorrowUSD
   let marketDaily = getOrCreateMarketDailySnapshot(event);
   marketDaily.dailyBorrowUSD = marketDaily.dailyBorrowUSD.plus(borrowAmountUSD);
-  marketDaily.cumulativeBorrowUSD = protocol.cumulativeBorrowUSD;
+  marketDaily.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
   marketDaily.blockNumber = event.block.number;
   marketDaily.timestamp = event.block.timestamp;
   marketDaily.save();
@@ -246,7 +246,7 @@ export function updateBorrow(event: Borrow): void {
   //      - cumulativeBorrowUSD
   let marketHourly = getOrCreateMarketHourlySnapshot(event);
   marketHourly.hourlyBorrowUSD = marketDaily.dailyBorrowUSD.plus(borrowAmountUSD);
-  marketHourly.cumulativeBorrowUSD = protocol.cumulativeBorrowUSD;
+  marketHourly.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
   marketHourly.blockNumber = event.block.number;
   marketHourly.timestamp = event.block.timestamp;
   marketHourly.save();
@@ -363,7 +363,7 @@ export function updateLiquidate(event: LiquidateBorrow): void {
   //      - cumulativeLiquidateUSD
   let marketDaily = getOrCreateMarketDailySnapshot(event);
   marketDaily.dailyLiquidateUSD = marketDaily.dailyLiquidateUSD.plus(liquidateAmountUSD);
-  marketDaily.cumulativeLiquidateUSD = protocol.cumulativeLiquidateUSD;
+  marketDaily.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
   marketDaily.blockNumber = event.block.number;
   marketDaily.timestamp = event.block.timestamp;
   marketDaily.save();
@@ -373,7 +373,7 @@ export function updateLiquidate(event: LiquidateBorrow): void {
   //      - cumulativeLiquidateUSD
   let marketHourly = getOrCreateMarketHourlySnapshot(event);
   marketHourly.hourlyLiquidateUSD = marketDaily.dailyLiquidateUSD.plus(liquidateAmountUSD);
-  marketHourly.cumulativeLiquidateUSD = protocol.cumulativeLiquidateUSD;
+  marketHourly.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
   marketHourly.blockNumber = event.block.number;
   marketHourly.timestamp = event.block.timestamp;
   marketHourly.save();


### PR DESCRIPTION
Commit f930dc474ad938888653e364db6409b7312694d3 fixed bugs in `MarketHourlySnapshot` and `MarketDailySnapshot` for item `cumulativeDepositUSD`, `cumulativeBorrowUSD`, and `cumulativeLiquidateUSD`. Values of the Market entity should be used but those of the protocol were used.

README.md was updated to bring information from the earlier specification at https://github.com/messari/subgraphs/blob/f96689a5db62de1238be0ef5a42b5a19d18eb315/subgraphs/inverse-finance/README.md#total-revenue-usd  & reflect the fact that fees from the Stablizer are included in protocol revenue.