### PR TITLE
Refactored to make compound-forks handlers more generic

### DIFF
--- a/subgraphs/compound-forks/aurigami/src/mapping.ts
+++ b/subgraphs/compound-forks/aurigami/src/mapping.ts
@@ -53,7 +53,8 @@ import { PriceOracle } from "../generated/templates/CToken/PriceOracle";
 
 export function handleNewPriceOracle(event: NewPriceOracle): void {
   let protocol = getOrCreateProtocol();
-  _handleNewPriceOracle(protocol, event);
+  let newPriceOracle = event.params.newPriceOracle;
+  _handleNewPriceOracle(protocol, newPriceOracle);
 }
 
 export function handleMarketListed(event: MarketListed): void {
@@ -116,42 +117,69 @@ export function handleMarketListed(event: MarketListed): void {
 }
 
 export function handleNewCollateralFactor(event: NewCollateralFactor): void {
-  _handleNewCollateralFactor(event);
+  let marketID = event.params.cToken.toHexString();
+  let collateralFactorMantissa = event.params.newCollateralFactorMantissa;
+  _handleNewCollateralFactor(marketID, collateralFactorMantissa);
 }
 
 export function handleNewLiquidationIncentive(
   event: NewLiquidationIncentive
 ): void {
   let protocol = getOrCreateProtocol();
-  _handleNewLiquidationIncentive(protocol, event);
+  let newLiquidationIncentive = event.params.newLiquidationIncentiveMantissa;
+  _handleNewLiquidationIncentive(protocol, newLiquidationIncentive);
 }
 
 export function handleActionPaused(event: ActionPaused1): void {
-  _handleActionPaused(event);
+  let marketID = event.params.cToken.toHexString();
+  let action = event.params.action;
+  let pauseState = event.params.pauseState;
+  _handleActionPaused(marketID, action, pauseState);
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {
-  _handleNewReserveFactor(event);
+  let marketID = event.address.toHexString();
+  let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
+  _handleNewReserveFactor(marketID, newReserveFactorMantissa);
 }
 
 export function handleMint(event: Mint): void {
-  _handleMint(comptrollerAddr, event);
+  let minter = event.params.minter;
+  let mintAmount = event.params.mintAmount;
+  _handleMint(comptrollerAddr, minter, mintAmount, event);
 }
 
 export function handleRedeem(event: Redeem): void {
-  _handleRedeem(comptrollerAddr, event);
+  let redeemer = event.params.redeemer;
+  let redeemAmount = event.params.redeemAmount;
+  _handleRedeem(comptrollerAddr, redeemer, redeemAmount, event);
 }
 
 export function handleBorrow(event: BorrowEvent): void {
-  _handleBorrow(comptrollerAddr, event);
+  let borrower = event.params.borrower;
+  let borrowAmount = event.params.borrowAmount;
+  _handleBorrow(comptrollerAddr, borrower, borrowAmount, event);
 }
 
 export function handleRepayBorrow(event: RepayBorrow): void {
-  _handleRepayBorrow(comptrollerAddr, event);
+  let payer = event.params.payer;
+  let repayAmount = event.params.repayAmount;
+  _handleRepayBorrow(comptrollerAddr, payer, repayAmount, event);
 }
 
 export function handleLiquidateBorrow(event: LiquidateBorrow): void {
-  _handleLiquidateBorrow(comptrollerAddr, event);
+  let cTokenCollateral = event.params.cTokenCollateral;
+  let liquidator = event.params.liquidator;
+  let seizeTokens = event.params.seizeTokens;
+  let repayAmount = event.params.repayAmount;
+  _handleLiquidateBorrow(
+    comptrollerAddr,
+    cTokenCollateral,
+    liquidator,
+    seizeTokens,
+    repayAmount,
+    event
+  );
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
@@ -169,7 +197,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     oracleContract.try_getUnderlyingPrice(marketAddress),
     SECONDS_PER_YEAR
   );
-  _handleAccrueInterest(updateMarketData, comptrollerAddr, event);
+
+  let interestAccumulated = event.params.interestAccumulated;
+  let totalBorrows = event.params.totalBorrows;
+  _handleAccrueInterest(
+    updateMarketData,
+    comptrollerAddr,
+    interestAccumulated,
+    totalBorrows,
+    event
+  );
 }
 
 function getOrCreateProtocol(): LendingProtocol {
@@ -179,7 +216,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Aurigami",
     "aurigami",
     "1.2.1",
-    "1.0.3",
+    "1.0.4",
     "1.0.0",
     Network.AURORA,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/banker-joe/src/mapping.ts
+++ b/subgraphs/compound-forks/banker-joe/src/mapping.ts
@@ -53,7 +53,8 @@ import { PriceOracle } from "../generated/templates/CToken/PriceOracle";
 
 export function handleNewPriceOracle(event: NewPriceOracle): void {
   let protocol = getOrCreateProtocol();
-  _handleNewPriceOracle(protocol, event);
+  let newPriceOracle = event.params.newPriceOracle;
+  _handleNewPriceOracle(protocol, newPriceOracle);
 }
 
 export function handleMarketListed(event: MarketListed): void {
@@ -106,42 +107,69 @@ export function handleMarketListed(event: MarketListed): void {
 }
 
 export function handleNewCollateralFactor(event: NewCollateralFactor): void {
-  _handleNewCollateralFactor(event);
+  let marketID = event.params.cToken.toHexString();
+  let collateralFactorMantissa = event.params.newCollateralFactorMantissa;
+  _handleNewCollateralFactor(marketID, collateralFactorMantissa);
 }
 
 export function handleNewLiquidationIncentive(
   event: NewLiquidationIncentive
 ): void {
   let protocol = getOrCreateProtocol();
-  _handleNewLiquidationIncentive(protocol, event);
+  let newLiquidationIncentive = event.params.newLiquidationIncentiveMantissa;
+  _handleNewLiquidationIncentive(protocol, newLiquidationIncentive);
 }
 
 export function handleActionPaused(event: ActionPaused1): void {
-  _handleActionPaused(event);
+  let marketID = event.params.cToken.toHexString();
+  let action = event.params.action;
+  let pauseState = event.params.pauseState;
+  _handleActionPaused(marketID, action, pauseState);
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {
-  _handleNewReserveFactor(event);
+  let marketID = event.address.toHexString();
+  let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
+  _handleNewReserveFactor(marketID, newReserveFactorMantissa);
 }
 
 export function handleMint(event: Mint): void {
-  _handleMint(comptrollerAddr, event);
+  let minter = event.params.minter;
+  let mintAmount = event.params.mintAmount;
+  _handleMint(comptrollerAddr, minter, mintAmount, event);
 }
 
 export function handleRedeem(event: Redeem): void {
-  _handleRedeem(comptrollerAddr, event);
+  let redeemer = event.params.redeemer;
+  let redeemAmount = event.params.redeemAmount;
+  _handleRedeem(comptrollerAddr, redeemer, redeemAmount, event);
 }
 
 export function handleBorrow(event: BorrowEvent): void {
-  _handleBorrow(comptrollerAddr, event);
+  let borrower = event.params.borrower;
+  let borrowAmount = event.params.borrowAmount;
+  _handleBorrow(comptrollerAddr, borrower, borrowAmount, event);
 }
 
 export function handleRepayBorrow(event: RepayBorrow): void {
-  _handleRepayBorrow(comptrollerAddr, event);
+  let payer = event.params.payer;
+  let repayAmount = event.params.repayAmount;
+  _handleRepayBorrow(comptrollerAddr, payer, repayAmount, event);
 }
 
 export function handleLiquidateBorrow(event: LiquidateBorrow): void {
-  _handleLiquidateBorrow(comptrollerAddr, event);
+  let cTokenCollateral = event.params.cTokenCollateral;
+  let liquidator = event.params.liquidator;
+  let seizeTokens = event.params.seizeTokens;
+  let repayAmount = event.params.repayAmount;
+  _handleLiquidateBorrow(
+    comptrollerAddr,
+    cTokenCollateral,
+    liquidator,
+    seizeTokens,
+    repayAmount,
+    event
+  );
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
@@ -159,7 +187,15 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     oracleContract.try_getUnderlyingPrice(marketAddress),
     SECONDS_PER_YEAR
   );
-  _handleAccrueInterest(updateMarketData, comptrollerAddr, event);
+  let interestAccumulated = event.params.interestAccumulated;
+  let totalBorrows = event.params.totalBorrows;
+  _handleAccrueInterest(
+    updateMarketData,
+    comptrollerAddr,
+    interestAccumulated,
+    totalBorrows,
+    event
+  );
 }
 
 function getOrCreateProtocol(): LendingProtocol {
@@ -169,7 +205,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Banker Joe",
     "banker-joe",
     "1.2.1",
-    "1.0.2",
+    "1.0.3",
     "1.0.0",
     Network.AVALANCHE,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/bastion-protocol/src/mapping.ts
+++ b/subgraphs/compound-forks/bastion-protocol/src/mapping.ts
@@ -53,7 +53,8 @@ import { PriceOracle } from "../generated/templates/CToken/PriceOracle";
 
 export function handleNewPriceOracle(event: NewPriceOracle): void {
   let protocol = getOrCreateProtocol();
-  _handleNewPriceOracle(protocol, event);
+  let newPriceOracle = event.params.newPriceOracle;
+  _handleNewPriceOracle(protocol, newPriceOracle);
 }
 
 export function handleMarketListed(event: MarketListed): void {
@@ -115,42 +116,69 @@ export function handleMarketListed(event: MarketListed): void {
 }
 
 export function handleNewCollateralFactor(event: NewCollateralFactor): void {
-  _handleNewCollateralFactor(event);
+  let marketID = event.params.cToken.toHexString();
+  let collateralFactorMantissa = event.params.newCollateralFactorMantissa;
+  _handleNewCollateralFactor(marketID, collateralFactorMantissa);
 }
 
 export function handleNewLiquidationIncentive(
   event: NewLiquidationIncentive
 ): void {
   let protocol = getOrCreateProtocol();
-  _handleNewLiquidationIncentive(protocol, event);
+  let newLiquidationIncentive = event.params.newLiquidationIncentiveMantissa;
+  _handleNewLiquidationIncentive(protocol, newLiquidationIncentive);
 }
 
 export function handleActionPaused(event: ActionPaused1): void {
-  _handleActionPaused(event);
+  let marketID = event.params.cToken.toHexString();
+  let action = event.params.action;
+  let pauseState = event.params.pauseState;
+  _handleActionPaused(marketID, action, pauseState);
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {
-  _handleNewReserveFactor(event);
+  let marketID = event.address.toHexString();
+  let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
+  _handleNewReserveFactor(marketID, newReserveFactorMantissa);
 }
 
 export function handleMint(event: Mint): void {
-  _handleMint(comptrollerAddr, event);
+  let minter = event.params.minter;
+  let mintAmount = event.params.mintAmount;
+  _handleMint(comptrollerAddr, minter, mintAmount, event);
 }
 
 export function handleRedeem(event: Redeem): void {
-  _handleRedeem(comptrollerAddr, event);
+  let redeemer = event.params.redeemer;
+  let redeemAmount = event.params.redeemAmount;
+  _handleRedeem(comptrollerAddr, redeemer, redeemAmount, event);
 }
 
 export function handleBorrow(event: BorrowEvent): void {
-  _handleBorrow(comptrollerAddr, event);
+  let borrower = event.params.borrower;
+  let borrowAmount = event.params.borrowAmount;
+  _handleBorrow(comptrollerAddr, borrower, borrowAmount, event);
 }
 
 export function handleRepayBorrow(event: RepayBorrow): void {
-  _handleRepayBorrow(comptrollerAddr, event);
+  let payer = event.params.payer;
+  let repayAmount = event.params.repayAmount;
+  _handleRepayBorrow(comptrollerAddr, payer, repayAmount, event);
 }
 
 export function handleLiquidateBorrow(event: LiquidateBorrow): void {
-  _handleLiquidateBorrow(comptrollerAddr, event);
+  let cTokenCollateral = event.params.cTokenCollateral;
+  let liquidator = event.params.liquidator;
+  let seizeTokens = event.params.seizeTokens;
+  let repayAmount = event.params.repayAmount;
+  _handleLiquidateBorrow(
+    comptrollerAddr,
+    cTokenCollateral,
+    liquidator,
+    seizeTokens,
+    repayAmount,
+    event
+  );
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
@@ -168,7 +196,15 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     oracleContract.try_getUnderlyingPrice(marketAddress),
     SECONDS_PER_YEAR
   );
-  _handleAccrueInterest(updateMarketData, comptrollerAddr, event);
+  let interestAccumulated = event.params.interestAccumulated;
+  let totalBorrows = event.params.totalBorrows;
+  _handleAccrueInterest(
+    updateMarketData,
+    comptrollerAddr,
+    interestAccumulated,
+    totalBorrows,
+    event
+  );
 }
 
 function getOrCreateProtocol(): LendingProtocol {
@@ -178,7 +214,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Bastion Protocol",
     "bastion-protocol",
     "1.2.1",
-    "1.0.6",
+    "1.0.7",
     "1.0.0",
     Network.AURORA,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/benqi/src/mapping.ts
+++ b/subgraphs/compound-forks/benqi/src/mapping.ts
@@ -89,7 +89,8 @@ class RewardTokenEmission {
 
 export function handleNewPriceOracle(event: NewPriceOracle): void {
   let protocol = getOrCreateProtocol();
-  _handleNewPriceOracle(protocol, event);
+  let newPriceOracle = event.params.newPriceOracle;
+  _handleNewPriceOracle(protocol, newPriceOracle);
 }
 
 export function handleMarketListed(event: MarketListed): void {
@@ -153,42 +154,69 @@ export function handleMarketListed(event: MarketListed): void {
 }
 
 export function handleNewCollateralFactor(event: NewCollateralFactor): void {
-  _handleNewCollateralFactor(event);
+  let marketID = event.params.cToken.toHexString();
+  let collateralFactorMantissa = event.params.newCollateralFactorMantissa;
+  _handleNewCollateralFactor(marketID, collateralFactorMantissa);
 }
 
 export function handleNewLiquidationIncentive(
   event: NewLiquidationIncentive
 ): void {
   let protocol = getOrCreateProtocol();
-  _handleNewLiquidationIncentive(protocol, event);
+  let newLiquidationIncentive = event.params.newLiquidationIncentiveMantissa;
+  _handleNewLiquidationIncentive(protocol, newLiquidationIncentive);
 }
 
 export function handleActionPaused(event: ActionPaused1): void {
-  _handleActionPaused(event);
+  let marketID = event.params.cToken.toHexString();
+  let action = event.params.action;
+  let pauseState = event.params.pauseState;
+  _handleActionPaused(marketID, action, pauseState);
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {
-  _handleNewReserveFactor(event);
+  let marketID = event.address.toHexString();
+  let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
+  _handleNewReserveFactor(marketID, newReserveFactorMantissa);
 }
 
 export function handleMint(event: Mint): void {
-  _handleMint(comptrollerAddr, event);
+  let minter = event.params.minter;
+  let mintAmount = event.params.mintAmount;
+  _handleMint(comptrollerAddr, minter, mintAmount, event);
 }
 
 export function handleRedeem(event: Redeem): void {
-  _handleRedeem(comptrollerAddr, event);
+  let redeemer = event.params.redeemer;
+  let redeemAmount = event.params.redeemAmount;
+  _handleRedeem(comptrollerAddr, redeemer, redeemAmount, event);
 }
 
 export function handleBorrow(event: BorrowEvent): void {
-  _handleBorrow(comptrollerAddr, event);
+  let borrower = event.params.borrower;
+  let borrowAmount = event.params.borrowAmount;
+  _handleBorrow(comptrollerAddr, borrower, borrowAmount, event);
 }
 
 export function handleRepayBorrow(event: RepayBorrow): void {
-  _handleRepayBorrow(comptrollerAddr, event);
+  let payer = event.params.payer;
+  let repayAmount = event.params.repayAmount;
+  _handleRepayBorrow(comptrollerAddr, payer, repayAmount, event);
 }
 
 export function handleLiquidateBorrow(event: LiquidateBorrow): void {
-  _handleLiquidateBorrow(comptrollerAddr, event);
+  let cTokenCollateral = event.params.cTokenCollateral;
+  let liquidator = event.params.liquidator;
+  let seizeTokens = event.params.seizeTokens;
+  let repayAmount = event.params.repayAmount;
+  _handleLiquidateBorrow(
+    comptrollerAddr,
+    cTokenCollateral,
+    liquidator,
+    seizeTokens,
+    repayAmount,
+    event
+  );
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
@@ -209,7 +237,15 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     SECONDS_PER_YEAR
   );
 
-  _handleAccrueInterest(updateMarketData, comptrollerAddr, event);
+  let interestAccumulated = event.params.interestAccumulated;
+  let totalBorrows = event.params.totalBorrows;
+  _handleAccrueInterest(
+    updateMarketData,
+    comptrollerAddr,
+    interestAccumulated,
+    totalBorrows,
+    event
+  );
 }
 
 function getOrCreateProtocol(): LendingProtocol {
@@ -219,7 +255,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "BENQI",
     "benqi",
     "1.2.1",
-    "1.0.4",
+    "1.0.5",
     "1.0.0",
     Network.AVALANCHE,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/cream-finance/src/mapping.ts
+++ b/subgraphs/compound-forks/cream-finance/src/mapping.ts
@@ -56,7 +56,8 @@ let nativeCToken = constant.nativeCToken;
 
 export function handleNewPriceOracle(event: NewPriceOracle): void {
   let protocol = getOrCreateProtocol();
-  _handleNewPriceOracle(protocol, event);
+  let newPriceOracle = event.params.newPriceOracle;
+  _handleNewPriceOracle(protocol, newPriceOracle);
 }
 
 export function handleMarketListed(event: MarketListed): void {
@@ -120,42 +121,69 @@ export function handleMarketListed(event: MarketListed): void {
 }
 
 export function handleNewCollateralFactor(event: NewCollateralFactor): void {
-  _handleNewCollateralFactor(event);
+  let marketID = event.params.cToken.toHexString();
+  let collateralFactorMantissa = event.params.newCollateralFactorMantissa;
+  _handleNewCollateralFactor(marketID, collateralFactorMantissa);
 }
 
 export function handleNewLiquidationIncentive(
   event: NewLiquidationIncentive
 ): void {
   let protocol = getOrCreateProtocol();
-  _handleNewLiquidationIncentive(protocol, event);
+  let newLiquidationIncentive = event.params.newLiquidationIncentiveMantissa;
+  _handleNewLiquidationIncentive(protocol, newLiquidationIncentive);
 }
 
 export function handleActionPaused(event: ActionPaused1): void {
-  _handleActionPaused(event);
+  let marketID = event.params.cToken.toHexString();
+  let action = event.params.action;
+  let pauseState = event.params.pauseState;
+  _handleActionPaused(marketID, action, pauseState);
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {
-  _handleNewReserveFactor(event);
+  let marketID = event.address.toHexString();
+  let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
+  _handleNewReserveFactor(marketID, newReserveFactorMantissa);
 }
 
 export function handleMint(event: Mint): void {
-  _handleMint(comptrollerAddr, event);
+  let minter = event.params.minter;
+  let mintAmount = event.params.mintAmount;
+  _handleMint(comptrollerAddr, minter, mintAmount, event);
 }
 
 export function handleRedeem(event: Redeem): void {
-  _handleRedeem(comptrollerAddr, event);
+  let redeemer = event.params.redeemer;
+  let redeemAmount = event.params.redeemAmount;
+  _handleRedeem(comptrollerAddr, redeemer, redeemAmount, event);
 }
 
 export function handleBorrow(event: BorrowEvent): void {
-  _handleBorrow(comptrollerAddr, event);
+  let borrower = event.params.borrower;
+  let borrowAmount = event.params.borrowAmount;
+  _handleBorrow(comptrollerAddr, borrower, borrowAmount, event);
 }
 
 export function handleRepayBorrow(event: RepayBorrow): void {
-  _handleRepayBorrow(comptrollerAddr, event);
+  let payer = event.params.payer;
+  let repayAmount = event.params.repayAmount;
+  _handleRepayBorrow(comptrollerAddr, payer, repayAmount, event);
 }
 
 export function handleLiquidateBorrow(event: LiquidateBorrow): void {
-  _handleLiquidateBorrow(comptrollerAddr, event);
+  let cTokenCollateral = event.params.cTokenCollateral;
+  let liquidator = event.params.liquidator;
+  let seizeTokens = event.params.seizeTokens;
+  let repayAmount = event.params.repayAmount;
+  _handleLiquidateBorrow(
+    comptrollerAddr,
+    cTokenCollateral,
+    liquidator,
+    seizeTokens,
+    repayAmount,
+    event
+  );
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
@@ -173,7 +201,15 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     oracleContract.try_getUnderlyingPrice(marketAddress),
     unitPerYear
   );
-  _handleAccrueInterest(updateMarketData, comptrollerAddr, event);
+  let interestAccumulated = event.params.interestAccumulated;
+  let totalBorrows = event.params.totalBorrows;
+  _handleAccrueInterest(
+    updateMarketData,
+    comptrollerAddr,
+    interestAccumulated,
+    totalBorrows,
+    event
+  );
 }
 
 function getOrCreateProtocol(): LendingProtocol {
@@ -183,7 +219,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "CREAM Finance",
     "cream-finance",
     "1.2.1",
-    "1.0.3",
+    "1.0.4",
     "1.0.0",
     network,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/iron-bank/src/mapping.ts
+++ b/subgraphs/compound-forks/iron-bank/src/mapping.ts
@@ -54,7 +54,8 @@ let unitPerYear = constant.unitPerYear;
 
 export function handleNewPriceOracle(event: NewPriceOracle): void {
   let protocol = getOrCreateProtocol();
-  _handleNewPriceOracle(protocol, event);
+  let newPriceOracle = event.params.newPriceOracle;
+  _handleNewPriceOracle(protocol, newPriceOracle);
 }
 
 export function handleMarketListed(event: MarketListed): void {
@@ -107,42 +108,69 @@ export function handleMarketListed(event: MarketListed): void {
 }
 
 export function handleNewCollateralFactor(event: NewCollateralFactor): void {
-  _handleNewCollateralFactor(event);
+  let marketID = event.params.cToken.toHexString();
+  let collateralFactorMantissa = event.params.newCollateralFactorMantissa;
+  _handleNewCollateralFactor(marketID, collateralFactorMantissa);
 }
 
 export function handleNewLiquidationIncentive(
   event: NewLiquidationIncentive
 ): void {
   let protocol = getOrCreateProtocol();
-  _handleNewLiquidationIncentive(protocol, event);
+  let newLiquidationIncentive = event.params.newLiquidationIncentiveMantissa;
+  _handleNewLiquidationIncentive(protocol, newLiquidationIncentive);
 }
 
 export function handleActionPaused(event: ActionPaused1): void {
-  _handleActionPaused(event);
+  let marketID = event.params.cToken.toHexString();
+  let action = event.params.action;
+  let pauseState = event.params.pauseState;
+  _handleActionPaused(marketID, action, pauseState);
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {
-  _handleNewReserveFactor(event);
+  let marketID = event.address.toHexString();
+  let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
+  _handleNewReserveFactor(marketID, newReserveFactorMantissa);
 }
 
 export function handleMint(event: Mint): void {
-  _handleMint(comptrollerAddr, event);
+  let minter = event.params.minter;
+  let mintAmount = event.params.mintAmount;
+  _handleMint(comptrollerAddr, minter, mintAmount, event);
 }
 
 export function handleRedeem(event: Redeem): void {
-  _handleRedeem(comptrollerAddr, event);
+  let redeemer = event.params.redeemer;
+  let redeemAmount = event.params.redeemAmount;
+  _handleRedeem(comptrollerAddr, redeemer, redeemAmount, event);
 }
 
 export function handleBorrow(event: BorrowEvent): void {
-  _handleBorrow(comptrollerAddr, event);
+  let borrower = event.params.borrower;
+  let borrowAmount = event.params.borrowAmount;
+  _handleBorrow(comptrollerAddr, borrower, borrowAmount, event);
 }
 
 export function handleRepayBorrow(event: RepayBorrow): void {
-  _handleRepayBorrow(comptrollerAddr, event);
+  let payer = event.params.payer;
+  let repayAmount = event.params.repayAmount;
+  _handleRepayBorrow(comptrollerAddr, payer, repayAmount, event);
 }
 
 export function handleLiquidateBorrow(event: LiquidateBorrow): void {
-  _handleLiquidateBorrow(comptrollerAddr, event);
+  let cTokenCollateral = event.params.cTokenCollateral;
+  let liquidator = event.params.liquidator;
+  let seizeTokens = event.params.seizeTokens;
+  let repayAmount = event.params.repayAmount;
+  _handleLiquidateBorrow(
+    comptrollerAddr,
+    cTokenCollateral,
+    liquidator,
+    seizeTokens,
+    repayAmount,
+    event
+  );
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
@@ -160,7 +188,15 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     oracleContract.try_getUnderlyingPrice(marketAddress),
     unitPerYear
   );
-  _handleAccrueInterest(updateMarketData, comptrollerAddr, event);
+  let interestAccumulated = event.params.interestAccumulated;
+  let totalBorrows = event.params.totalBorrows;
+  _handleAccrueInterest(
+    updateMarketData,
+    comptrollerAddr,
+    interestAccumulated,
+    totalBorrows,
+    event
+  );
 }
 
 function getOrCreateProtocol(): LendingProtocol {
@@ -170,7 +206,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Iron Bank",
     "iron-bank",
     "1.2.1",
-    "1.0.5",
+    "1.0.6",
     "1.0.0",
     network,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/moonwell/src/mapping.ts
+++ b/subgraphs/compound-forks/moonwell/src/mapping.ts
@@ -88,7 +88,8 @@ class RewardTokenEmission {
 
 export function handleNewPriceOracle(event: NewPriceOracle): void {
   let protocol = getOrCreateProtocol();
-  _handleNewPriceOracle(protocol, event);
+  let newPriceOracle = event.params.newPriceOracle;
+  _handleNewPriceOracle(protocol, newPriceOracle);
 }
 
 export function handleMarketListed(event: MarketListed): void {
@@ -152,7 +153,9 @@ export function handleMarketListed(event: MarketListed): void {
 }
 
 export function handleNewCollateralFactor(event: NewCollateralFactor): void {
-  _handleNewCollateralFactor(event);
+  let marketID = event.params.cToken.toHexString();
+  let collateralFactorMantissa = event.params.newCollateralFactorMantissa;
+  _handleNewCollateralFactor(marketID, collateralFactorMantissa);
 }
 
 export function handleActionPaused(event: ActionPaused1): void {
@@ -176,31 +179,53 @@ export function handleNewLiquidationIncentive(
   event: NewLiquidationIncentive
 ): void {
   let protocol = getOrCreateProtocol();
-  _handleNewLiquidationIncentive(protocol, event);
+  let newLiquidationIncentive = event.params.newLiquidationIncentiveMantissa;
+  _handleNewLiquidationIncentive(protocol, newLiquidationIncentive);
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {
-  _handleNewReserveFactor(event);
+  let marketID = event.address.toHexString();
+  let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
+  _handleNewReserveFactor(marketID, newReserveFactorMantissa);
 }
 
 export function handleMint(event: Mint): void {
-  _handleMint(comptrollerAddr, event);
+  let minter = event.params.minter;
+  let mintAmount = event.params.mintAmount;
+  _handleMint(comptrollerAddr, minter, mintAmount, event);
 }
 
 export function handleRedeem(event: Redeem): void {
-  _handleRedeem(comptrollerAddr, event);
+  let redeemer = event.params.redeemer;
+  let redeemAmount = event.params.redeemAmount;
+  _handleRedeem(comptrollerAddr, redeemer, redeemAmount, event);
 }
 
 export function handleBorrow(event: BorrowEvent): void {
-  _handleBorrow(comptrollerAddr, event);
+  let borrower = event.params.borrower;
+  let borrowAmount = event.params.borrowAmount;
+  _handleBorrow(comptrollerAddr, borrower, borrowAmount, event);
 }
 
 export function handleRepayBorrow(event: RepayBorrow): void {
-  _handleRepayBorrow(comptrollerAddr, event);
+  let payer = event.params.payer;
+  let repayAmount = event.params.repayAmount;
+  _handleRepayBorrow(comptrollerAddr, payer, repayAmount, event);
 }
 
 export function handleLiquidateBorrow(event: LiquidateBorrow): void {
-  _handleLiquidateBorrow(comptrollerAddr, event);
+  let cTokenCollateral = event.params.cTokenCollateral;
+  let liquidator = event.params.liquidator;
+  let seizeTokens = event.params.seizeTokens;
+  let repayAmount = event.params.repayAmount;
+  _handleLiquidateBorrow(
+    comptrollerAddr,
+    cTokenCollateral,
+    liquidator,
+    seizeTokens,
+    repayAmount,
+    event
+  );
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
@@ -221,7 +246,15 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     SECONDS_PER_YEAR
   );
 
-  _handleAccrueInterest(updateMarketData, comptrollerAddr, event);
+  let interestAccumulated = event.params.interestAccumulated;
+  let totalBorrows = event.params.totalBorrows;
+  _handleAccrueInterest(
+    updateMarketData,
+    comptrollerAddr,
+    interestAccumulated,
+    totalBorrows,
+    event
+  );
 }
 
 function getOrCreateProtocol(): LendingProtocol {
@@ -231,7 +264,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Moonwell",
     "moonwell",
     "1.2.1",
-    "1.0.6",
+    "1.0.7",
     "1.0.0",
     Network.MOONRIVER,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/scream/src/mapping.ts
+++ b/subgraphs/compound-forks/scream/src/mapping.ts
@@ -53,7 +53,8 @@ import { PriceOracle } from "../generated/templates/CToken/PriceOracle";
 
 export function handleNewPriceOracle(event: NewPriceOracle): void {
   let protocol = getOrCreateProtocol();
-  _handleNewPriceOracle(protocol, event);
+  let newPriceOracle = event.params.newPriceOracle;
+  _handleNewPriceOracle(protocol, newPriceOracle);
 }
 
 export function handleMarketListed(event: MarketListed): void {
@@ -106,42 +107,69 @@ export function handleMarketListed(event: MarketListed): void {
 }
 
 export function handleNewCollateralFactor(event: NewCollateralFactor): void {
-  _handleNewCollateralFactor(event);
+  let marketID = event.params.cToken.toHexString();
+  let collateralFactorMantissa = event.params.newCollateralFactorMantissa;
+  _handleNewCollateralFactor(marketID, collateralFactorMantissa);
 }
 
 export function handleNewLiquidationIncentive(
   event: NewLiquidationIncentive
 ): void {
   let protocol = getOrCreateProtocol();
-  _handleNewLiquidationIncentive(protocol, event);
+  let newLiquidationIncentive = event.params.newLiquidationIncentiveMantissa;
+  _handleNewLiquidationIncentive(protocol, newLiquidationIncentive);
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {
-  _handleNewReserveFactor(event);
+  let marketID = event.address.toHexString();
+  let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
+  _handleNewReserveFactor(marketID, newReserveFactorMantissa);
 }
 
 export function handleActionPaused(event: ActionPaused1): void {
-  _handleActionPaused(event);
+  let marketID = event.params.cToken.toHexString();
+  let action = event.params.action;
+  let pauseState = event.params.pauseState;
+  _handleActionPaused(marketID, action, pauseState);
 }
 
 export function handleMint(event: Mint): void {
-  _handleMint(comptrollerAddr, event);
+  let minter = event.params.minter;
+  let mintAmount = event.params.mintAmount;
+  _handleMint(comptrollerAddr, minter, mintAmount, event);
 }
 
 export function handleRedeem(event: Redeem): void {
-  _handleRedeem(comptrollerAddr, event);
+  let redeemer = event.params.redeemer;
+  let redeemAmount = event.params.redeemAmount;
+  _handleRedeem(comptrollerAddr, redeemer, redeemAmount, event);
 }
 
 export function handleBorrow(event: BorrowEvent): void {
-  _handleBorrow(comptrollerAddr, event);
+  let borrower = event.params.borrower;
+  let borrowAmount = event.params.borrowAmount;
+  _handleBorrow(comptrollerAddr, borrower, borrowAmount, event);
 }
 
 export function handleRepayBorrow(event: RepayBorrow): void {
-  _handleRepayBorrow(comptrollerAddr, event);
+  let payer = event.params.payer;
+  let repayAmount = event.params.repayAmount;
+  _handleRepayBorrow(comptrollerAddr, payer, repayAmount, event);
 }
 
 export function handleLiquidateBorrow(event: LiquidateBorrow): void {
-  _handleLiquidateBorrow(comptrollerAddr, event);
+  let cTokenCollateral = event.params.cTokenCollateral;
+  let liquidator = event.params.liquidator;
+  let seizeTokens = event.params.seizeTokens;
+  let repayAmount = event.params.repayAmount;
+  _handleLiquidateBorrow(
+    comptrollerAddr,
+    cTokenCollateral,
+    liquidator,
+    seizeTokens,
+    repayAmount,
+    event
+  );
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
@@ -159,7 +187,15 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     oracleContract.try_getUnderlyingPrice(marketAddress),
     FANTOM_BLOCKS_PER_YEAR
   );
-  _handleAccrueInterest(updateMarketData, comptrollerAddr, event);
+  let interestAccumulated = event.params.interestAccumulated;
+  let totalBorrows = event.params.totalBorrows;
+  _handleAccrueInterest(
+    updateMarketData,
+    comptrollerAddr,
+    interestAccumulated,
+    totalBorrows,
+    event
+  );
 }
 
 function getOrCreateProtocol(): LendingProtocol {
@@ -169,7 +205,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Scream",
     "scream",
     "1.2.1",
-    "1.0.3",
+    "1.0.4",
     "1.0.0",
     Network.FANTOM,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/src/mapping.ts
+++ b/subgraphs/compound-forks/src/mapping.ts
@@ -169,14 +169,16 @@ export class UpdateMarketData {
 // event.params.cToken:
 // event.params.oldCollateralFactorMantissa:
 // event.params.newCollateralFactorMantissa:
-export function _handleNewCollateralFactor(event: NewCollateralFactor): void {
-  let marketID = event.params.cToken.toHexString();
+export function _handleNewCollateralFactor(
+  marketID: string,
+  newCollateralFactorMantissa: BigInt
+): void {
   let market = Market.load(marketID);
   if (market == null) {
     log.warning("[handleNewCollateralFactor] Market not found: {}", [marketID]);
     return;
   }
-  let collateralFactor = event.params.newCollateralFactorMantissa
+  let collateralFactor = newCollateralFactorMantissa
     .toBigDecimal()
     .div(mantissaFactorBD)
     .times(BIGDECIMAL_HUNDRED);
@@ -200,9 +202,9 @@ export function _handleNewCollateralFactor(event: NewCollateralFactor): void {
 // event.params.newLiquidationIncentiveMantissa
 export function _handleNewLiquidationIncentive(
   protocol: LendingProtocol,
-  event: NewLiquidationIncentive
+  newLiquidationIncentiveMantissa: BigInt
 ): void {
-  let liquidationIncentive = event.params.newLiquidationIncentiveMantissa
+  let liquidationIncentive = newLiquidationIncentiveMantissa
     .toBigDecimal()
     .div(mantissaFactorBD)
     .minus(BIGDECIMAL_ONE)
@@ -231,9 +233,9 @@ export function _handleNewLiquidationIncentive(
 // - newPriceOracle
 export function _handleNewPriceOracle(
   protocol: LendingProtocol,
-  event: NewPriceOracle
+  newPriceOracle: Address
 ): void {
-  protocol._priceOracle = event.params.newPriceOracle.toHexString();
+  protocol._priceOracle = newPriceOracle.toHexString();
   protocol.save();
 }
 
@@ -243,18 +245,21 @@ export function _handleNewPriceOracle(
 //  - cToken: Address
 //  - action: string
 //  - pauseState: boolean
-export function _handleActionPaused(event: ActionPaused1): void {
-  let marketID = event.params.cToken.toHexString();
+export function _handleActionPaused(
+  marketID: string,
+  action: string,
+  pauseState: boolean
+): void {
   let market = Market.load(marketID);
   if (!market) {
     log.warning("[handleActionPaused] Market not found: {}", [marketID]);
     return;
   }
 
-  if (event.params.action == "Mint") {
-    market.isActive = event.params.pauseState;
-  } else if (event.params.action == "Borrow") {
-    market.canBorrowFrom = event.params.pauseState;
+  if (action == "Mint") {
+    market.isActive = pauseState;
+  } else if (action == "Borrow") {
+    market.canBorrowFrom = pauseState;
   }
 
   market.save();
@@ -265,9 +270,10 @@ export function _handleActionPaused(event: ActionPaused1): void {
 // event.params.cToken: The address of the market (token) to list
 export function _handleMarketListed(
   marketListedData: MarketListedData,
-  event: MarketListed
+  event: ethereum.Event
 ): void {
-  let cTokenAddr = event.params.cToken;
+  //let cTokenAddr = event.params.cToken;
+  let cTokenAddr = marketListedData.cToken.address;
   let cToken = Token.load(cTokenAddr.toHexString());
   if (cToken != null) {
     return;
@@ -373,7 +379,13 @@ export function _handleMarketListed(
 // - minter
 // - mintAmount: The amount of underlying assets to mint
 // - mintTokens: The amount of cTokens minted
-export function _handleMint(comptrollerAddr: Address, event: Mint): void {
+export function _handleMint(
+  comptrollerAddr: Address,
+  minter: Address,
+  mintAmount: BigInt,
+  //mintTokens: BigInt, //not used
+  event: ethereum.Event
+): void {
   let protocol = LendingProtocol.load(comptrollerAddr.toHexString());
   if (!protocol) {
     log.warning("[handleMint] protocol not found: {}", [
@@ -404,14 +416,14 @@ export function _handleMint(comptrollerAddr: Address, event: Mint): void {
   deposit.logIndex = event.transactionLogIndex.toI32();
   deposit.protocol = protocol.id;
   deposit.to = marketID;
-  deposit.from = event.params.minter.toHexString();
+  deposit.from = minter.toHexString();
   deposit.blockNumber = event.block.number;
   deposit.timestamp = event.block.timestamp;
   deposit.market = marketID;
   deposit.asset = market.inputToken;
-  deposit.amount = event.params.mintAmount;
+  deposit.amount = mintAmount;
   let depositUSD = market.inputTokenPriceUSD.times(
-    event.params.mintAmount
+    mintAmount
       .toBigDecimal()
       .div(exponentToBigDecimal(underlyingToken.decimals))
   );
@@ -432,7 +444,7 @@ export function _handleMint(comptrollerAddr: Address, event: Mint): void {
     comptrollerAddr,
     event.block.number,
     event.block.timestamp,
-    event.params.minter.toHexString(),
+    minter.toHexString(),
     EventType.Deposit
   );
 }
@@ -443,7 +455,12 @@ export function _handleMint(comptrollerAddr: Address, event: Mint): void {
 // - redeemer
 // - redeemAmount
 // - redeecTokens
-export function _handleRedeem(comptrollerAddr: Address, event: Redeem): void {
+export function _handleRedeem(
+  comptrollerAddr: Address,
+  redeemer: Address,
+  redeemAmount: BigInt,
+  event: ethereum.Event
+): void {
   let protocol = LendingProtocol.load(comptrollerAddr.toHexString());
   if (!protocol) {
     log.warning("[handleMint] protocol not found: {}", [
@@ -473,15 +490,15 @@ export function _handleRedeem(comptrollerAddr: Address, event: Redeem): void {
   withdraw.hash = event.transaction.hash.toHexString();
   withdraw.logIndex = event.transactionLogIndex.toI32();
   withdraw.protocol = protocol.id;
-  withdraw.to = event.params.redeemer.toHexString();
+  withdraw.to = redeemer.toHexString();
   withdraw.from = marketID;
   withdraw.blockNumber = event.block.number;
   withdraw.timestamp = event.block.timestamp;
   withdraw.market = marketID;
   withdraw.asset = market.inputToken;
-  withdraw.amount = event.params.redeemAmount;
+  withdraw.amount = redeemAmount;
   withdraw.amountUSD = market.inputTokenPriceUSD.times(
-    event.params.redeemAmount
+    redeemAmount
       .toBigDecimal()
       .div(exponentToBigDecimal(underlyingToken.decimals))
   );
@@ -493,7 +510,7 @@ export function _handleRedeem(comptrollerAddr: Address, event: Redeem): void {
     comptrollerAddr,
     event.block.number,
     event.block.timestamp,
-    event.params.redeemer.toHexString(),
+    redeemer.toHexString(),
     EventType.Withdraw
   );
 }
@@ -507,7 +524,9 @@ export function _handleRedeem(comptrollerAddr: Address, event: Redeem): void {
 // - totalBorrows
 export function _handleBorrow(
   comptrollerAddr: Address,
-  event: BorrowEvent
+  borrower: Address,
+  borrowAmount: BigInt,
+  event: ethereum.Event
 ): void {
   let protocol = LendingProtocol.load(comptrollerAddr.toHexString());
   if (!protocol) {
@@ -538,15 +557,15 @@ export function _handleBorrow(
   borrow.hash = event.transaction.hash.toHexString();
   borrow.logIndex = event.transactionLogIndex.toI32();
   borrow.protocol = protocol.id;
-  borrow.to = event.params.borrower.toHexString();
+  borrow.to = borrower.toHexString();
   borrow.from = marketID;
   borrow.blockNumber = event.block.number;
   borrow.timestamp = event.block.timestamp;
   borrow.market = marketID;
   borrow.asset = market.inputToken;
-  borrow.amount = event.params.borrowAmount;
+  borrow.amount = borrowAmount;
   let borrowUSD = market.inputTokenPriceUSD.times(
-    event.params.borrowAmount
+    borrowAmount
       .toBigDecimal()
       .div(exponentToBigDecimal(underlyingToken.decimals))
   );
@@ -567,7 +586,7 @@ export function _handleBorrow(
     comptrollerAddr,
     event.block.number,
     event.block.timestamp,
-    event.params.borrower.toHexString(),
+    borrower.toHexString(),
     EventType.Borrow
   );
 }
@@ -582,7 +601,9 @@ export function _handleBorrow(
 // - totalBorrows
 export function _handleRepayBorrow(
   comptrollerAddr: Address,
-  event: RepayBorrow
+  payer: Address,
+  repayAmount: BigInt,
+  event: ethereum.Event
 ): void {
   let protocol = LendingProtocol.load(comptrollerAddr.toHexString());
   if (!protocol) {
@@ -614,14 +635,14 @@ export function _handleRepayBorrow(
   repay.logIndex = event.transactionLogIndex.toI32();
   repay.protocol = protocol.id;
   repay.to = marketID;
-  repay.from = event.params.payer.toHexString();
+  repay.from = payer.toHexString();
   repay.blockNumber = event.block.number;
   repay.timestamp = event.block.timestamp;
   repay.market = marketID;
   repay.asset = market.inputToken;
-  repay.amount = event.params.repayAmount;
+  repay.amount = repayAmount;
   repay.amountUSD = market.inputTokenPriceUSD.times(
-    event.params.repayAmount
+    repayAmount
       .toBigDecimal()
       .div(exponentToBigDecimal(underlyingToken.decimals))
   );
@@ -631,7 +652,7 @@ export function _handleRepayBorrow(
     comptrollerAddr,
     event.block.number,
     event.block.timestamp,
-    event.params.payer.toHexString(),
+    payer.toHexString(),
     EventType.Repay
   );
 }
@@ -646,7 +667,11 @@ export function _handleRepayBorrow(
 // - seizeTokens
 export function _handleLiquidateBorrow(
   comptrollerAddr: Address,
-  event: LiquidateBorrow
+  cTokenCollateral: Address,
+  liquidator: Address,
+  seizeTokens: BigInt,
+  repayAmount: BigInt,
+  event: ethereum.Event
 ): void {
   let protocol = LendingProtocol.load(comptrollerAddr.toHexString());
   if (!protocol) {
@@ -678,7 +703,7 @@ export function _handleLiquidateBorrow(
     return;
   }
 
-  let liquidatedCTokenMarketID = event.params.cTokenCollateral.toHexString();
+  let liquidatedCTokenMarketID = cTokenCollateral.toHexString();
   let liquidatedCTokenMarket = Market.load(liquidatedCTokenMarketID);
   if (!liquidatedCTokenMarket) {
     log.warning(
@@ -714,7 +739,7 @@ export function _handleLiquidateBorrow(
   liquidate.logIndex = event.transactionLogIndex.toI32();
   liquidate.protocol = protocol.id;
   liquidate.to = repayTokenMarketID;
-  liquidate.from = event.params.liquidator.toHexString();
+  liquidate.from = liquidator.toHexString();
   liquidate.blockNumber = event.block.number;
   liquidate.timestamp = event.block.timestamp;
   liquidate.market = repayTokenMarketID;
@@ -722,12 +747,12 @@ export function _handleLiquidateBorrow(
     // this is logically redundant since nullcheck has been done before, but removing the if check will fail 'graph build'
     liquidate.asset = liquidatedCTokenID;
   }
-  liquidate.amount = event.params.seizeTokens;
-  let gainUSD = event.params.seizeTokens
+  liquidate.amount = seizeTokens;
+  let gainUSD = seizeTokens
     .toBigDecimal()
     .div(cTokenDecimalsBD)
     .times(liquidatedCTokenMarket.outputTokenPriceUSD);
-  let lossUSD = event.params.repayAmount
+  let lossUSD = repayAmount
     .toBigDecimal()
     .div(exponentToBigDecimal(repayToken.decimals))
     .times(repayTokenMarket.inputTokenPriceUSD);
@@ -750,7 +775,7 @@ export function _handleLiquidateBorrow(
     comptrollerAddr,
     event.block.number,
     event.block.timestamp,
-    event.params.liquidator.toHexString(),
+    liquidator.toHexString(),
     EventType.Liquidate
   );
 }
@@ -763,7 +788,9 @@ export function _handleLiquidateBorrow(
 export function _handleAccrueInterest(
   updateMarketData: UpdateMarketData,
   comptrollerAddr: Address,
-  event: AccrueInterest
+  interestAccumulated: BigInt,
+  totalBorrows: BigInt,
+  event: ethereum.Event
 ): void {
   let marketID = event.address.toHexString();
   let market = Market.load(marketID);
@@ -782,8 +809,8 @@ export function _handleAccrueInterest(
   updateMarket(
     updateMarketData,
     marketID,
-    event.params.interestAccumulated,
-    event.params.totalBorrows,
+    interestAccumulated,
+    totalBorrows,
     event.block.number,
     event.block.timestamp
   );
@@ -801,14 +828,16 @@ export function _handleAccrueInterest(
 // event.params
 // - oldReserveFactorMantissa
 // - newReserveFactorMantissa
-export function _handleNewReserveFactor(event: NewReserveFactor): void {
-  let marketID = event.address.toHexString();
+export function _handleNewReserveFactor(
+  marketID: string,
+  newReserveFactorMantissa: BigInt
+): void {
   let market = Market.load(marketID);
   if (market == null) {
     log.warning("[handleNewReserveFactor] Market not found: {}", [marketID]);
     return;
   }
-  let reserveFactor = event.params.newReserveFactorMantissa
+  let reserveFactor = newReserveFactorMantissa
     .toBigDecimal()
     .div(mantissaFactorBD);
   market._reserveFactor = reserveFactor;

--- a/subgraphs/compound-forks/src/mapping.ts
+++ b/subgraphs/compound-forks/src/mapping.ts
@@ -6,22 +6,6 @@ import {
   log,
 } from "@graphprotocol/graph-ts";
 import {
-  MarketListed,
-  NewCollateralFactor,
-  NewLiquidationIncentive,
-  NewPriceOracle,
-  ActionPaused1,
-} from "../generated/Comptroller/Comptroller";
-import {
-  Mint,
-  Redeem,
-  Borrow as BorrowEvent,
-  RepayBorrow,
-  LiquidateBorrow,
-  AccrueInterest,
-  NewReserveFactor,
-} from "../generated/templates/CToken/CToken";
-import {
   Account,
   Borrow,
   ActiveAccount,

--- a/subgraphs/compound-forks/venus/src/mapping.ts
+++ b/subgraphs/compound-forks/venus/src/mapping.ts
@@ -53,7 +53,8 @@ import { PriceOracle } from "../generated/templates/CToken/PriceOracle";
 
 export function handleNewPriceOracle(event: NewPriceOracle): void {
   let protocol = getOrCreateProtocol();
-  _handleNewPriceOracle(protocol, event);
+  let newPriceOracle = event.params.newPriceOracle;
+  _handleNewPriceOracle(protocol, newPriceOracle);
 }
 
 export function handleMarketListed(event: MarketListed): void {
@@ -115,42 +116,69 @@ export function handleMarketListed(event: MarketListed): void {
 }
 
 export function handleNewCollateralFactor(event: NewCollateralFactor): void {
-  _handleNewCollateralFactor(event);
+  let marketID = event.params.cToken.toHexString();
+  let collateralFactorMantissa = event.params.newCollateralFactorMantissa;
+  _handleNewCollateralFactor(marketID, collateralFactorMantissa);
 }
 
 export function handleNewLiquidationIncentive(
   event: NewLiquidationIncentive
 ): void {
   let protocol = getOrCreateProtocol();
-  _handleNewLiquidationIncentive(protocol, event);
+  let newLiquidationIncentive = event.params.newLiquidationIncentiveMantissa;
+  _handleNewLiquidationIncentive(protocol, newLiquidationIncentive);
 }
 
 export function handleActionPaused(event: ActionPaused1): void {
-  _handleActionPaused(event);
+  let marketID = event.params.cToken.toHexString();
+  let action = event.params.action;
+  let pauseState = event.params.pauseState;
+  _handleActionPaused(marketID, action, pauseState);
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {
-  _handleNewReserveFactor(event);
+  let marketID = event.address.toHexString();
+  let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
+  _handleNewReserveFactor(marketID, newReserveFactorMantissa);
 }
 
 export function handleMint(event: Mint): void {
-  _handleMint(comptrollerAddr, event);
+  let minter = event.params.minter;
+  let mintAmount = event.params.mintAmount;
+  _handleMint(comptrollerAddr, minter, mintAmount, event);
 }
 
 export function handleRedeem(event: Redeem): void {
-  _handleRedeem(comptrollerAddr, event);
+  let redeemer = event.params.redeemer;
+  let redeemAmount = event.params.redeemAmount;
+  _handleRedeem(comptrollerAddr, redeemer, redeemAmount, event);
 }
 
 export function handleBorrow(event: BorrowEvent): void {
-  _handleBorrow(comptrollerAddr, event);
+  let borrower = event.params.borrower;
+  let borrowAmount = event.params.borrowAmount;
+  _handleBorrow(comptrollerAddr, borrower, borrowAmount, event);
 }
 
 export function handleRepayBorrow(event: RepayBorrow): void {
-  _handleRepayBorrow(comptrollerAddr, event);
+  let payer = event.params.payer;
+  let repayAmount = event.params.repayAmount;
+  _handleRepayBorrow(comptrollerAddr, payer, repayAmount, event);
 }
 
 export function handleLiquidateBorrow(event: LiquidateBorrow): void {
-  _handleLiquidateBorrow(comptrollerAddr, event);
+  let cTokenCollateral = event.params.cTokenCollateral;
+  let liquidator = event.params.liquidator;
+  let seizeTokens = event.params.seizeTokens;
+  let repayAmount = event.params.repayAmount;
+  _handleLiquidateBorrow(
+    comptrollerAddr,
+    cTokenCollateral,
+    liquidator,
+    seizeTokens,
+    repayAmount,
+    event
+  );
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
@@ -168,7 +196,15 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     oracleContract.try_getUnderlyingPrice(marketAddress),
     BSC_BLOCKS_PER_YEAR
   );
-  _handleAccrueInterest(updateMarketData, comptrollerAddr, event);
+  let interestAccumulated = event.params.interestAccumulated;
+  let totalBorrows = event.params.totalBorrows;
+  _handleAccrueInterest(
+    updateMarketData,
+    comptrollerAddr,
+    interestAccumulated,
+    totalBorrows,
+    event
+  );
 }
 
 function getOrCreateProtocol(): LendingProtocol {
@@ -178,7 +214,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Venus",
     "venus",
     "1.2.1",
-    "1.0.3",
+    "1.0.4",
     "1.0.0",
     Network.BSC,
     comptroller.try_liquidationIncentiveMantissa(),


### PR DESCRIPTION
This PR refactors src/mapping.ts for compound-forks to make the handlers more generic (accepting necessary information as arguments to handler functions instead of from a particular Event object), following the discussion at https://github.com/messari/subgraphs/pull/263#issuecomment-1145430732 .

Two test runs are ongoing: https://thegraph.com/hosted-service/subgraph/tnkrxyz/aurigami and https://thegraph.com/hosted-service/subgraph/tnkrxyz/venus-subgraph (no errors so far).