### PR TITLE
fixed bug when creating MarketListedData for compound-forks

### DIFF
--- a/subgraphs/compound-forks/aurigami/src/mapping.ts
+++ b/subgraphs/compound-forks/aurigami/src/mapping.ts
@@ -97,13 +97,13 @@ export function handleMarketListed(event: MarketListed): void {
     new MarketListedData(
       protocol,
       new TokenData(
-        underlyingTokenAddr,
+        cTokenAddr,
         getOrElse<string>(cTokenContract.try_name(), "unknown"),
         getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
         cTokenDecimals
       ),
       new TokenData(
-        cTokenAddr,
+        underlyingTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)

--- a/subgraphs/compound-forks/aurigami/src/mapping.ts
+++ b/subgraphs/compound-forks/aurigami/src/mapping.ts
@@ -179,7 +179,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Aurigami",
     "aurigami",
     "1.2.1",
-    "1.0.2",
+    "1.0.3",
     "1.0.0",
     Network.AURORA,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/aurigami/src/mapping.ts
+++ b/subgraphs/compound-forks/aurigami/src/mapping.ts
@@ -97,17 +97,18 @@ export function handleMarketListed(event: MarketListed): void {
     new MarketListedData(
       protocol,
       new TokenData(
-        cTokenAddr,
-        getOrElse<string>(cTokenContract.try_name(), "unknown"),
-        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
-        cTokenDecimals
-      ),
-      new TokenData(
         underlyingTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)
       ),
+      new TokenData(
+        cTokenAddr,
+        getOrElse<string>(cTokenContract.try_name(), "unknown"),
+        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
+        cTokenDecimals
+      ),
+
       cTokenReserveFactorMantissa
     ),
     event

--- a/subgraphs/compound-forks/banker-joe/src/mapping.ts
+++ b/subgraphs/compound-forks/banker-joe/src/mapping.ts
@@ -87,17 +87,18 @@ export function handleMarketListed(event: MarketListed): void {
     new MarketListedData(
       protocol,
       new TokenData(
-        cTokenAddr,
-        getOrElse<string>(cTokenContract.try_name(), "unknown"),
-        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
-        cTokenDecimals
-      ),
-      new TokenData(
         underlyingTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)
       ),
+      new TokenData(
+        cTokenAddr,
+        getOrElse<string>(cTokenContract.try_name(), "unknown"),
+        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
+        cTokenDecimals
+      ),
+ 
       cTokenReserveFactorMantissa
     ),
     event

--- a/subgraphs/compound-forks/banker-joe/src/mapping.ts
+++ b/subgraphs/compound-forks/banker-joe/src/mapping.ts
@@ -98,7 +98,7 @@ export function handleMarketListed(event: MarketListed): void {
         getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
         cTokenDecimals
       ),
- 
+
       cTokenReserveFactorMantissa
     ),
     event
@@ -169,7 +169,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Banker Joe",
     "banker-joe",
     "1.2.1",
-    "1.0.1",
+    "1.0.2",
     "1.0.0",
     Network.AVALANCHE,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/banker-joe/src/mapping.ts
+++ b/subgraphs/compound-forks/banker-joe/src/mapping.ts
@@ -87,13 +87,13 @@ export function handleMarketListed(event: MarketListed): void {
     new MarketListedData(
       protocol,
       new TokenData(
-        underlyingTokenAddr,
+        cTokenAddr,
         getOrElse<string>(cTokenContract.try_name(), "unknown"),
         getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
         cTokenDecimals
       ),
       new TokenData(
-        cTokenAddr,
+        underlyingTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)

--- a/subgraphs/compound-forks/bastion-protocol/src/mapping.ts
+++ b/subgraphs/compound-forks/bastion-protocol/src/mapping.ts
@@ -97,13 +97,13 @@ export function handleMarketListed(event: MarketListed): void {
     new MarketListedData(
       protocol,
       new TokenData(
-        underlyingTokenAddr,
+        cTokenAddr,
         getOrElse<string>(cTokenContract.try_name(), "unknown"),
         getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
         cTokenDecimals
       ),
       new TokenData(
-        cTokenAddr,
+        underlyingTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)

--- a/subgraphs/compound-forks/bastion-protocol/src/mapping.ts
+++ b/subgraphs/compound-forks/bastion-protocol/src/mapping.ts
@@ -178,7 +178,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Bastion Protocol",
     "bastion-protocol",
     "1.2.1",
-    "1.0.5",
+    "1.0.6",
     "1.0.0",
     Network.AURORA,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/bastion-protocol/src/mapping.ts
+++ b/subgraphs/compound-forks/bastion-protocol/src/mapping.ts
@@ -97,16 +97,16 @@ export function handleMarketListed(event: MarketListed): void {
     new MarketListedData(
       protocol,
       new TokenData(
-        cTokenAddr,
-        getOrElse<string>(cTokenContract.try_name(), "unknown"),
-        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
-        cTokenDecimals
-      ),
-      new TokenData(
         underlyingTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)
+      ),
+      new TokenData(
+        cTokenAddr,
+        getOrElse<string>(cTokenContract.try_name(), "unknown"),
+        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
+        cTokenDecimals
       ),
       cTokenReserveFactorMantissa
     ),

--- a/subgraphs/compound-forks/benqi/src/mapping.ts
+++ b/subgraphs/compound-forks/benqi/src/mapping.ts
@@ -219,7 +219,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "BENQI",
     "benqi",
     "1.2.1",
-    "1.0.3",
+    "1.0.4",
     "1.0.0",
     Network.AVALANCHE,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/cream-finance/src/mapping.ts
+++ b/subgraphs/compound-forks/cream-finance/src/mapping.ts
@@ -183,7 +183,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "CREAM Finance",
     "cream-finance",
     "1.2.1",
-    "1.0.2",
+    "1.0.3",
     "1.0.0",
     network,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/cream-finance/src/mapping.ts
+++ b/subgraphs/compound-forks/cream-finance/src/mapping.ts
@@ -101,17 +101,18 @@ export function handleMarketListed(event: MarketListed): void {
     new MarketListedData(
       protocol,
       new TokenData(
-        cTokenAddr,
-        getOrElse<string>(cTokenContract.try_name(), "unknown"),
-        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
-        cTokenDecimals
-      ),
-      new TokenData(
         underlyingTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)
       ),
+      new TokenData(
+        cTokenAddr,
+        getOrElse<string>(cTokenContract.try_name(), "unknown"),
+        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
+        cTokenDecimals
+      ),
+
       cTokenReserveFactorMantissa
     ),
     event

--- a/subgraphs/compound-forks/cream-finance/src/mapping.ts
+++ b/subgraphs/compound-forks/cream-finance/src/mapping.ts
@@ -101,13 +101,13 @@ export function handleMarketListed(event: MarketListed): void {
     new MarketListedData(
       protocol,
       new TokenData(
-        underlyingTokenAddr,
+        cTokenAddr,
         getOrElse<string>(cTokenContract.try_name(), "unknown"),
         getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
         cTokenDecimals
       ),
       new TokenData(
-        cTokenAddr,
+        underlyingTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)

--- a/subgraphs/compound-forks/iron-bank/src/mapping.ts
+++ b/subgraphs/compound-forks/iron-bank/src/mapping.ts
@@ -89,16 +89,17 @@ export function handleMarketListed(event: MarketListed): void {
       protocol,
       new TokenData(
         underlyingTokenAddr,
-        getOrElse<string>(cTokenContract.try_name(), "unknown"),
-        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
-        cTokenDecimals
-      ),
-      new TokenData(
-        cTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)
       ),
+      new TokenData(
+        cTokenAddr,
+        getOrElse<string>(cTokenContract.try_name(), "unknown"),
+        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
+        cTokenDecimals
+      ),
+
       cTokenReserveFactorMantissa
     ),
     event

--- a/subgraphs/compound-forks/iron-bank/src/mapping.ts
+++ b/subgraphs/compound-forks/iron-bank/src/mapping.ts
@@ -170,7 +170,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Iron Bank",
     "iron-bank",
     "1.2.1",
-    "1.0.4",
+    "1.0.5",
     "1.0.0",
     network,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/moonwell/src/mapping.ts
+++ b/subgraphs/compound-forks/moonwell/src/mapping.ts
@@ -231,7 +231,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Moonwell",
     "moonwell",
     "1.2.1",
-    "1.0.5",
+    "1.0.6",
     "1.0.0",
     Network.MOONRIVER,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/scream/src/mapping.ts
+++ b/subgraphs/compound-forks/scream/src/mapping.ts
@@ -169,7 +169,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Scream",
     "scream",
     "1.2.1",
-    "1.0.2",
+    "1.0.3",
     "1.0.0",
     Network.FANTOM,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/scream/src/mapping.ts
+++ b/subgraphs/compound-forks/scream/src/mapping.ts
@@ -88,16 +88,17 @@ export function handleMarketListed(event: MarketListed): void {
       protocol,
       new TokenData(
         underlyingTokenAddr,
-        getOrElse<string>(cTokenContract.try_name(), "unknown"),
-        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
-        cTokenDecimals
-      ),
-      new TokenData(
-        cTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)
       ),
+      new TokenData(
+        cTokenAddr,
+        getOrElse<string>(cTokenContract.try_name(), "unknown"),
+        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
+        cTokenDecimals
+      ),
+
       cTokenReserveFactorMantissa
     ),
     event

--- a/subgraphs/compound-forks/venus/src/mapping.ts
+++ b/subgraphs/compound-forks/venus/src/mapping.ts
@@ -97,13 +97,13 @@ export function handleMarketListed(event: MarketListed): void {
     new MarketListedData(
       protocol,
       new TokenData(
-        underlyingTokenAddr,
+        cTokenAddr,
         getOrElse<string>(cTokenContract.try_name(), "unknown"),
         getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
         cTokenDecimals
       ),
       new TokenData(
-        cTokenAddr,
+        underlyingTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)

--- a/subgraphs/compound-forks/venus/src/mapping.ts
+++ b/subgraphs/compound-forks/venus/src/mapping.ts
@@ -178,7 +178,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Venus",
     "venus",
     "1.2.1",
-    "1.0.2",
+    "1.0.3",
     "1.0.0",
     Network.BSC,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/venus/src/mapping.ts
+++ b/subgraphs/compound-forks/venus/src/mapping.ts
@@ -97,16 +97,16 @@ export function handleMarketListed(event: MarketListed): void {
     new MarketListedData(
       protocol,
       new TokenData(
-        cTokenAddr,
-        getOrElse<string>(cTokenContract.try_name(), "unknown"),
-        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
-        cTokenDecimals
-      ),
-      new TokenData(
         underlyingTokenAddr,
         getOrElse<string>(underlyingTokenContract.try_name(), "unknown"),
         getOrElse<string>(underlyingTokenContract.try_symbol(), "unknown"),
         getOrElse<i32>(underlyingTokenContract.try_decimals(), 0)
+      ),
+      new TokenData(
+        cTokenAddr,
+        getOrElse<string>(cTokenContract.try_name(), "unknown"),
+        getOrElse<string>(cTokenContract.try_symbol(), "unknown"),
+        cTokenDecimals
       ),
       cTokenReserveFactorMantissa
     ),


### PR DESCRIPTION
A number of compound-fork subgraphs have their cTokenAddr and underlyingTokenAddr swapped when creating MarketListedData. This PR fixes the bug.