### PR TITLE
Fix Liquidation event table for Lending 1.3.0 schema

### DIFF
--- a/dashboard/src/common/chartComponents/TableEvents.tsx
+++ b/dashboard/src/common/chartComponents/TableEvents.tsx
@@ -30,7 +30,7 @@ export const TableEvents = ({ datasetLabel, protocolNetwork, data, eventName }: 
     const tableData: any[] = [];
     for (let i = 0; i < dataTable.length; i++) {
       const currentData = { ...dataTable[i] };
-      if (currentData?.liquidatee) {
+      if (currentData?.liquidatee?.id) {
         currentData.liquidatee = currentData.liquidatee.id;
       }
       if (currentData?.liquidator) {


### PR DESCRIPTION
1.3.0 has `liquidatee` field typed as String, not Account