### PR TITLE
[Gov] Fix issues with OZGovernor entities and subgraphs

### DIFF
--- a/subgraphs/openzeppelin-governor/protocols/angle-governance/src/governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/angle-governance/src/governor.ts
@@ -112,8 +112,8 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
     governanceFramework.version = contract.version();
 
     governanceFramework.contractAddress = contractAddress;
-    governanceFramework.tokenAddress = contract.timelock().toHexString();
-    governanceFramework.timelockAddress = contract.token().toHexString();
+    governanceFramework.tokenAddress = contract.token().toHexString();
+    governanceFramework.timelockAddress = contract.timelock().toHexString();
 
     governanceFramework.votingDelay = contract.votingDelay();
     governanceFramework.votingPeriod = contract.votingPeriod();

--- a/subgraphs/openzeppelin-governor/protocols/angle-governance/src/governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/angle-governance/src/governor.ts
@@ -27,10 +27,12 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
+  let contract = Governor.bind(event.address);
+  let quorum = contract.quorum(event.block.number);
+
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
-
   _handleProposalCreated(
     event.params.proposalId.toString(),
     event.params.proposer.toHexString(),
@@ -41,6 +43,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
+    quorum,
     event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/angle-governance/src/governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/angle-governance/src/governor.ts
@@ -12,14 +12,20 @@ import {
   VotingPeriodUpdated,
 } from "../../../generated/Governor/Governor";
 import { Governor } from "../../../generated/Governor/Governor";
-import { GovernanceFramework } from "../../../generated/schema";
-import { GovernanceFrameworkType } from "../../../src/constants";
+import { GovernanceFramework, Proposal } from "../../../generated/schema";
+import {
+  BIGINT_ONE,
+  GovernanceFrameworkType,
+  ProposalState,
+} from "../../../src/constants";
 import {
   _handleProposalCreated,
   _handleProposalCanceled,
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
+  getOrCreateProposal,
+  getGovernance,
 } from "../../../src/handlers";
 
 export function handleProposalCanceled(event: ProposalCanceled): void {
@@ -27,8 +33,9 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
-  let contract = Governor.bind(event.address);
-  let quorum = contract.quorum(event.block.number);
+  let quorumVotes = Governor.bind(event.address).quorum(
+    event.block.number.minus(BIGINT_ONE)
+  );
 
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
@@ -43,7 +50,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
-    quorum,
+    quorumVotes,
     event
   );
 }
@@ -77,9 +84,34 @@ export function handleTimelockChange(event: TimelockChange): void {
   governanceFramework.save();
 }
 
+function getLatestProposalValues(
+  proposalId: string,
+  contractAddress: Address
+): Proposal {
+  let proposal = getOrCreateProposal(proposalId);
+
+  // On first vote, set state and quorum values
+  if (proposal.state == ProposalState.PENDING) {
+    let contract = Governor.bind(contractAddress);
+    proposal.state = ProposalState.ACTIVE;
+    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+
+    let governance = getGovernance();
+    proposal.tokenHoldersAtStart = governance.currentTokenHolders;
+    proposal.delegatesAtStart = governance.currentDelegates;
+  }
+  return proposal;
+}
+
 export function handleVoteCast(event: VoteCast): void {
-  _handleVoteCast(
+  let proposal = getLatestProposalValues(
     event.params.proposalId.toString(),
+    event.address
+  );
+
+  // Proposal will be updated as part of handler
+  _handleVoteCast(
+    proposal,
     event.params.voter.toHexString(),
     event.params.weight,
     event.params.reason,

--- a/subgraphs/openzeppelin-governor/protocols/code4rena-governance/config/templates/code4rena-governance.template.yaml
+++ b/subgraphs/openzeppelin-governor/protocols/code4rena-governance/config/templates/code4rena-governance.template.yaml
@@ -24,8 +24,7 @@ dataSources:
         - name: ArenaGovernor
           file: ./abis/code4rena-governance/ArenaGovernor.json
       eventHandlers:
-        # Part of GovernorPreventLateQuorum 
-        # Our entities currently don't track deadline
+        # Sets the no. of blocks of an extension, currently not tracked
         # - event: LateQuorumVoteExtensionSet(uint64,uint64)
         #   handler: handleLateQuorumVoteExtensionSet
         - event: ProposalCanceled(uint256)
@@ -34,8 +33,8 @@ dataSources:
           handler: handleProposalCreated
         - event: ProposalExecuted(uint256)
           handler: handleProposalExecuted
-        # - event: ProposalExtended(indexed uint256,uint64)
-        #   handler: handleProposalExtended
+        - event: ProposalExtended(indexed uint256,uint64)
+          handler: handleProposalExtended
         - event: ProposalQueued(uint256,uint256)
           handler: handleProposalQueued
         - event: ProposalThresholdSet(uint256,uint256)

--- a/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-governor.ts
@@ -3,6 +3,7 @@ import {
   ProposalCanceled,
   ProposalCreated,
   ProposalExecuted,
+  ProposalExtended,
   ProposalQueued,
   ProposalThresholdSet,
   TimelockChange,
@@ -16,6 +17,7 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
+  _handleProposalExtended,
 } from "../../../src/handlers";
 import { ArenaGovernor } from "../../../generated/ArenaGovernor/ArenaGovernor";
 import { GovernanceFramework } from "../../../generated/schema";
@@ -49,6 +51,14 @@ export function handleProposalCreated(event: ProposalCreated): void {
 // ProposalExecuted(proposalId)
 export function handleProposalExecuted(event: ProposalExecuted): void {
   _handleProposalExecuted(event.params.proposalId.toString(), event);
+}
+
+// ProposalExtended(proposalId,extendedDeadline)
+export function handleProposalExtended(event: ProposalExtended): void {
+  _handleProposalExtended(
+    event.params.proposalId.toString(),
+    event.params.extendedDeadline
+  );
 }
 
 // ProposalQueued(proposalId, eta)

--- a/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-governor.ts
@@ -30,10 +30,12 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
+  let contract = ArenaGovernor.bind(event.address);
+  let quorum = contract.quorum(event.block.number);
+
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
-
   _handleProposalCreated(
     event.params.proposalId.toString(),
     event.params.proposer.toHexString(),
@@ -44,6 +46,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
+    quorum,
     event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-governor.ts
@@ -116,8 +116,8 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
     governanceFramework.version = contract.version();
 
     governanceFramework.contractAddress = contractAddress;
-    governanceFramework.tokenAddress = contract.timelock().toHexString();
-    governanceFramework.timelockAddress = contract.token().toHexString();
+    governanceFramework.tokenAddress = contract.token().toHexString();
+    governanceFramework.timelockAddress = contract.timelock().toHexString();
 
     governanceFramework.votingDelay = contract.votingDelay();
     governanceFramework.votingPeriod = contract.votingPeriod();

--- a/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-governor.ts
@@ -95,8 +95,8 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
     governanceFramework.version = contract.version();
 
     governanceFramework.contractAddress = contractAddress;
-    governanceFramework.tokenAddress = contract.timelock().toHexString();
-    governanceFramework.timelockAddress = contract.token().toHexString();
+    governanceFramework.tokenAddress = contract.token().toHexString();
+    governanceFramework.timelockAddress = contract.timelock().toHexString();
 
     governanceFramework.votingDelay = contract.votingDelay();
     governanceFramework.votingPeriod = contract.votingPeriod();

--- a/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-governor.ts
@@ -14,10 +14,16 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
+  getOrCreateProposal,
+  getGovernance,
 } from "../../../src/handlers";
 import { ENSGovernor } from "../../../generated/ENSGovernor/ENSGovernor";
-import { GovernanceFramework } from "../../../generated/schema";
-import { GovernanceFrameworkType } from "../../../src/constants";
+import { GovernanceFramework, Proposal } from "../../../generated/schema";
+import {
+  BIGINT_ONE,
+  GovernanceFrameworkType,
+  ProposalState,
+} from "../../../src/constants";
 
 // ProposalCanceled(proposalId)
 export function handleProposalCanceled(event: ProposalCanceled): void {
@@ -26,8 +32,9 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
-  let contract = ENSGovernor.bind(event.address);
-  let quorum = contract.quorum(event.block.number);
+  let quorumVotes = ENSGovernor.bind(event.address).quorum(
+    event.block.number.minus(BIGINT_ONE)
+  );
 
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
@@ -42,7 +49,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
-    quorum,
+    quorumVotes,
     event
   );
 }
@@ -73,10 +80,35 @@ export function handleTimelockChange(event: TimelockChange): void {
   governanceFramework.save();
 }
 
+function getLatestProposalValues(
+  proposalId: string,
+  contractAddress: Address
+): Proposal {
+  let proposal = getOrCreateProposal(proposalId);
+
+  // On first vote, set state and quorum values
+  if (proposal.state == ProposalState.PENDING) {
+    let contract = ENSGovernor.bind(contractAddress);
+    proposal.state = ProposalState.ACTIVE;
+    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+
+    let governance = getGovernance();
+    proposal.tokenHoldersAtStart = governance.currentTokenHolders;
+    proposal.delegatesAtStart = governance.currentDelegates;
+  }
+  return proposal;
+}
+
 // VoteCast(account, proposalId, support, weight, reason);
 export function handleVoteCast(event: VoteCast): void {
-  _handleVoteCast(
+  let proposal = getLatestProposalValues(
     event.params.proposalId.toString(),
+    event.address
+  );
+
+  // Proposal will be updated as part of handler
+  _handleVoteCast(
+    proposal,
     event.params.voter.toHexString(),
     event.params.weight,
     event.params.reason,

--- a/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-governor.ts
@@ -26,10 +26,12 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
+  let contract = ENSGovernor.bind(event.address);
+  let quorum = contract.quorum(event.block.number);
+
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
-
   _handleProposalCreated(
     event.params.proposalId.toString(),
     event.params.proposer.toHexString(),
@@ -40,6 +42,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
+    quorum,
     event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
+++ b/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
@@ -4,6 +4,7 @@ import {
   ProposalCreated,
   ProposalExecuted,
   ProposalQueued,
+  ProposalThresholdSet,
   QuorumNumeratorUpdated,
   TimelockChange,
   VoteCast,
@@ -55,6 +56,13 @@ export function handleProposalExecuted(event: ProposalExecuted): void {
 // ProposalQueued(proposalId, eta)
 export function handleProposalQueued(event: ProposalQueued): void {
   _handleProposalQueued(event.params.proposalId, event.params.eta);
+}
+
+// ProposalThresholdSet(oldProposalThreshold, newProposalThreshold)
+export function handleProposalThresholdSet(event: ProposalThresholdSet): void {
+  let governanceFramework = getGovernanceFramework(event.address.toHexString());
+  governanceFramework.proposalThreshold = event.params.newProposalThreshold;
+  governanceFramework.save();
 }
 
 // QuorumNumeratorUpdated(oldQuorumNumerator, newQuorumNumerator)

--- a/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
+++ b/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
@@ -121,8 +121,8 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
     governanceFramework.version = contract.version();
 
     governanceFramework.contractAddress = contractAddress;
-    governanceFramework.tokenAddress = contract.timelock().toHexString();
-    governanceFramework.timelockAddress = contract.token().toHexString();
+    governanceFramework.tokenAddress = contract.token().toHexString();
+    governanceFramework.timelockAddress = contract.timelock().toHexString();
 
     governanceFramework.votingDelay = contract.votingDelay();
     governanceFramework.votingPeriod = contract.votingPeriod();

--- a/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
+++ b/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
@@ -19,9 +19,15 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
+  getOrCreateProposal,
+  getGovernance,
 } from "../../../src/handlers";
-import { GovernanceFramework } from "../../../generated/schema";
-import { GovernanceFrameworkType } from "../../../src/constants";
+import { GovernanceFramework, Proposal } from "../../../generated/schema";
+import {
+  BIGINT_ONE,
+  GovernanceFrameworkType,
+  ProposalState,
+} from "../../../src/constants";
 
 // ProposalCanceled(proposalId)
 export function handleProposalCanceled(event: ProposalCanceled): void {
@@ -30,8 +36,9 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
-  let contract = Governance.bind(event.address);
-  let quorum = contract.quorum(event.block.number);
+  let quorumVotes = Governance.bind(event.address).quorum(
+    event.block.number.minus(BIGINT_ONE)
+  );
 
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
@@ -46,7 +53,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
-    quorum,
+    quorumVotes,
     event
   );
 }
@@ -84,10 +91,34 @@ export function handleTimelockChange(event: TimelockChange): void {
   governanceFramework.save();
 }
 
+function getLatestProposalValues(
+  proposalId: string,
+  contractAddress: Address
+): Proposal {
+  let proposal = getOrCreateProposal(proposalId);
+
+  // On first vote, set state and quorum values
+  if (proposal.state == ProposalState.PENDING) {
+    let contract = Governance.bind(contractAddress);
+    proposal.state = ProposalState.ACTIVE;
+    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+
+    let governance = getGovernance();
+    proposal.tokenHoldersAtStart = governance.currentTokenHolders;
+    proposal.delegatesAtStart = governance.currentDelegates;
+  }
+  return proposal;
+}
+
 // VoteCast(account, proposalId, support, weight, reason);
 export function handleVoteCast(event: VoteCast): void {
-  _handleVoteCast(
+  let proposal = getLatestProposalValues(
     event.params.proposalId.toString(),
+    event.address
+  );
+
+  _handleVoteCast(
+    proposal,
     event.params.voter.toHexString(),
     event.params.weight,
     event.params.reason,
@@ -96,9 +127,15 @@ export function handleVoteCast(event: VoteCast): void {
   );
 }
 
+// Treat VoteCastWithParams same as VoteCast
 export function handleVoteCastWithParams(event: VoteCastWithParams): void {
-  _handleVoteCast(
+  let proposal = getLatestProposalValues(
     event.params.proposalId.toString(),
+    event.address
+  );
+
+  _handleVoteCast(
+    proposal,
     event.params.voter.toHexString(),
     event.params.weight,
     event.params.reason,

--- a/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
+++ b/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
@@ -30,10 +30,12 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
+  let contract = Governance.bind(event.address);
+  let quorum = contract.quorum(event.block.number);
+
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
-
   _handleProposalCreated(
     event.params.proposalId.toString(),
     event.params.proposer.toHexString(),
@@ -44,6 +46,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
+    quorum,
     event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/fei-governance/src/fei-dao.ts
+++ b/subgraphs/openzeppelin-governor/protocols/fei-governance/src/fei-dao.ts
@@ -112,8 +112,8 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
     governanceFramework.version = contract.version();
 
     governanceFramework.contractAddress = contractAddress;
-    governanceFramework.tokenAddress = contract.timelock().toHexString();
-    governanceFramework.timelockAddress = contract.token().toHexString();
+    governanceFramework.tokenAddress = contract.token().toHexString();
+    governanceFramework.timelockAddress = contract.timelock().toHexString();
 
     governanceFramework.votingDelay = contract.votingDelay();
     governanceFramework.votingPeriod = contract.votingPeriod();

--- a/subgraphs/openzeppelin-governor/protocols/fei-governance/src/fei-dao.ts
+++ b/subgraphs/openzeppelin-governor/protocols/fei-governance/src/fei-dao.ts
@@ -27,6 +27,9 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
+  let contract = FeiDAO.bind(event.address);
+  let quorum = contract.quorum(event.block.number);
+
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
@@ -41,6 +44,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
+    quorum,
     event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/fei-governance/src/fei-dao.ts
+++ b/subgraphs/openzeppelin-governor/protocols/fei-governance/src/fei-dao.ts
@@ -12,14 +12,20 @@ import {
   VotingPeriodUpdated,
 } from "../../../generated/FeiDAO/FeiDAO";
 import { FeiDAO } from "../../../generated/FeiDAO/FeiDAO";
-import { GovernanceFramework } from "../../../generated/schema";
-import { GovernanceFrameworkType } from "../../../src/constants";
+import { GovernanceFramework, Proposal } from "../../../generated/schema";
+import {
+  BIGINT_ONE,
+  GovernanceFrameworkType,
+  ProposalState,
+} from "../../../src/constants";
 import {
   _handleProposalCreated,
   _handleProposalCanceled,
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
+  getOrCreateProposal,
+  getGovernance,
 } from "../../../src/handlers";
 
 export function handleProposalCanceled(event: ProposalCanceled): void {
@@ -27,13 +33,13 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
-  let contract = FeiDAO.bind(event.address);
-  let quorum = contract.quorum(event.block.number);
+  let quorumVotes = FeiDAO.bind(event.address).quorum(
+    event.block.number.minus(BIGINT_ONE)
+  );
 
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
-
   _handleProposalCreated(
     event.params.proposalId.toString(),
     event.params.proposer.toHexString(),
@@ -44,7 +50,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
-    quorum,
+    quorumVotes,
     event
   );
 }
@@ -78,9 +84,34 @@ export function handleTimelockChange(event: TimelockChange): void {
   governanceFramework.save();
 }
 
+function getLatestProposalValues(
+  proposalId: string,
+  contractAddress: Address
+): Proposal {
+  let proposal = getOrCreateProposal(proposalId);
+
+  // On first vote, set state and quorum values
+  if (proposal.state == ProposalState.PENDING) {
+    let contract = FeiDAO.bind(contractAddress);
+    proposal.state = ProposalState.ACTIVE;
+    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+
+    let governance = getGovernance();
+    proposal.tokenHoldersAtStart = governance.currentTokenHolders;
+    proposal.delegatesAtStart = governance.currentDelegates;
+  }
+  return proposal;
+}
+
 export function handleVoteCast(event: VoteCast): void {
-  _handleVoteCast(
+  let proposal = getLatestProposalValues(
     event.params.proposalId.toString(),
+    event.address
+  );
+
+  // Proposal will be updated as part of handler
+  _handleVoteCast(
+    proposal,
     event.params.voter.toHexString(),
     event.params.weight,
     event.params.reason,

--- a/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-governor.ts
@@ -24,10 +24,12 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
+  let contract = HOPGovernor.bind(event.address);
+  let quorum = contract.quorum(event.block.number);
+
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
-
   _handleProposalCreated(
     event.params.proposalId.toString(),
     event.params.proposer.toHexString(),
@@ -38,6 +40,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
+    quorum,
     event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-governor.ts
@@ -88,8 +88,8 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
     governanceFramework.version = contract.version();
 
     governanceFramework.contractAddress = contractAddress;
-    governanceFramework.tokenAddress = contract.timelock().toHexString();
-    governanceFramework.timelockAddress = contract.token().toHexString();
+    governanceFramework.tokenAddress = contract.token().toHexString();
+    governanceFramework.timelockAddress = contract.timelock().toHexString();
 
     governanceFramework.votingDelay = contract.votingDelay();
     governanceFramework.votingPeriod = contract.votingPeriod();

--- a/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-governor.ts
@@ -14,18 +14,25 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
+  getOrCreateProposal,
+  getGovernance,
 } from "../../../src/handlers";
 import { HOPGovernor } from "../../../generated/HOPGovernor/HOPGovernor";
-import { GovernanceFramework } from "../../../generated/schema";
-import { GovernanceFrameworkType } from "../../../src/constants";
+import { GovernanceFramework, Proposal } from "../../../generated/schema";
+import {
+  BIGINT_ONE,
+  GovernanceFrameworkType,
+  ProposalState,
+} from "../../../src/constants";
 
 export function handleProposalCanceled(event: ProposalCanceled): void {
   _handleProposalCanceled(event.params.proposalId.toString(), event);
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
-  let contract = HOPGovernor.bind(event.address);
-  let quorum = contract.quorum(event.block.number);
+  let quorumVotes = HOPGovernor.bind(event.address).quorum(
+    event.block.number.minus(BIGINT_ONE)
+  );
 
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
@@ -40,7 +47,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
-    quorum,
+    quorumVotes,
     event
   );
 }
@@ -67,9 +74,34 @@ export function handleTimelockChange(event: TimelockChange): void {
   governanceFramework.save();
 }
 
+function getLatestProposalValues(
+  proposalId: string,
+  contractAddress: Address
+): Proposal {
+  let proposal = getOrCreateProposal(proposalId);
+
+  // On first vote, set state and quorum values
+  if (proposal.state == ProposalState.PENDING) {
+    let contract = HOPGovernor.bind(contractAddress);
+    proposal.state = ProposalState.ACTIVE;
+    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+
+    let governance = getGovernance();
+    proposal.tokenHoldersAtStart = governance.currentTokenHolders;
+    proposal.delegatesAtStart = governance.currentDelegates;
+  }
+  return proposal;
+}
+
 export function handleVoteCast(event: VoteCast): void {
-  _handleVoteCast(
+  let proposal = getLatestProposalValues(
     event.params.proposalId.toString(),
+    event.address
+  );
+
+  // Proposal will be updated as part of handler
+  _handleVoteCast(
+    proposal,
     event.params.voter.toHexString(),
     event.params.weight,
     event.params.reason,

--- a/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governor.ts
@@ -18,9 +18,15 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
+  getOrCreateProposal,
+  getGovernance,
 } from "../../../src/handlers";
-import { GovernanceFramework } from "../../../generated/schema";
-import { GovernanceFrameworkType } from "../../../src/constants";
+import { GovernanceFramework, Proposal } from "../../../generated/schema";
+import {
+  BIGINT_ONE,
+  GovernanceFrameworkType,
+  ProposalState,
+} from "../../../src/constants";
 
 // ProposalCanceled(proposalId)
 export function handleProposalCanceled(event: ProposalCanceled): void {
@@ -29,8 +35,9 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
-  let contract = SiloGovernor.bind(event.address);
-  let quorum = contract.quorum(event.block.number);
+  let quorumVotes = SiloGovernor.bind(event.address).quorum(
+    event.block.number.minus(BIGINT_ONE)
+  );
 
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
@@ -45,7 +52,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
-    quorum,
+    quorumVotes,
     event
   );
 }
@@ -82,10 +89,34 @@ export function handleTimelockChange(event: TimelockChange): void {
   governanceFramework.save();
 }
 
+function getLatestProposalValues(
+  proposalId: string,
+  contractAddress: Address
+): Proposal {
+  let proposal = getOrCreateProposal(proposalId);
+
+  // On first vote, set state and quorum values
+  if (proposal.state == ProposalState.PENDING) {
+    let contract = SiloGovernor.bind(contractAddress);
+    proposal.state = ProposalState.ACTIVE;
+    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+
+    let governance = getGovernance();
+    proposal.tokenHoldersAtStart = governance.currentTokenHolders;
+    proposal.delegatesAtStart = governance.currentDelegates;
+  }
+  return proposal;
+}
+
 // VoteCast(account, proposalId, support, weight, reason);
 export function handleVoteCast(event: VoteCast): void {
-  _handleVoteCast(
+  let proposal = getLatestProposalValues(
     event.params.proposalId.toString(),
+    event.address
+  );
+
+  _handleVoteCast(
+    proposal,
     event.params.voter.toHexString(),
     event.params.weight,
     event.params.reason,

--- a/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governor.ts
@@ -29,10 +29,12 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
+  let contract = SiloGovernor.bind(event.address);
+  let quorum = contract.quorum(event.block.number);
+
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
-
   _handleProposalCreated(
     event.params.proposalId.toString(),
     event.params.proposer.toHexString(),
@@ -43,6 +45,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
+    quorum,
     event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governor.ts
@@ -116,8 +116,8 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
     governanceFramework.version = contract.version();
 
     governanceFramework.contractAddress = contractAddress;
-    governanceFramework.tokenAddress = contract.timelock().toHexString();
-    governanceFramework.timelockAddress = contract.token().toHexString();
+    governanceFramework.tokenAddress = contract.token().toHexString();
+    governanceFramework.timelockAddress = contract.timelock().toHexString();
 
     governanceFramework.votingDelay = contract.votingDelay();
     governanceFramework.votingPeriod = contract.votingPeriod();

--- a/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/dao-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/dao-governor.ts
@@ -121,8 +121,8 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
     governanceFramework.version = contract.version();
 
     governanceFramework.contractAddress = contractAddress;
-    governanceFramework.tokenAddress = contract.timelock().toHexString();
-    governanceFramework.timelockAddress = contract.token().toHexString();
+    governanceFramework.tokenAddress = contract.token().toHexString();
+    governanceFramework.timelockAddress = contract.timelock().toHexString();
 
     governanceFramework.votingDelay = contract.votingDelay();
     governanceFramework.votingPeriod = contract.votingPeriod();

--- a/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/dao-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/dao-governor.ts
@@ -18,18 +18,25 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
+  getOrCreateProposal,
+  getGovernance,
 } from "../../../src/handlers";
 import { DaoGovernor } from "../../../generated/DaoGovernor/DaoGovernor";
-import { GovernanceFramework } from "../../../generated/schema";
-import { GovernanceFrameworkType } from "../../../src/constants";
+import { GovernanceFramework, Proposal } from "../../../generated/schema";
+import {
+  BIGINT_ONE,
+  GovernanceFrameworkType,
+  ProposalState,
+} from "../../../src/constants";
 
 export function handleProposalCanceled(event: ProposalCanceled): void {
   _handleProposalCanceled(event.params.proposalId.toString(), event);
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
-  let contract = DaoGovernor.bind(event.address);
-  let quorum = contract.quorum(event.block.number);
+  let quorumVotes = DaoGovernor.bind(event.address).quorum(
+    event.block.number.minus(BIGINT_ONE)
+  );
 
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
@@ -44,7 +51,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
-    quorum,
+    quorumVotes,
     event
   );
 }
@@ -77,9 +84,34 @@ export function handleTimelockChange(event: TimelockChange): void {
   governanceFramework.save();
 }
 
+function getLatestProposalValues(
+  proposalId: string,
+  contractAddress: Address
+): Proposal {
+  let proposal = getOrCreateProposal(proposalId);
+
+  // On first vote, set state and quorum values
+  if (proposal.state == ProposalState.PENDING) {
+    let contract = DaoGovernor.bind(contractAddress);
+    proposal.state = ProposalState.ACTIVE;
+    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+
+    let governance = getGovernance();
+    proposal.tokenHoldersAtStart = governance.currentTokenHolders;
+    proposal.delegatesAtStart = governance.currentDelegates;
+  }
+  return proposal;
+}
+
 export function handleVoteCast(event: VoteCast): void {
-  _handleVoteCast(
+  let proposal = getLatestProposalValues(
     event.params.proposalId.toString(),
+    event.address
+  );
+
+  // Proposal will be updated as part of handler
+  _handleVoteCast(
+    proposal,
     event.params.voter.toHexString(),
     event.params.weight,
     event.params.reason,
@@ -89,8 +121,14 @@ export function handleVoteCast(event: VoteCast): void {
 }
 // Treat VoteCastWithParams same as VoteCast
 export function handleVoteCastWithParams(event: VoteCastWithParams): void {
-  _handleVoteCast(
+  let proposal = getLatestProposalValues(
     event.params.proposalId.toString(),
+    event.address
+  );
+
+  // Proposal will be updated as part of handler
+  _handleVoteCast(
+    proposal,
     event.params.voter.toHexString(),
     event.params.weight,
     event.params.reason,

--- a/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/dao-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/dao-governor.ts
@@ -28,10 +28,12 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
+  let contract = DaoGovernor.bind(event.address);
+  let quorum = contract.quorum(event.block.number);
+
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
-
   _handleProposalCreated(
     event.params.proposalId.toString(),
     event.params.proposer.toHexString(),
@@ -42,6 +44,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
+    quorum,
     event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
@@ -110,8 +110,8 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
     governanceFramework.version = contract.version();
 
     governanceFramework.contractAddress = contractAddress;
-    governanceFramework.tokenAddress = contract.timelock().toHexString();
-    governanceFramework.timelockAddress = contract.token().toHexString();
+    governanceFramework.tokenAddress = contract.token().toHexString();
+    governanceFramework.timelockAddress = contract.timelock().toHexString();
 
     governanceFramework.votingDelay = contract.votingDelay();
     governanceFramework.votingPeriod = contract.votingPeriod();

--- a/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
@@ -19,7 +19,7 @@ import {
 } from "../../../src/handlers";
 import { UnlockProtocolGovernor } from "../../../generated/UnlockProtocolGovernor/UnlockProtocolGovernor";
 import { GovernanceFramework } from "../../../generated/schema";
-import { GovernanceFrameworkType } from "../../../src/constants";
+import { BIGINT_ZERO, GovernanceFrameworkType } from "../../../src/constants";
 
 // ProposalCanceled(proposalId)
 export function handleProposalCanceled(event: ProposalCanceled): void {
@@ -116,8 +116,9 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
     governanceFramework.votingDelay = contract.votingDelay();
     governanceFramework.votingPeriod = contract.votingPeriod();
 
-    // Missing from this old version of Governor
-    // governanceFramework.proposalThreshold = contract.proposalThreshold();
+    // Missing from this old version of Governor, default it to Zero
+    governanceFramework.proposalThreshold = BIGINT_ZERO;
+
     const startBlock = new BigInt(13148447);
     governanceFramework.quorumVotes = contract.quorum(startBlock);
   }

--- a/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
@@ -16,10 +16,17 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
+  getOrCreateProposal,
+  getGovernance,
 } from "../../../src/handlers";
 import { UnlockProtocolGovernor } from "../../../generated/UnlockProtocolGovernor/UnlockProtocolGovernor";
-import { GovernanceFramework } from "../../../generated/schema";
-import { BIGINT_ZERO, GovernanceFrameworkType } from "../../../src/constants";
+import { GovernanceFramework, Proposal } from "../../../generated/schema";
+import {
+  BIGINT_ONE,
+  BIGINT_ZERO,
+  GovernanceFrameworkType,
+  ProposalState,
+} from "../../../src/constants";
 
 // ProposalCanceled(proposalId)
 export function handleProposalCanceled(event: ProposalCanceled): void {
@@ -28,8 +35,9 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
-  let contract = UnlockProtocolGovernor.bind(event.address);
-  let quorum = contract.quorum(event.block.number);
+  let quorumVotes = UnlockProtocolGovernor.bind(event.address).quorum(
+    event.block.number.minus(BIGINT_ONE)
+  );
 
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
@@ -44,7 +52,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
-    quorum,
+    quorumVotes,
     event
   );
 }
@@ -73,10 +81,33 @@ export function handleTimelockChange(event: TimelockChange): void {
   governanceFramework.save();
 }
 
+function getLatestProposalValues(
+  proposalId: string,
+  contractAddress: Address
+): Proposal {
+  let proposal = getOrCreateProposal(proposalId);
+
+  // On first vote, set state and quorum values
+  if (proposal.state == ProposalState.PENDING) {
+    let contract = UnlockProtocolGovernor.bind(contractAddress);
+    proposal.state = ProposalState.ACTIVE;
+    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+
+    let governance = getGovernance();
+    proposal.tokenHoldersAtStart = governance.currentTokenHolders;
+    proposal.delegatesAtStart = governance.currentDelegates;
+  }
+  return proposal;
+}
 // VoteCast(account, proposalId, support, weight, reason);
 export function handleVoteCast(event: VoteCast): void {
-  _handleVoteCast(
+  let proposal = getLatestProposalValues(
     event.params.proposalId.toString(),
+    event.address
+  );
+
+  _handleVoteCast(
+    proposal,
     event.params.voter.toHexString(),
     event.params.weight,
     event.params.reason,

--- a/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
@@ -28,10 +28,12 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
+  let contract = UnlockProtocolGovernor.bind(event.address);
+  let quorum = contract.quorum(event.block.number);
+
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
-
   _handleProposalCreated(
     event.params.proposalId.toString(),
     event.params.proposer.toHexString(),
@@ -42,6 +44,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.startBlock,
     event.params.endBlock,
     event.params.description,
+    quorum,
     event
   );
 }

--- a/subgraphs/openzeppelin-governor/schema.graphql
+++ b/subgraphs/openzeppelin-governor/schema.graphql
@@ -76,13 +76,21 @@ type Proposal @entity {
   "State of the proposal"
   state: ProposalState!
 
-  "Votes against the proposal"
+  "Unweighted Votes against the proposal"
+  delegateAgainstVotes: BigInt!
+  "Unweighted Votes for the proposal"
+  delegateForVotes: BigInt!
+  "Unweighted Votes abstaining to the proposal"
+  delegateAbstainVotes: BigInt!
+  "Total unweighted for/against/abstaining votes"
+  delegateTotalVotes: BigInt!
+  "Weighted votes against the proposal"
   againstVotes: BigInt!
-  "Votes for the proposal"
+  "Weighted votes for the proposal"
   forVotes: BigInt!
-  "Votes abstaining to the proposal"
+  "Weighted votes abstaining to the proposal"
   abstainVotes: BigInt!
-  "Total for/against/abstaining votes"
+  "Total weighted for/against/abstaining votes"
   totalVotes: BigInt!
   "Votes associated to this proposal"
   votes: [Vote!]! @derivedFrom(field: "proposal")

--- a/subgraphs/openzeppelin-governor/schema.graphql
+++ b/subgraphs/openzeppelin-governor/schema.graphql
@@ -75,6 +75,8 @@ type Proposal @entity {
   proposer: Delegate!
   "State of the proposal"
   state: ProposalState!
+  "The number of votes for a proposal to succeed."
+  quorumVotes: BigInt!
 
   "Unweighted Votes against the proposal"
   delegateAgainstVotes: BigInt!

--- a/subgraphs/openzeppelin-governor/schema.graphql
+++ b/subgraphs/openzeppelin-governor/schema.graphql
@@ -77,23 +77,29 @@ type Proposal @entity {
   state: ProposalState!
   "The number of votes for a proposal to succeed."
   quorumVotes: BigInt!
+  "Number of tokenholders at start of voting"
+  tokenHoldersAtStart: BigInt!
+  "Number of delegates at start of voting"
+  delegatesAtStart: BigInt!
 
-  "Unweighted Votes against the proposal"
-  delegateAgainstVotes: BigInt!
-  "Unweighted Votes for the proposal"
-  delegateForVotes: BigInt!
-  "Unweighted Votes abstaining to the proposal"
-  delegateAbstainVotes: BigInt!
-  "Total unweighted for/against/abstaining votes"
-  delegateTotalVotes: BigInt!
+  "Number of delegates that voted against the proposal"
+  againstDelegateVotes: BigInt!
+  "Number of delegates that voted for the proposal"
+  forDelegateVotes: BigInt!
+  "Number of delegates that voted abstain to the proposal"
+  abstainDelegateVotes: BigInt!
+  "Total number of delegates that voted on the proposal"
+  totalDelegateVotes: BigInt!
+
   "Weighted votes against the proposal"
-  againstVotes: BigInt!
+  againstWeightedVotes: BigInt!
   "Weighted votes for the proposal"
-  forVotes: BigInt!
+  forWeightedVotes: BigInt!
   "Weighted votes abstaining to the proposal"
-  abstainVotes: BigInt!
+  abstainWeightedVotes: BigInt!
   "Total weighted for/against/abstaining votes"
-  totalVotes: BigInt!
+  totalWeightedVotes: BigInt!
+
   "Votes associated to this proposal"
   votes: [Vote!]! @derivedFrom(field: "proposal")
 

--- a/subgraphs/openzeppelin-governor/src/handlers.ts
+++ b/subgraphs/openzeppelin-governor/src/handlers.ts
@@ -154,6 +154,7 @@ export function _handleProposalCreated(
   startBlock: BigInt,
   endBlock: BigInt,
   description: string,
+  quorum: BigInt,
   event: ethereum.Event
 ): void {
   let proposal = getOrCreateProposal(proposalId);
@@ -194,6 +195,7 @@ export function _handleProposalCreated(
       ? ProposalState.ACTIVE
       : ProposalState.PENDING;
   proposal.governanceFramework = event.address.toHexString();
+  proposal.quorumVotes = quorum;
   proposal.save();
 
   // Increment gov proposal count

--- a/subgraphs/openzeppelin-governor/src/handlers.ts
+++ b/subgraphs/openzeppelin-governor/src/handlers.ts
@@ -232,6 +232,16 @@ export function _handleProposalExecuted(
   governance.save();
 }
 
+export function _handleProposalExtended(
+  proposalId: string,
+  extendedDeadline: BigInt
+): void {
+  // Update proposal endBlock
+  let proposal = getOrCreateProposal(proposalId);
+  proposal.endBlock = extendedDeadline;
+  proposal.save();
+}
+
 export function _handleProposalQueued(proposalId: BigInt, eta: BigInt): void {
   // Update proposal status + execution metadata
   let proposal = getOrCreateProposal(proposalId.toString());

--- a/subgraphs/openzeppelin-governor/src/handlers.ts
+++ b/subgraphs/openzeppelin-governor/src/handlers.ts
@@ -172,6 +172,10 @@ export function _handleProposalCreated(
   proposer = getOrCreateDelegate(proposerAddr);
 
   proposal.proposer = proposer.id;
+  proposal.delegateAgainstVotes = BIGINT_ZERO;
+  proposal.delegateForVotes = BIGINT_ZERO;
+  proposal.delegateAbstainVotes = BIGINT_ZERO;
+  proposal.delegateTotalVotes = BIGINT_ZERO;
   proposal.againstVotes = BIGINT_ZERO;
   proposal.forVotes = BIGINT_ZERO;
   proposal.abstainVotes = BIGINT_ZERO;
@@ -282,15 +286,22 @@ export function _handleVoteCast(
   }
 
   // Increment respective vote choice counts
+  // NOTE: We are counting the weight instead of individual votes
   if (support === 0) {
-    proposal.againstVotes = proposal.againstVotes.plus(BIGINT_ONE);
+    proposal.delegateAgainstVotes =
+      proposal.delegateAgainstVotes.plus(BIGINT_ONE);
+    proposal.againstVotes = proposal.againstVotes.plus(weight);
   } else if (support === 1) {
-    proposal.forVotes = proposal.forVotes.plus(BIGINT_ONE);
+    proposal.delegateForVotes = proposal.delegateForVotes.plus(BIGINT_ONE);
+    proposal.forVotes = proposal.forVotes.plus(weight);
   } else if (support === 2) {
-    proposal.abstainVotes = proposal.abstainVotes.plus(BIGINT_ONE);
+    proposal.delegateAbstainVotes =
+      proposal.delegateAbstainVotes.plus(BIGINT_ONE);
+    proposal.abstainVotes = proposal.abstainVotes.plus(weight);
   }
   // Increment total
-  proposal.totalVotes = proposal.totalVotes.plus(BIGINT_ONE);
+  proposal.delegateTotalVotes = proposal.delegateTotalVotes.plus(BIGINT_ONE);
+  proposal.totalVotes = proposal.totalVotes.plus(weight);
   proposal.save();
 
   // Add 1 to participant's proposal voting count


### PR DESCRIPTION
## Description 

This PR aims to address several bugs / inconsistencies with the OZGovernor entities/subgraphs

**1. Handle ProposalExtended event** 
- Part of OZGovernor LateQuorumVoteExtensionSet extension

**2. Mix up of Timelock and Token address in governanceFramework creation [GOV-59]**(https://linear.app/messari/issue/GOV-59/fix-token-and-timelock-address-mix-up-in-subgraphs)

**3. Euler subgraph was failing due to a missing handler for `ProposalThresholdSet`**

**4. Unlock subgraph was failing due to not setting `proposalThreshold` which is required.**
- If no proposal threshold set, default it to 0?

**5. Capture both weighted and unweighted votes**

**6. Capture quorum, tokenHolder, delegate snapshot at proposal level on first vote**
```typescript
  // On first vote, set state and quorum values
  if (proposal.state == ProposalState.PENDING) {
    let contract = DaoGovernor.bind(contractAddress);
    proposal.state = ProposalState.ACTIVE;
    proposal.quorumVotes = contract.quorum(proposal.startBlock);

    let governance = getGovernance();
    proposal.tokenHoldersAtStart = governance.currentTokenHolders;
    proposal.delegatesAtStart = governance.currentDelegates;
  }
```

## Related PRs
https://github.com/messari/governor-service/pull/28