### PR TITLE
Aave V2: Fix Deployments

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -45,7 +45,7 @@
           "template": "aave.v2.template.yaml",
           "messari": "messari/aave-arc-ethereum",
           "dmelotik": "dmelotik/aave-v2-arc",
-          "deploy-on-merge": true
+          "deploy-on-merge": false
         },
         "avalanche": {
           "template": "aave.v2.template.yaml",
@@ -63,7 +63,7 @@
           "template": "aave.v2.template.yaml",
           "messari": "messari/aave-amm-ethereum",
           "dmelotik": "dmelotik/aave-v2-ethereum-amm",
-          "deploy-on-merge": true
+          "deploy-on-merge": false
         },
         "polygon": {
           "template": "aave.v2.template.yaml",
@@ -75,7 +75,7 @@
           "template": "aave.v2.template.yaml",
           "messari": "messari/aave-rwa-ethereum",
           "dmelotik": "dmelotik/aave-v2-rwa",
-          "deploy-on-merge": true
+          "deploy-on-merge": false
         }
       },
       "geist-finance": {
@@ -83,7 +83,7 @@
           "template": "geist.finance.template.yaml",
           "messari": "messari/geist-finance-fantom",
           "dmelotik": "dmelotik/geist-fantom",
-          "deploy-on-merge": true
+          "deploy-on-merge": false
         }
       }
     },

--- a/subgraphs/aave-v2-forks/protocols/aave-v2/config/networks/avalanche/avalanche.json
+++ b/subgraphs/aave-v2-forks/protocols/aave-v2/config/networks/avalanche/avalanche.json
@@ -2,7 +2,7 @@
   "network": "avalanche",
   "startBlock": "4606868",
   "factoryAddress": "0xb6A86025F0FE1862B372cb0ca18CE3EDe02A318f",
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "QmbEQvJSV6QdaLucfAuQ3x4z5jp1wErdafKK88JYfLm5na",
   "graftStartBlock": 17825987
 }

--- a/subgraphs/aave-v2-forks/protocols/aave-v2/config/networks/ethereum/ethereum.json
+++ b/subgraphs/aave-v2-forks/protocols/aave-v2/config/networks/ethereum/ethereum.json
@@ -2,7 +2,7 @@
   "network": "mainnet",
   "startBlock": "11362562",
   "factoryAddress": "0xB53C1a33016B2DC2fF3653530bfF1848a515c8c5",
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "QmfHRGh3tC4yb2bBRn5A6ctytG32Jwfi9eNo76EFjiWyrf",
   "graftStartBlock": 15217959
 }

--- a/subgraphs/aave-v2-forks/protocols/aave-v2/config/networks/polygon/polygon.json
+++ b/subgraphs/aave-v2-forks/protocols/aave-v2/config/networks/polygon/polygon.json
@@ -2,7 +2,7 @@
   "network": "matic",
   "startBlock": "12687216",
   "factoryAddress": "0xd05e3E715d945B59290df0ae8eF85c1BdB684744",
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "QmWRUVJCcB5dsa8sHmmdWWpSA62R8pjGBatjoQZf1RwNPS",
   "graftStartBlock": 15083810
 }

--- a/subgraphs/aave-v2-forks/src/mapping.ts
+++ b/subgraphs/aave-v2-forks/src/mapping.ts
@@ -1,5 +1,4 @@
 // generic aave-v2 handlers
-
 import {
   Address,
   BigDecimal,

--- a/subgraphs/aave-v2-forks/src/token.ts
+++ b/subgraphs/aave-v2-forks/src/token.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prefer-const */
 import { Address } from "@graphprotocol/graph-ts";
 import { ERC20 } from "../generated/templates/LendingPool/ERC20";
 import { ERC20NameBytes } from "../generated/templates/LendingPool/ERC20NameBytes";


### PR DESCRIPTION
I accidentally left grafting turned on for aave v2 `ethereum`, `polygon`, and `avalanche`...

So the `market.cumulativeLiquidateUSD` fix is not accurate for those deployments.

The fix is to redeploy only the mentioned subgraphs with grafting turned off. I made a few aesthetic changes in the main `/src` folder in order to trigger the deployments.