### PR TITLE
Schema Proposal: Add Side to Position ID, use BigInt for nonce;

### DIFF
--- a/schema-lending-extended.graphql
+++ b/schema-lending-extended.graphql
@@ -931,7 +931,7 @@ type Account @entity {
 }
 
 type Position @entity {
-  " { Account address }-{ Market address }-{ Counter } "
+  " { Account address }-{ Market address }-{ Position Type }-{ Counter } "
   id: ID!
 
   " Account that owns this position "

--- a/schema-lending-extended.graphql
+++ b/schema-lending-extended.graphql
@@ -1039,7 +1039,7 @@ interface Event {
   hash: String!
 
   " Nonce of the transaction that emitted this event "
-  nonce: Int!
+  nonce: BigInt!
 
   " Event log index. For transactions that don't emit event, create arbitrary index starting from 0 "
   logIndex: Int!
@@ -1068,7 +1068,7 @@ type Deposit implements Event @entity {
   hash: String!
 
   " Nonce of the transaction that emitted this event "
-  nonce: Int!
+  nonce: BigInt!
 
   " Event log index. For transactions that don't emit event, create arbitrary index starting from 0 "
   logIndex: Int!
@@ -1111,7 +1111,7 @@ type Withdraw implements Event @entity {
   hash: String!
 
   " Nonce of the transaction that emitted this event "
-  nonce: Int!
+  nonce: BigInt!
 
   " Event log index. For transactions that don't emit event, create arbitrary index starting from 0 "
   logIndex: Int!
@@ -1159,7 +1159,7 @@ type Borrow implements Event @entity {
   hash: String!
 
   " Nonce of the transaction that emitted this event "
-  nonce: Int!
+  nonce: BigInt!
 
   " Event log index. For transactions that don't emit event, create arbitrary index starting from 0 "
   logIndex: Int!
@@ -1203,7 +1203,7 @@ type Repay implements Event @entity {
   hash: String!
 
   " Nonce of the transaction that emitted this event "
-  nonce: Int!
+  nonce: BigInt!
 
   " Event log index. For transactions that don't emit event, create arbitrary index starting from 0 "
   logIndex: Int!
@@ -1246,7 +1246,7 @@ type Liquidate implements Event @entity {
   hash: String!
 
   " Nonce of the transaction that emitted this event "
-  nonce: Int!
+  nonce: BigInt!
 
   " Event log index. For transactions that don't emit event, create arbitrary index starting from 0 "
   logIndex: Int!

--- a/schema-lending-extended.graphql
+++ b/schema-lending-extended.graphql
@@ -931,7 +931,7 @@ type Account @entity {
 }
 
 type Position @entity {
-  " { Account address }-{ Market address }-{ Position Type }-{ Counter } "
+  " { Account address }-{ Market address }-{ Position Side }-{ Counter } "
   id: ID!
 
   " Account that owns this position "


### PR DESCRIPTION
- Having the type of the postion in the id is beneficial as it allows for quickly finding the latest open position of each type example code:
```
// Finds the open lending position or opens a new one 
export function getOrCreateLendingOpenPosition(marketId: string, accountId: string, event: ethereum.Event): Position {
  let positionIdPrefix = `${accountId}-${marketId}-LENDER`;

  let account = getOrCreateAccount(accountId, event);
  for (let curr = 0; curr < account.openPositionCount; curr += 1) {
    let op = account.openPositions.at(curr);
    if (op.startsWith(positionIdPrefix)) {
      return Position.load(op)!;
    }
  }

  let count = 0;
  for (let curr = 0; curr < account.closedPositionCount; curr += 1) {
    let cp = account.closedPositions.at(curr);
    if (cp.startsWith(positionIdPrefix)) {
      count += 1;
    }
  }

  let newPositionId = `${accountId}-${marketId}-LENDER-${count}`;
```

- event.transaction.nonce is BigInt so we should use BigInt in nonce for event;