### PR TITLE
Rari Fuse: Prevent Hourly Snapshot error

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -472,7 +472,7 @@
           "template": "rari-fuse.template.yaml",
           "messari": "messari/rari-fuse-ethereum",
           "dmelotik": "dmelotik/fuse-mainnet",
-          "deploy-on-merge": false
+          "deploy-on-merge": true
         }
       },
       "scream": {

--- a/subgraphs/compound-forks-ext/README.md
+++ b/subgraphs/compound-forks-ext/README.md
@@ -18,10 +18,10 @@ Once everything is setup properly deploying is very easy.
 
 ```bash
 # This example will deploy rari-fuse on all networks to the hosted service under "dmelotik" in deploymentConfigurations.json
-npm run deploy --SUBGRAPH=compound-forks --PROTOCOL=rari-fuse --LOCATION=dmelotik
+npm run deploy --SUBGRAPH=compound-forks-ext --PROTOCOL=rari-fuse --LOCATION=dmelotik
 
 # This will do the same, but only deploying the mainnet subgraph
-npm run deploy --SUBGRAPH=compound-forks --PROTOCOL=rari-fuse --NETWORK=mainnet --LOCATION=dmelotik
+npm run deploy --SUBGRAPH=compound-forks-ext --PROTOCOL=rari-fuse --NETWORK=ethereum --LOCATION=dmelotik
 ```
 
 > Setting `deploy-on-merge` to `true` in [deploymentConfigurations.json](../../deployment/deploymentConfigurations.json) will run the above commands on subgraphs that have changed to messari's hosted service.
@@ -34,7 +34,7 @@ To setup the subgraph manifest from the template:
 
 ```bash
 # Use rari fuse as an example
-npm run prepare:yaml --PROTOCOL=rari-fuse --NETWORK=mainnet --TEMPLATE=rari-fuse.template.yaml
+npm run prepare:yaml --PROTOCOL=rari-fuse --NETWORK=ethereum --TEMPLATE=rari-fuse.template.yaml
 ```
 
 To codegen and build:

--- a/subgraphs/compound-forks-ext/protocols/compound-v2/src/mapping.ts
+++ b/subgraphs/compound-forks-ext/protocols/compound-v2/src/mapping.ts
@@ -52,7 +52,6 @@ import {
   setBorrowInterestRate,
   setSupplyInterestRate,
   snapshotFinancials,
-  snapshotMarket,
   TokenData,
   updateAllMarketPrices,
   UpdateMarketData,
@@ -368,10 +367,23 @@ function handleAccrueInterest(
   updateRewards(event, market);
 
   // creates and initializes market snapshots
-  snapshotMarket(
-    event.address.toHexString(),
-    event.block.number,
-    event.block.timestamp
+
+  //
+  // daily snapshot
+  //
+  getOrCreateMarketDailySnapshot(
+    market,
+    event.block.timestamp,
+    event.block.number
+  );
+
+  //
+  // hourly snapshot
+  //
+  getOrCreateMarketHourlySnapshot(
+    market,
+    event.block.timestamp,
+    event.block.number
   );
 
   updateMarket(
@@ -567,8 +579,9 @@ function updateMarket(
 
   // update daily fields in marketDailySnapshot
   let dailySnapshot = getOrCreateMarketDailySnapshot(
-    market.id,
-    blockTimestamp.toI32()
+    market,
+    blockTimestamp,
+    blockNumber
   );
   dailySnapshot.dailyTotalRevenueUSD = dailySnapshot.dailyTotalRevenueUSD.plus(
     interestAccumulatedUSD
@@ -581,8 +594,9 @@ function updateMarket(
 
   // update hourly fields in marketHourlySnapshot
   let hourlySnapshot = getOrCreateMarketHourlySnapshot(
-    market.id,
-    blockTimestamp.toI32()
+    market,
+    blockTimestamp,
+    blockNumber
   );
   hourlySnapshot.hourlyTotalRevenueUSD =
     hourlySnapshot.hourlyTotalRevenueUSD.plus(interestAccumulatedUSD);

--- a/subgraphs/compound-forks/README.md
+++ b/subgraphs/compound-forks/README.md
@@ -21,7 +21,7 @@ Once everything is setup properly deploying is very easy.
 npm run deploy --SUBGRAPH=compound-forks --PROTOCOL=rari-fuse --LOCATION=dmelotik
 
 # This will do the same, but only deploying the mainnet subgraph
-npm run deploy --SUBGRAPH=compound-forks --PROTOCOL=rari-fuse --NETWORK=mainnet --LOCATION=dmelotik
+npm run deploy --SUBGRAPH=compound-forks --PROTOCOL=rari-fuse --NETWORK=ethereum --LOCATION=dmelotik
 ```
 
 > Setting `deploy-on-merge` to `true` in [deploymentConfigurations.json](../../deployment/deploymentConfigurations.json) will run the above commands on subgraphs that have changed to messari's hosted service.
@@ -34,7 +34,7 @@ To setup the subgraph manifest from the template:
 
 ```bash
 # Use rari fuse as an example
-npm run prepare:yaml --PROTOCOL=rari-fuse --NETWORK=mainnet --TEMPLATE=rari-fuse.template.yaml
+npm run prepare:yaml --PROTOCOL=rari-fuse --NETWORK=ethereum --TEMPLATE=rari-fuse.template.yaml
 ```
 
 To codegen and build:

--- a/subgraphs/compound-forks/protocols/compound-v2/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/compound-v2/src/mapping.ts
@@ -52,7 +52,6 @@ import {
   setBorrowInterestRate,
   setSupplyInterestRate,
   snapshotFinancials,
-  snapshotMarket,
   TokenData,
   updateAllMarketPrices,
   UpdateMarketData,
@@ -326,10 +325,23 @@ function handleAccrueInterest(
   updateRewards(event, market);
 
   // creates and initializes market snapshots
-  snapshotMarket(
-    event.address.toHexString(),
-    event.block.number,
-    event.block.timestamp
+
+  //
+  // daily snapshot
+  //
+  getOrCreateMarketDailySnapshot(
+    market,
+    event.block.timestamp,
+    event.block.number
+  );
+
+  //
+  // hourly snapshot
+  //
+  getOrCreateMarketHourlySnapshot(
+    market,
+    event.block.timestamp,
+    event.block.number
   );
 
   updateMarket(
@@ -525,8 +537,9 @@ function updateMarket(
 
   // update daily fields in marketDailySnapshot
   let dailySnapshot = getOrCreateMarketDailySnapshot(
-    market.id,
-    blockTimestamp.toI32()
+    market,
+    blockTimestamp,
+    blockNumber
   );
   dailySnapshot.dailyTotalRevenueUSD = dailySnapshot.dailyTotalRevenueUSD.plus(
     interestAccumulatedUSD
@@ -539,8 +552,9 @@ function updateMarket(
 
   // update hourly fields in marketHourlySnapshot
   let hourlySnapshot = getOrCreateMarketHourlySnapshot(
-    market.id,
-    blockTimestamp.toI32()
+    market,
+    blockTimestamp,
+    blockNumber
   );
   hourlySnapshot.hourlyTotalRevenueUSD =
     hourlySnapshot.hourlyTotalRevenueUSD.plus(interestAccumulatedUSD);

--- a/subgraphs/compound-forks/src/mapping.ts
+++ b/subgraphs/compound-forks/src/mapping.ts
@@ -375,8 +375,9 @@ export function _handleMint(
   market.save();
 
   updateMarketSnapshots(
-    marketID,
-    event.block.timestamp.toI32(),
+    market,
+    event.block.timestamp,
+    event.block.number,
     depositUSD,
     EventType.Deposit
   );
@@ -448,8 +449,9 @@ export function _handleRedeem(
   market.save();
 
   updateMarketSnapshots(
-    marketID,
-    event.block.timestamp.toI32(),
+    market,
+    event.block.timestamp,
+    event.block.number,
     withdraw.amountUSD,
     EventType.Withdraw
   );
@@ -524,8 +526,9 @@ export function _handleBorrow(
   market.save();
 
   updateMarketSnapshots(
-    marketID,
-    event.block.timestamp.toI32(),
+    market,
+    event.block.timestamp,
+    event.block.number,
     borrowUSD,
     EventType.Borrow
   );
@@ -597,8 +600,9 @@ export function _handleRepayBorrow(
   repay.save();
 
   updateMarketSnapshots(
-    marketID,
-    event.block.timestamp.toI32(),
+    market,
+    event.block.timestamp,
+    event.block.number,
     repay.amountUSD,
     EventType.Repay
   );
@@ -719,8 +723,9 @@ export function _handleLiquidateBorrow(
   liquidatedCTokenMarket.save();
 
   updateMarketSnapshots(
-    liquidatedCTokenMarketID,
-    event.block.timestamp.toI32(),
+    liquidatedCTokenMarket,
+    event.block.timestamp,
+    event.block.number,
     gainUSD,
     EventType.Liquidate
   );
@@ -755,10 +760,23 @@ export function _handleAccrueInterest(
   }
 
   // creates and initializes market snapshots
-  snapshotMarket(
-    event.address.toHexString(),
-    event.block.number,
-    event.block.timestamp
+
+  //
+  // daily snapshot
+  //
+  getOrCreateMarketDailySnapshot(
+    market,
+    event.block.timestamp,
+    event.block.number
+  );
+
+  //
+  // hourly snapshot
+  //
+  getOrCreateMarketHourlySnapshot(
+    market,
+    event.block.timestamp,
+    event.block.number
   );
 
   updateMarket(
@@ -804,90 +822,6 @@ export function _handleNewReserveFactor(
 /////////////////////////
 //// Entity Updaters ////
 /////////////////////////
-
-export function snapshotMarket(
-  marketID: string,
-  blockNumber: BigInt,
-  blockTimestamp: BigInt
-): void {
-  let market = Market.load(marketID);
-  if (!market) {
-    log.warning("[snapshotMarket] Market not found: {}", [marketID]);
-    return;
-  }
-
-  //
-  // daily snapshot
-  //
-  let dailySnapshot = getOrCreateMarketDailySnapshot(
-    marketID,
-    blockTimestamp.toI32()
-  );
-  dailySnapshot.protocol = market.protocol;
-  dailySnapshot.market = marketID;
-  dailySnapshot.totalValueLockedUSD = market.totalValueLockedUSD;
-  dailySnapshot.cumulativeTotalRevenueUSD = market.cumulativeTotalRevenueUSD;
-  dailySnapshot.cumulativeProtocolSideRevenueUSD =
-    market.cumulativeProtocolSideRevenueUSD;
-  dailySnapshot.cumulativeSupplySideRevenueUSD =
-    market.cumulativeSupplySideRevenueUSD;
-  dailySnapshot.totalDepositBalanceUSD = market.totalDepositBalanceUSD;
-  dailySnapshot.cumulativeDepositUSD = market.cumulativeDepositUSD;
-  dailySnapshot.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
-  dailySnapshot.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
-  dailySnapshot.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
-  dailySnapshot.inputTokenBalance = market.inputTokenBalance;
-  dailySnapshot.inputTokenPriceUSD = market.inputTokenPriceUSD;
-  dailySnapshot.outputTokenSupply = market.outputTokenSupply;
-  dailySnapshot.outputTokenPriceUSD = market.outputTokenPriceUSD;
-  dailySnapshot.exchangeRate = market.exchangeRate;
-  dailySnapshot.rewardTokenEmissionsAmount = market.rewardTokenEmissionsAmount;
-  dailySnapshot.rewardTokenEmissionsUSD = market.rewardTokenEmissionsUSD;
-  dailySnapshot.blockNumber = blockNumber;
-  dailySnapshot.timestamp = blockTimestamp;
-  dailySnapshot.rates = getSnapshotRates(
-    market.rates,
-    (blockTimestamp.toI64() / SECONDS_PER_DAY).toString()
-  );
-
-  dailySnapshot.save();
-
-  //
-  // hourly snapshot
-  //
-  let hourlySnapshot = getOrCreateMarketHourlySnapshot(
-    marketID,
-    blockTimestamp.toI32()
-  );
-  hourlySnapshot.protocol = market.protocol;
-  hourlySnapshot.market = marketID;
-  hourlySnapshot.totalValueLockedUSD = market.totalValueLockedUSD;
-  hourlySnapshot.cumulativeTotalRevenueUSD = market.cumulativeTotalRevenueUSD;
-  hourlySnapshot.cumulativeProtocolSideRevenueUSD =
-    market.cumulativeProtocolSideRevenueUSD;
-  hourlySnapshot.cumulativeSupplySideRevenueUSD =
-    market.cumulativeSupplySideRevenueUSD;
-  hourlySnapshot.totalDepositBalanceUSD = market.totalDepositBalanceUSD;
-  hourlySnapshot.cumulativeDepositUSD = market.cumulativeDepositUSD;
-  hourlySnapshot.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
-  hourlySnapshot.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
-  hourlySnapshot.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
-  hourlySnapshot.inputTokenBalance = market.inputTokenBalance;
-  hourlySnapshot.inputTokenPriceUSD = market.inputTokenPriceUSD;
-  hourlySnapshot.outputTokenSupply = market.outputTokenSupply;
-  hourlySnapshot.outputTokenPriceUSD = market.outputTokenPriceUSD;
-  hourlySnapshot.exchangeRate = market.exchangeRate;
-  hourlySnapshot.rewardTokenEmissionsAmount = market.rewardTokenEmissionsAmount;
-  hourlySnapshot.rewardTokenEmissionsUSD = market.rewardTokenEmissionsUSD;
-  hourlySnapshot.blockNumber = blockNumber;
-  hourlySnapshot.timestamp = blockTimestamp;
-  hourlySnapshot.rates = getSnapshotRates(
-    market.rates,
-    (blockTimestamp.toI64() / SECONDS_PER_HOUR).toString()
-  );
-
-  hourlySnapshot.save();
-}
 
 /**
  *
@@ -1131,14 +1065,16 @@ function snapshotUsage(
 }
 
 function updateMarketSnapshots(
-  marketID: string,
-  timestamp: i32,
+  market: Market,
+  timestamp: BigInt,
+  blockNumber: BigInt,
   amountUSD: BigDecimal,
   eventType: EventType
 ): void {
   let marketHourlySnapshot = getOrCreateMarketHourlySnapshot(
-    marketID,
-    timestamp
+    market,
+    timestamp,
+    blockNumber
   );
   switch (eventType) {
     case EventType.Deposit:
@@ -1166,7 +1102,11 @@ function updateMarketSnapshots(
   }
   marketHourlySnapshot.save();
 
-  let marketDailySnapshot = getOrCreateMarketDailySnapshot(marketID, timestamp);
+  let marketDailySnapshot = getOrCreateMarketDailySnapshot(
+    market,
+    timestamp,
+    blockNumber
+  );
   switch (eventType) {
     case EventType.Deposit:
       marketDailySnapshot.dailyDepositUSD =
@@ -1370,8 +1310,9 @@ export function updateMarket(
 
   // update daily fields in marketDailySnapshot
   let dailySnapshot = getOrCreateMarketDailySnapshot(
-    market.id,
-    blockTimestamp.toI32()
+    market,
+    blockTimestamp,
+    blockNumber
   );
   dailySnapshot.dailyTotalRevenueUSD = dailySnapshot.dailyTotalRevenueUSD.plus(
     interestAccumulatedUSD
@@ -1384,8 +1325,9 @@ export function updateMarket(
 
   // update hourly fields in marketHourlySnapshot
   let hourlySnapshot = getOrCreateMarketHourlySnapshot(
-    market.id,
-    blockTimestamp.toI32()
+    market,
+    blockTimestamp,
+    blockNumber
   );
   hourlySnapshot.hourlyTotalRevenueUSD =
     hourlySnapshot.hourlyTotalRevenueUSD.plus(interestAccumulatedUSD);
@@ -1526,29 +1468,6 @@ export function _getOrCreateProtocol(
   return protocol;
 }
 
-export function getOrCreateMarketHourlySnapshot(
-  marketID: string,
-  blockTimestamp: i32
-): MarketHourlySnapshot {
-  let snapshotID = getMarketHourlySnapshotID(marketID, blockTimestamp);
-  let snapshot = MarketHourlySnapshot.load(snapshotID);
-  if (!snapshot) {
-    snapshot = new MarketHourlySnapshot(snapshotID);
-
-    // initialize zero values to ensure no null runtime errors
-    snapshot.hourlyDepositUSD = BIGDECIMAL_ZERO;
-    snapshot.hourlyBorrowUSD = BIGDECIMAL_ZERO;
-    snapshot.hourlyLiquidateUSD = BIGDECIMAL_ZERO;
-    snapshot.hourlyWithdrawUSD = BIGDECIMAL_ZERO;
-    snapshot.hourlyRepayUSD = BIGDECIMAL_ZERO;
-    snapshot.hourlyTotalRevenueUSD = BIGDECIMAL_ZERO;
-    snapshot.hourlyProtocolSideRevenueUSD = BIGDECIMAL_ZERO;
-    snapshot.hourlySupplySideRevenueUSD = BIGDECIMAL_ZERO;
-  }
-
-  return snapshot;
-}
-
 /////////////////
 //// Helpers ////
 /////////////////
@@ -1611,18 +1530,18 @@ function setInterestRate(
 }
 
 export function getOrCreateMarketDailySnapshot(
-  marketID: string,
-  blockTimestamp: i32
+  market: Market,
+  blockTimestamp: BigInt,
+  blockNumber: BigInt
 ): MarketDailySnapshot {
-  let snapshotID = getMarketDailySnapshotID(marketID, blockTimestamp);
+  let snapshotID = `${market.id}-${(
+    blockTimestamp.toI32() / SECONDS_PER_DAY
+  ).toString()}`;
   let snapshot = MarketDailySnapshot.load(snapshotID);
   if (!snapshot) {
     snapshot = new MarketDailySnapshot(snapshotID);
 
-    let market = Market.load(marketID);
-
     // initialize zero values to ensure no null runtime errors
-    snapshot.protocol = market!.protocol;
     snapshot.dailyDepositUSD = BIGDECIMAL_ZERO;
     snapshot.dailyBorrowUSD = BIGDECIMAL_ZERO;
     snapshot.dailyLiquidateUSD = BIGDECIMAL_ZERO;
@@ -1631,7 +1550,91 @@ export function getOrCreateMarketDailySnapshot(
     snapshot.dailyTotalRevenueUSD = BIGDECIMAL_ZERO;
     snapshot.dailySupplySideRevenueUSD = BIGDECIMAL_ZERO;
     snapshot.dailyProtocolSideRevenueUSD = BIGDECIMAL_ZERO;
+
+    snapshot.protocol = market.protocol;
+    snapshot.market = market.id;
   }
+
+  snapshot.rates = getSnapshotRates(
+    market.rates,
+    (blockTimestamp.toI32() / SECONDS_PER_DAY).toString()
+  );
+  snapshot.totalValueLockedUSD = market.totalValueLockedUSD;
+  snapshot.cumulativeSupplySideRevenueUSD =
+    market.cumulativeSupplySideRevenueUSD;
+  snapshot.cumulativeProtocolSideRevenueUSD =
+    market.cumulativeProtocolSideRevenueUSD;
+  snapshot.cumulativeTotalRevenueUSD = market.cumulativeTotalRevenueUSD;
+  snapshot.totalDepositBalanceUSD = market.totalDepositBalanceUSD;
+  snapshot.cumulativeDepositUSD = market.cumulativeDepositUSD;
+  snapshot.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
+  snapshot.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
+  snapshot.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
+  snapshot.inputTokenBalance = market.inputTokenBalance;
+  snapshot.outputTokenSupply = market.outputTokenSupply;
+  snapshot.inputTokenPriceUSD = market.inputTokenPriceUSD;
+  snapshot.outputTokenPriceUSD = market.outputTokenPriceUSD;
+  snapshot.exchangeRate = market.exchangeRate;
+  snapshot.rewardTokenEmissionsAmount = market.rewardTokenEmissionsAmount;
+  snapshot.rewardTokenEmissionsUSD = market.rewardTokenEmissionsUSD;
+  snapshot.blockNumber = blockNumber;
+  snapshot.timestamp = blockTimestamp;
+  snapshot.save();
+
+  return snapshot;
+}
+
+export function getOrCreateMarketHourlySnapshot(
+  market: Market,
+  blockTimestamp: BigInt,
+  blockNumber: BigInt
+): MarketHourlySnapshot {
+  let snapshotID = `${market.id}-${(
+    blockTimestamp.toI32() / SECONDS_PER_HOUR
+  ).toString()}`;
+  let snapshot = MarketHourlySnapshot.load(snapshotID);
+  if (!snapshot) {
+    snapshot = new MarketHourlySnapshot(snapshotID);
+
+    // initialize zero values to ensure no null runtime errors
+    snapshot.hourlyDepositUSD = BIGDECIMAL_ZERO;
+    snapshot.hourlyBorrowUSD = BIGDECIMAL_ZERO;
+    snapshot.hourlyLiquidateUSD = BIGDECIMAL_ZERO;
+    snapshot.hourlyWithdrawUSD = BIGDECIMAL_ZERO;
+    snapshot.hourlyRepayUSD = BIGDECIMAL_ZERO;
+    snapshot.hourlyTotalRevenueUSD = BIGDECIMAL_ZERO;
+    snapshot.hourlyProtocolSideRevenueUSD = BIGDECIMAL_ZERO;
+    snapshot.hourlySupplySideRevenueUSD = BIGDECIMAL_ZERO;
+
+    snapshot.protocol = market.protocol;
+    snapshot.market = market.id;
+  }
+
+  snapshot.blockNumber = blockNumber;
+  snapshot.timestamp = blockTimestamp;
+  snapshot.rates = getSnapshotRates(
+    market.rates,
+    (blockTimestamp.toI32() / SECONDS_PER_HOUR).toString()
+  );
+  snapshot.totalValueLockedUSD = market.totalValueLockedUSD;
+  snapshot.cumulativeSupplySideRevenueUSD =
+    market.cumulativeSupplySideRevenueUSD;
+  snapshot.cumulativeProtocolSideRevenueUSD =
+    market.cumulativeProtocolSideRevenueUSD;
+  snapshot.cumulativeTotalRevenueUSD = market.cumulativeTotalRevenueUSD;
+  snapshot.totalDepositBalanceUSD = market.totalDepositBalanceUSD;
+  snapshot.cumulativeDepositUSD = market.cumulativeDepositUSD;
+  snapshot.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
+  snapshot.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
+  snapshot.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
+  snapshot.inputTokenBalance = market.inputTokenBalance;
+  snapshot.outputTokenSupply = market.outputTokenSupply;
+  snapshot.inputTokenPriceUSD = market.inputTokenPriceUSD;
+  snapshot.outputTokenPriceUSD = market.outputTokenPriceUSD;
+  snapshot.exchangeRate = market.exchangeRate;
+  snapshot.rewardTokenEmissionsAmount = market.rewardTokenEmissionsAmount;
+  snapshot.rewardTokenEmissionsUSD = market.rewardTokenEmissionsUSD;
+  snapshot.save();
 
   return snapshot;
 }


### PR DESCRIPTION
Error: Sometimes the market hourly snapshot is not created where it is expected, so it does not populate with the correct data to prevent a null field error.

```
A non-deterministic fatal error occured at block 13380834: failed to process trigger: block #13380834 (0x8580…d7fe), transaction d754eb9700435134f365158b1c1e69a8846745ecd0edee3db8e6b0930491cb88: Entity MarketHourlySnapshot[0xfd3300a9a74b3250f1b2abc12b47611171910b07-453814]: missing value for non-nullable field `protocol` wasm backtrace: 0: 0x766c - <unknown>!generated/schema/MarketHourlySnapshot#save 1: 0x7b9e - <unknown>!src/mapping/updateMarketSnapshots 2: 0x88cf - <unknown>!src/mapping/_handleMint 3: 0x8952 - <unknown>!protocols/rari-fuse/src/mappings/handleMint
```

Fix: populate all of the non nullable fields in MarketDailySnapshots/MarketHourlySnapshots upon creation.

Testing: 
- https://okgraph.xyz/?q=dmelotik%2Ffuse-mainnet
- https://okgraph.xyz/?q=dmelotik%2Fcompound-ethereum
- https://okgraph.xyz/?q=dmelotik%2Fbenqi