### PR TITLE
Change unknown token decimals

### DIFF
--- a/subgraphs/_reference_/src/common/tokens.ts
+++ b/subgraphs/_reference_/src/common/tokens.ts
@@ -4,7 +4,7 @@ import { ERC20SymbolBytes } from "../../generated/UniswapV2Factory/ERC20SymbolBy
 import { ERC20NameBytes } from "../../generated/UniswapV2Factory/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/aave-v2-forks-ext/src/token.ts
+++ b/subgraphs/aave-v2-forks-ext/src/token.ts
@@ -4,7 +4,7 @@ import { ERC20 } from "../generated/templates/LendingPool/ERC20";
 import { ERC20NameBytes } from "../generated/templates/LendingPool/ERC20NameBytes";
 import { ERC20SymbolBytes } from "../generated/templates/LendingPool/ERC20SymbolBytes";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/aave-v2-forks/src/token.ts
+++ b/subgraphs/aave-v2-forks/src/token.ts
@@ -4,7 +4,7 @@ import { ERC20 } from "../generated/templates/LendingPool/ERC20";
 import { ERC20NameBytes } from "../generated/templates/LendingPool/ERC20NameBytes";
 import { ERC20SymbolBytes } from "../generated/templates/LendingPool/ERC20SymbolBytes";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/abracadabra-ext/src/common/tokens.ts
+++ b/subgraphs/abracadabra-ext/src/common/tokens.ts
@@ -4,7 +4,7 @@ import { ERC20SymbolBytes } from "../../generated/BentoBox/ERC20SymbolBytes";
 import { ERC20NameBytes } from "../../generated/BentoBox/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/abracadabra/src/common/tokens.ts
+++ b/subgraphs/abracadabra/src/common/tokens.ts
@@ -4,7 +4,7 @@ import { ERC20SymbolBytes } from "../../generated/BentoBox/ERC20SymbolBytes";
 import { ERC20NameBytes } from "../../generated/BentoBox/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/arrakis-finance/src/common/tokens.ts
+++ b/subgraphs/arrakis-finance/src/common/tokens.ts
@@ -4,7 +4,7 @@ import { ERC20SymbolBytes } from "../../generated/templates/ArrakisVault/ERC20Sy
 import { ERC20NameBytes } from "../../generated/templates/ArrakisVault/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/compound-forks-ext/protocols/compound-v2/src/token.ts
+++ b/subgraphs/compound-forks-ext/protocols/compound-v2/src/token.ts
@@ -4,7 +4,7 @@ import { ERC20SymbolBytes } from "../../../generated/Comptroller/ERC20SymbolByte
 import { ERC20NameBytes } from "../../../generated/Comptroller/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/compound-forks/protocols/compound-v2/src/token.ts
+++ b/subgraphs/compound-forks/protocols/compound-v2/src/token.ts
@@ -4,7 +4,7 @@ import { ERC20SymbolBytes } from "../../../generated/Comptroller/ERC20SymbolByte
 import { ERC20NameBytes } from "../../../generated/Comptroller/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/curve-finance/src/common/tokens.ts
+++ b/subgraphs/curve-finance/src/common/tokens.ts
@@ -5,7 +5,7 @@ import { ERC20SymbolBytes } from "../../generated/templates/CurvePoolTemplate/ER
 import { ERC20NameBytes } from "../../generated/templates/CurvePoolTemplate/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/ellipsis-finance/src/common/tokens.ts
+++ b/subgraphs/ellipsis-finance/src/common/tokens.ts
@@ -4,7 +4,7 @@ import { ERC20SymbolBytes } from "../../generated/Factory/ERC20SymbolBytes";
 import { ERC20NameBytes } from "../../generated/Factory/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/gamma-strategies/src/common/tokens.ts
+++ b/subgraphs/gamma-strategies/src/common/tokens.ts
@@ -4,7 +4,7 @@ import { ERC20SymbolBytes } from "../../generated/templates/Hypervisor/ERC20Symb
 import { ERC20NameBytes } from "../../generated/templates/Hypervisor/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/makerdao/src/common/tokens.ts
+++ b/subgraphs/makerdao/src/common/tokens.ts
@@ -3,7 +3,7 @@ import { ERC20 } from "../../generated/Vat/ERC20";
 import { ERC20SymbolBytes } from "../../generated/Vat/ERC20SymbolBytes";
 import { ERC20NameBytes } from "../../generated/Vat/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {

--- a/subgraphs/platypus-finance/src/common/tokens.ts
+++ b/subgraphs/platypus-finance/src/common/tokens.ts
@@ -4,7 +4,7 @@ import { ERC20SymbolBytes } from "../../generated/Pool/ERC20SymbolBytes";
 import { ERC20NameBytes } from "../../generated/Pool/ERC20NameBytes";
 import { Address } from "@graphprotocol/graph-ts";
 
-export const INVALID_TOKEN_DECIMALS = 9999;
+export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {


### PR DESCRIPTION
Fix: change unkown token decimals to 0. This prevents an out of bounds error when trying to convert a BigInt value to BigDecimal.

Note: Turn off deployments on this merge