### PR TITLE
Use whitelisted token volumeUSD for non-whitelisted token instead of 0

### DIFF
--- a/subgraphs/uniswap-forks/src/price/price.ts
+++ b/subgraphs/uniswap-forks/src/price/price.ts
@@ -218,7 +218,7 @@ export function getTrackedVolumeUSD(
   ) {
     return [
       tokenAmount0.times(price0USD),
-      BIGDECIMAL_ZERO,
+      tokenAmount0.times(price0USD),
       tokenAmount0.times(price0USD),
     ];
   }
@@ -229,7 +229,7 @@ export function getTrackedVolumeUSD(
     NetworkConfigs.getWhitelistTokens().includes(token1.id)
   ) {
     return [
-      BIGDECIMAL_ZERO,
+      tokenAmount1.times(price1USD),
       tokenAmount1.times(price1USD),
       tokenAmount1.times(price1USD),
     ];


### PR DESCRIPTION
### Context

`getTrackedVolumeUSD()` returns `[token0VolumeUSD, token1VolumeUSD, token01Average]`. As of now, if either token is not whitelisted, its volumeUSD will be 0. 

### Problem

Pools made of a `non-whitelisted/whitelisted` input token pair get their `dailyVolumeByTokenUSD` and `hourlyVolumeByTokenUSD` values zeroed for the non-whitelisted token.

This is because we return a 0 volumeUSD if the token is not whitelisted.

### Proposal

In those cases we can default to the whitelisted token volumeUSD, since they should be really close in value in practice. 

An alternative, in case we prefer to keep the this out of the price module, and to make it explicit that the 0 volume means the token is not whitelisted, we could move this logic to [here](https://github.com/messari/subgraphs/blob/master/subgraphs/uniswap-forks/src/common/updateMetrics.ts#L289-L296) instead. Doing something like defaulting to the average, which is the same a the whitelisted volume:

```diff
let trackedAmountUSD = getTrackedVolumeUSD(...)

...

poolMetricsDaily.dailyVolumeByTokenUSD = [
    poolMetricsDaily.dailyVolumeByTokenUSD[INT_ZERO].plus(
-      trackedAmountUSD[INT_ZERO]
+      trackedAmountUSD[INT_ZERO] ? trackedAmountUSD[INT_ZERO] : trackedAmountUSD[INT_TWO]
    ),
    poolMetricsDaily.dailyVolumeByTokenUSD[INT_ONE].plus(
-      trackedAmountUSD[INT_ONE]
+      trackedAmountUSD[INT_ONE] ? trackedAmountUSD[INT_ONE] : trackedAmountUSD[INT_TWO]
    ),
];
```