### PR TITLE
fix: uniswap-forks; pool snapshots cumulative values

### DIFF
--- a/subgraphs/uniswap-forks/src/common/updateMetrics.ts
+++ b/subgraphs/uniswap-forks/src/common/updateMetrics.ts
@@ -148,6 +148,9 @@ export function updatePoolMetrics(event: ethereum.Event): void {
   poolMetricsDaily.rewardTokenEmissionsAmount = pool.rewardTokenEmissionsAmount;
   poolMetricsDaily.rewardTokenEmissionsUSD = pool.rewardTokenEmissionsUSD;
   poolMetricsDaily.stakedOutputTokenAmount = pool.stakedOutputTokenAmount;
+  poolMetricsDaily.cumulativeTotalRevenueUSD = pool.cumulativeTotalRevenueUSD;
+  poolMetricsDaily.cumulativeSupplySideRevenueUSD = pool.cumulativeSupplySideRevenueUSD;
+  poolMetricsDaily.cumulativeProtocolSideRevenueUSD = pool.cumulativeProtocolSideRevenueUSD;
 
   poolMetricsHourly.totalValueLockedUSD = pool.totalValueLockedUSD;
   poolMetricsHourly.cumulativeVolumeUSD = pool.cumulativeVolumeUSD;
@@ -160,6 +163,9 @@ export function updatePoolMetrics(event: ethereum.Event): void {
   poolMetricsHourly.rewardTokenEmissionsAmount = pool.rewardTokenEmissionsAmount;
   poolMetricsHourly.rewardTokenEmissionsUSD = pool.rewardTokenEmissionsUSD;
   poolMetricsHourly.stakedOutputTokenAmount = pool.stakedOutputTokenAmount;
+  poolMetricsHourly.cumulativeTotalRevenueUSD = pool.cumulativeTotalRevenueUSD;
+  poolMetricsHourly.cumulativeSupplySideRevenueUSD = pool.cumulativeSupplySideRevenueUSD;
+  poolMetricsHourly.cumulativeProtocolSideRevenueUSD = pool.cumulativeProtocolSideRevenueUSD;
 
   poolMetricsDaily.save();
   poolMetricsHourly.save();
@@ -377,11 +383,11 @@ export function updateVolumeAndFees(
     poolMetricsDaily.dailyProtocolSideRevenueUSD.plus(protocolFeeAmountUSD);
 
   poolMetricsDaily.cumulativeTotalRevenueUSD =
-    protocol.cumulativeTotalRevenueUSD;
+    pool.cumulativeTotalRevenueUSD;
   poolMetricsDaily.cumulativeSupplySideRevenueUSD =
-    protocol.cumulativeSupplySideRevenueUSD;
+    pool.cumulativeSupplySideRevenueUSD;
   poolMetricsDaily.cumulativeProtocolSideRevenueUSD =
-    protocol.cumulativeProtocolSideRevenueUSD;
+    pool.cumulativeProtocolSideRevenueUSD;
 
   // Hourly Pool Metrics
   poolMetricsHourly.hourlyTotalRevenueUSD =
@@ -392,11 +398,11 @@ export function updateVolumeAndFees(
     poolMetricsHourly.hourlyProtocolSideRevenueUSD.plus(protocolFeeAmountUSD);
 
   poolMetricsHourly.cumulativeTotalRevenueUSD =
-    protocol.cumulativeTotalRevenueUSD;
+    pool.cumulativeTotalRevenueUSD;
   poolMetricsHourly.cumulativeSupplySideRevenueUSD =
-    protocol.cumulativeSupplySideRevenueUSD;
+    pool.cumulativeSupplySideRevenueUSD;
   poolMetricsHourly.cumulativeProtocolSideRevenueUSD =
-    protocol.cumulativeProtocolSideRevenueUSD;
+    pool.cumulativeProtocolSideRevenueUSD;
 
   financialMetrics.save();
   poolMetricsDaily.save();


### PR DESCRIPTION
This PR aims to fix 2 issues:

### 1
Hourly and daily cumulative revenue values are only updated on Swap events, but snapshots might be created too on Mint/Burn.

It might happen that at during hour/day there are no swaps, but there are lp mints or burns. If this happens, we initialize a snapshot with a 0 cumulativeRevenue value (it would be updated on swap). Since there are no swaps during that hour it stays at 0.

### 2

We seem to be using protocol cumulative metrics for pool snaphots? I would assume we want pool cumulative metrics instead, since protocol cumulatives are tracked on the financials snapshots. 