### PR TITLE
Fix Arbitrum Rari Fuse crazy high TVL

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This repo contains subgraphs defined using a set of standardized schemas. These 
 | [Maple Finance](https://www.maple.finance/) | 🛠 | 1.2.1 / 1.1.0 / 1.0.0 | [![Maple Finance Ethereum](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/maple-finance-ethereum) |
 | [Moonwell Finance](https://moonwell.fi/) | 🛠 | 1.3.0 / 1.0.10 / 1.0.0 | [![Moonwell Moonriver](./docs/images/chains/moonriver.png)](https://thegraph.com/hosted-service/subgraph/messari/moonwell-moonriver)  |
 | Notional Finance | 🔨 | | |
-| [Rari Fuse](https://app.rari.capital/fuse) | 🔨 | 1.3.0 / 1.0.16 / 1.0.0 | [![Rari Fuse Ethereum](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/rari-fuse-ethereum) [![Rari Fuse Arbitrum](./docs/images/chains/arbitrum.png)](https://thegraph.com/hosted-service/subgraph/messari/rari-fuse-arbitrum) |
+| [Rari Fuse](https://app.rari.capital/fuse) | 🔨 | 1.3.0 / 1.0.18 / 1.0.0 | [![Rari Fuse Ethereum](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/rari-fuse-ethereum) [![Rari Fuse Arbitrum](./docs/images/chains/arbitrum.png)](https://thegraph.com/hosted-service/subgraph/messari/rari-fuse-arbitrum) |
 | [SCREAM](https://scream.sh/) | 🛠 | 1.3.0 / 1.0.6 / 1.0.0 | [![SCREAM Fantom](./docs/images/chains/fantom.png)](https://thegraph.com/hosted-service/subgraph/messari/scream-fantom)  |
 | [Venus Protocol](https://venus.io/) | 🛠 | 1.3.0 / 1.0.6 / 1.0.0 | [![Venus Protocol BSC](./docs/images/chains/bsc.png)](https://thegraph.com/hosted-service/subgraph/messari/venus-protocol-bsc) |
 | [Yeti Finance](https://yeti.finance/) | 🔨 | | |

--- a/subgraphs/compound-forks/protocols/rari-fuse/README.md
+++ b/subgraphs/compound-forks/protocols/rari-fuse/README.md
@@ -73,6 +73,8 @@ Count of Unique Addresses which have interacted with the protocol via any transa
 - Arbitrum One:
   - Market `0xc0c997227922004da3a47185ac2be1d648db0062` has a very high TVL (~$100m). This is likely due to the fact that 10% of the total supply of the `inputToken` is in this vault and there are only 5 holders. Price of this asset is probably hard to calculate.
     - A potential fix is to recalculate TVL in every market each time `AccrueInterest` emits. This would slow down syncing as lots of contract calls would be introduced.
+  - `fMIM` seems to have price oracle manipulation between 2/1/22 - 2/4/22 so I took the average price and overrided any transactions within those timestamps
+
 
 ## Reference and Useful Links
 

--- a/subgraphs/compound-forks/protocols/rari-fuse/src/constants.ts
+++ b/subgraphs/compound-forks/protocols/rari-fuse/src/constants.ts
@@ -54,6 +54,7 @@ export const ETH_SYMBOL = "ETH";
 
 export const SOHM_ADDRESS = "0x04f2694c8fcee23e8fd0dfea1d4f5bb8c352111f";
 export const GOHM_ADDRESS = "0x0ab87046fBb341D058F17CBC4c1133F25a20a52f";
+export const FMIM_ADDRESS = "0xd9444bab79720e8223b83e5d913d00c679b44b65";
 
 ///////////////////////////
 //// Protocol Specific ////
@@ -61,6 +62,6 @@ export const GOHM_ADDRESS = "0x0ab87046fBb341D058F17CBC4c1133F25a20a52f";
 
 export const PROTOCOL_NAME = "Rari Fuse";
 export const PROTOCOL_SLUG = "rari-fuse";
-export const SUBGRAPH_VERSION = "1.0.17";
+export const SUBGRAPH_VERSION = "1.0.18";
 export const SCHEMA_VERSION = "1.3.0";
 export const METHODOLOGY_VERSION = "1.0.0";

--- a/subgraphs/compound-forks/protocols/rari-fuse/src/mappings.ts
+++ b/subgraphs/compound-forks/protocols/rari-fuse/src/mappings.ts
@@ -39,6 +39,7 @@ import {
   ETH_ADDRESS,
   ETH_NAME,
   ETH_SYMBOL,
+  FMIM_ADDRESS,
   getNetworkSpecificConstant,
   GOHM_ADDRESS,
   METHODOLOGY_VERSION,
@@ -638,6 +639,16 @@ function updateMarket(
       .toBigDecimal()
       .div(bdFactor);
     underlyingTokenPriceUSD = priceInEth.times(ethPriceUSD); // get price in USD
+  }
+
+  // Protect fMIM from price oracle manipulation on 2/1/22-2/4/22
+  // The average price on those days is $0.99632525
+  if (
+    marketID.toLowerCase() == FMIM_ADDRESS.toLowerCase() &&
+    blockTimestamp.toI32() >= 1643695208 && // beginning of day 2/1
+    blockTimestamp.toI32() <= 1643954408 // EOD 2/4
+  ) {
+    underlyingTokenPriceUSD = BigDecimal.fromString("0.99632525");
   }
 
   underlyingToken.lastPriceUSD = underlyingTokenPriceUSD;


### PR DESCRIPTION
A fuse pool on arbitrum had a crazy high asset price for MIM. To fix this I overrided prices during the affected time period to the average price. MIM is a stable coin so there was very little real variance in price so I thought that was a fair solution.

Testing: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/id/QmRSMpgxPhGgHYWwLn21DSs9zoEpdSJ8JLpdndGLm7nUpp&tab=protocol