### PR TITLE
Uniswap Forks - Used reward token getter in Masterchef handlers 

### DIFF
--- a/subgraphs/uniswap-forks/protocols/apeswap/src/common/handlers/handleReward.ts
+++ b/subgraphs/uniswap-forks/protocols/apeswap/src/common/handlers/handleReward.ts
@@ -12,7 +12,10 @@ import {
   MasterChef,
   RECENT_BLOCK_THRESHOLD,
 } from "../../../../../src/common/constants";
-import { getOrCreateToken } from "../../../../../src/common/getters";
+import {
+  getOrCreateRewardToken,
+  getOrCreateToken,
+} from "../../../../../src/common/getters";
 import { getRewardsPerDay } from "../../../../../src/common/rewards";
 import {
   convertTokenToDecimal,
@@ -63,7 +66,9 @@ export function handleReward(
   }
 
   let rewardToken = getOrCreateToken(NetworkConfigs.getRewardToken());
-  pool.rewardTokens = [rewardToken.id];
+  pool.rewardTokens = [
+    getOrCreateRewardToken(NetworkConfigs.getRewardToken()).id,
+  ];
 
   // Update staked amounts
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);

--- a/subgraphs/uniswap-forks/protocols/apeswap/src/common/handlers/handleReward.ts
+++ b/subgraphs/uniswap-forks/protocols/apeswap/src/common/handlers/handleReward.ts
@@ -71,6 +71,7 @@ export function handleReward(
   ];
 
   // Update staked amounts
+  // Positive for deposits, negative for withdraws
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);
 
   // Return if you have calculated rewards recently - Performance Boost

--- a/subgraphs/uniswap-forks/protocols/apeswap/src/common/handlers/handleRewardMini.ts
+++ b/subgraphs/uniswap-forks/protocols/apeswap/src/common/handlers/handleRewardMini.ts
@@ -7,7 +7,10 @@ import {
   _MasterChefStakingPool,
 } from "../../../../../generated/schema";
 import { INT_ZERO, MasterChef } from "../../../../../src/common/constants";
-import { getOrCreateToken } from "../../../../../src/common/getters";
+import {
+  getOrCreateRewardToken,
+  getOrCreateToken,
+} from "../../../../../src/common/getters";
 import { getRewardsPerDay } from "../../../../../src/common/rewards";
 import { getOrCreateMasterChef } from "../../../../../src/common/masterchef/helpers";
 import {
@@ -33,7 +36,9 @@ export function updateMasterChef(
   }
 
   let rewardToken = getOrCreateToken(NetworkConfigs.getRewardToken());
-  pool.rewardTokens = [rewardToken.id];
+  pool.rewardTokens = [
+    getOrCreateRewardToken(NetworkConfigs.getRewardToken()).id,
+  ];
 
   // Get the amount of Banana tokens emitted for all pools per second.
   if (masterChefV2.lastUpdatedRewardRate != event.block.number) {

--- a/subgraphs/uniswap-forks/protocols/apeswap/src/common/handlers/handleRewardMini.ts
+++ b/subgraphs/uniswap-forks/protocols/apeswap/src/common/handlers/handleRewardMini.ts
@@ -66,7 +66,8 @@ export function updateMasterChef(
     masterChefV2.rewardTokenInterval
   );
 
-  // Update the amount of staked tokens after deposit
+  // Update the amount of staked tokens
+  // Positive for deposits, negative for withdraws
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);
   pool.rewardTokenEmissionsAmount = [
     BigInt.fromString(roundToWholeNumber(rewardTokenPerDay).toString()),

--- a/subgraphs/uniswap-forks/protocols/solarbeam/src/common/handlers/handleReward.ts
+++ b/subgraphs/uniswap-forks/protocols/solarbeam/src/common/handlers/handleReward.ts
@@ -12,7 +12,10 @@ import {
   MasterChef,
   RECENT_BLOCK_THRESHOLD,
 } from "../../../../../src/common/constants";
-import { getOrCreateToken } from "../../../../../src/common/getters";
+import {
+  getOrCreateRewardToken,
+  getOrCreateToken,
+} from "../../../../../src/common/getters";
 import { getRewardsPerDay } from "../../../../../src/common/rewards";
 import {
   convertTokenToDecimal,
@@ -63,7 +66,9 @@ export function handleReward(
   }
 
   let rewardToken = getOrCreateToken(NetworkConfigs.getRewardToken());
-  pool.rewardTokens = [rewardToken.id];
+  pool.rewardTokens = [
+    getOrCreateRewardToken(NetworkConfigs.getRewardToken()).id,
+  ];
 
   // Update staked amounts
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);

--- a/subgraphs/uniswap-forks/protocols/solarbeam/src/common/handlers/handleReward.ts
+++ b/subgraphs/uniswap-forks/protocols/solarbeam/src/common/handlers/handleReward.ts
@@ -71,6 +71,7 @@ export function handleReward(
   ];
 
   // Update staked amounts
+  // Positive for deposits, negative for withdraws
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);
 
   // Return if you have calculated rewards recently - Performance Boost

--- a/subgraphs/uniswap-forks/protocols/spookyswap/src/common/handlers/handleReward.ts
+++ b/subgraphs/uniswap-forks/protocols/spookyswap/src/common/handlers/handleReward.ts
@@ -12,7 +12,10 @@ import {
   MasterChef,
   RECENT_BLOCK_THRESHOLD,
 } from "../../../../../src/common/constants";
-import { getOrCreateToken } from "../../../../../src/common/getters";
+import {
+  getOrCreateRewardToken,
+  getOrCreateToken,
+} from "../../../../../src/common/getters";
 import { getRewardsPerDay } from "../../../../../src/common/rewards";
 import {
   convertTokenToDecimal,
@@ -63,7 +66,9 @@ export function handleReward(
   }
 
   let rewardToken = getOrCreateToken(NetworkConfigs.getRewardToken());
-  pool.rewardTokens = [rewardToken.id];
+  pool.rewardTokens = [
+    getOrCreateRewardToken(NetworkConfigs.getRewardToken()).id,
+  ];
 
   // Update staked amounts
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);

--- a/subgraphs/uniswap-forks/protocols/spookyswap/src/common/handlers/handleReward.ts
+++ b/subgraphs/uniswap-forks/protocols/spookyswap/src/common/handlers/handleReward.ts
@@ -71,6 +71,7 @@ export function handleReward(
   ];
 
   // Update staked amounts
+  // Positive for deposits, negative for withdraws
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);
 
   // Return if you have calculated rewards recently - Performance Boost

--- a/subgraphs/uniswap-forks/protocols/spookyswap/src/common/handlers/handleRewardV2.ts
+++ b/subgraphs/uniswap-forks/protocols/spookyswap/src/common/handlers/handleRewardV2.ts
@@ -62,6 +62,7 @@ export function updateMasterChef(
   );
 
   // Update the amount of staked tokens after withdraw
+  // Positive for deposits, negative for withdraws
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);
   pool.rewardTokenEmissionsAmount = [
     BigInt.fromString(roundToWholeNumber(rewardTokenPerDay).toString()),

--- a/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleReward.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleReward.ts
@@ -14,7 +14,10 @@ import {
   MasterChef,
   RECENT_BLOCK_THRESHOLD,
 } from "../../../../../src/common/constants";
-import { getOrCreateToken } from "../../../../../src/common/getters";
+import {
+  getOrCreateRewardToken,
+  getOrCreateToken,
+} from "../../../../../src/common/getters";
 import { getRewardsPerDay } from "../../../../../src/common/rewards";
 import {
   getOrCreateMasterChef,
@@ -67,7 +70,9 @@ export function handleReward(
   }
 
   let rewardToken = getOrCreateToken(NetworkConfigs.getRewardToken());
-  pool.rewardTokens = [rewardToken.id];
+  pool.rewardTokens = [
+    getOrCreateRewardToken(NetworkConfigs.getRewardToken()).id,
+  ];
 
   // Update staked amounts
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);

--- a/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleReward.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleReward.ts
@@ -75,6 +75,7 @@ export function handleReward(
   ];
 
   // Update staked amounts
+  // Positive for deposits, negative for withdraws
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);
 
   // Return if you have calculated rewards recently - Performance Boost

--- a/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleRewardMini.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleRewardMini.ts
@@ -56,6 +56,7 @@ export function updateMasterChef(
   );
 
   // Update the amount of staked tokens after deposit
+  // Positive for deposits, negative for withdraws
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);
   pool.rewardTokenEmissionsAmount = [
     BigInt.fromString(roundToWholeNumber(rewardTokenPerDay).toString()),

--- a/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleRewardMini.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleRewardMini.ts
@@ -6,7 +6,10 @@ import {
   _MasterChefStakingPool,
 } from "../../../../../generated/schema";
 import { INT_ZERO, MasterChef } from "../../../../../src/common/constants";
-import { getOrCreateToken } from "../../../../../src/common/getters";
+import {
+  getOrCreateRewardToken,
+  getOrCreateToken,
+} from "../../../../../src/common/getters";
 import { getRewardsPerDay } from "../../../../../src/common/rewards";
 import {
   convertTokenToDecimal,
@@ -31,7 +34,9 @@ export function updateMasterChef(
   }
 
   let rewardToken = getOrCreateToken(NetworkConfigs.getRewardToken());
-  pool.rewardTokens = [rewardToken.id];
+  pool.rewardTokens = [
+    getOrCreateRewardToken(NetworkConfigs.getRewardToken()).id,
+  ];
 
   // Calculate Reward Emission per second to a specific pool
   // Pools are allocated based on their fraction of the total allocation times the rewards emitted per second

--- a/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleRewardV2.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleRewardV2.ts
@@ -5,8 +5,15 @@ import {
   _MasterChef,
   _MasterChefStakingPool,
 } from "../../../../../generated/schema";
-import { BIGINT_ZERO, INT_ZERO, MasterChef } from "../../../../../src/common/constants";
-import { getOrCreateToken } from "../../../../../src/common/getters";
+import {
+  BIGINT_ZERO,
+  INT_ZERO,
+  MasterChef,
+} from "../../../../../src/common/constants";
+import {
+  getOrCreateRewardToken,
+  getOrCreateToken,
+} from "../../../../../src/common/getters";
 import { getRewardsPerDay } from "../../../../../src/common/rewards";
 import {
   convertTokenToDecimal,
@@ -32,8 +39,10 @@ export function updateMasterChef(
   }
 
   let rewardToken = getOrCreateToken(NetworkConfigs.getRewardToken());
-  pool.rewardTokens = [rewardToken.id];
-  
+  pool.rewardTokens = [
+    getOrCreateRewardToken(NetworkConfigs.getRewardToken()).id,
+  ];
+
   // Calculate Reward Emission per second to a specific pool
   // Pools are allocated based on their fraction of the total allocation times the rewards emitted per block.
   // Adjusted reward token rate is calculated in the MasterChefV1 handler since rewards feed in from MasterChefV1.

--- a/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleRewardV2.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/src/common/handlers/handleRewardV2.ts
@@ -72,7 +72,8 @@ export function updateMasterChef(
     masterChefV2.rewardTokenInterval
   );
 
-  // Update the amount of staked tokens after withdraw
+  // Update the amount of staked LP tokens
+  // Positive for deposits, negative for withdraws
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);
   pool.rewardTokenEmissionsAmount = [
     BigInt.fromString(roundToWholeNumber(rewardTokenPerDay).toString()),

--- a/subgraphs/uniswap-forks/protocols/trader-joe/src/common/handlers/handleRewardV2.ts
+++ b/subgraphs/uniswap-forks/protocols/trader-joe/src/common/handlers/handleRewardV2.ts
@@ -5,7 +5,10 @@ import {
   _HelperStore,
   _MasterChefStakingPool,
 } from "../../../../../generated/schema";
-import { getOrCreateToken } from "../../../../../src/common/getters";
+import {
+  getOrCreateRewardToken,
+  getOrCreateToken,
+} from "../../../../../src/common/getters";
 import { getRewardsPerDay } from "../../../../../src/common/rewards";
 import { getOrCreateMasterChef } from "../../../../../src/common/masterchef/helpers";
 import { INT_ZERO, MasterChef } from "../../../../../src/common/constants";
@@ -32,7 +35,9 @@ export function updateMasterChef(
   }
 
   let rewardToken = getOrCreateToken(NetworkConfigs.getRewardToken());
-  pool.rewardTokens = [rewardToken.id];
+  pool.rewardTokens = [
+    getOrCreateRewardToken(NetworkConfigs.getRewardToken()).id,
+  ];
 
   // Calculate Reward Emission per second to a specific pool
   // Pools are allocated based on their fraction of the total allocation times the rewards emitted per second

--- a/subgraphs/uniswap-forks/protocols/trader-joe/src/common/handlers/handleRewardV2.ts
+++ b/subgraphs/uniswap-forks/protocols/trader-joe/src/common/handlers/handleRewardV2.ts
@@ -57,6 +57,7 @@ export function updateMasterChef(
   );
 
   // Update the amount of staked tokens after deposit
+  // Positive for deposits, negative for withdraws
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);
   pool.rewardTokenEmissionsAmount = [
     BigInt.fromString(roundToWholeNumber(rewardTokenPerDay).toString()),

--- a/subgraphs/uniswap-forks/protocols/trader-joe/src/common/handlers/handleRewardV3.ts
+++ b/subgraphs/uniswap-forks/protocols/trader-joe/src/common/handlers/handleRewardV3.ts
@@ -6,7 +6,10 @@ import {
   _HelperStore,
   _MasterChefStakingPool,
 } from "../../../../../generated/schema";
-import { getOrCreateToken } from "../../../../../src/common/getters";
+import {
+  getOrCreateRewardToken,
+  getOrCreateToken,
+} from "../../../../../src/common/getters";
 import { getRewardsPerDay } from "../../../../../src/common/rewards";
 import { getOrCreateMasterChef } from "../../../../../src/common/masterchef/helpers";
 import { INT_ZERO, MasterChef } from "../../../../../src/common/constants";
@@ -34,7 +37,9 @@ export function updateMasterChef(
   }
 
   let rewardToken = getOrCreateToken(NetworkConfigs.getRewardToken());
-  pool.rewardTokens = [rewardToken.id];
+  pool.rewardTokens = [
+    getOrCreateRewardToken(NetworkConfigs.getRewardToken()).id,
+  ];
 
   // Get the amount of Joe tokens emitted for all pools per second.
   if (masterChefV3.lastUpdatedRewardRate != event.block.number) {

--- a/subgraphs/uniswap-forks/protocols/vvs-finance/src/common/handlers/handleReward.ts
+++ b/subgraphs/uniswap-forks/protocols/vvs-finance/src/common/handlers/handleReward.ts
@@ -12,7 +12,10 @@ import {
   MasterChef,
   RECENT_BLOCK_THRESHOLD,
 } from "../../../../../src/common/constants";
-import { getOrCreateToken } from "../../../../../src/common/getters";
+import {
+  getOrCreateRewardToken,
+  getOrCreateToken,
+} from "../../../../../src/common/getters";
 import { getRewardsPerDay } from "../../../../../src/common/rewards";
 import {
   convertTokenToDecimal,
@@ -63,7 +66,9 @@ export function handleReward(
   }
 
   let rewardToken = getOrCreateToken(NetworkConfigs.getRewardToken());
-  pool.rewardTokens = [rewardToken.id];
+  pool.rewardTokens = [
+    getOrCreateRewardToken(NetworkConfigs.getRewardToken()).id,
+  ];
 
   // Update staked amounts
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);

--- a/subgraphs/uniswap-forks/protocols/vvs-finance/src/common/handlers/handleReward.ts
+++ b/subgraphs/uniswap-forks/protocols/vvs-finance/src/common/handlers/handleReward.ts
@@ -71,6 +71,7 @@ export function handleReward(
   ];
 
   // Update staked amounts
+  // Positive for deposits, negative for withdraws
   pool.stakedOutputTokenAmount = pool.stakedOutputTokenAmount!.plus(amount);
 
   // Return if you have calculated rewards recently - Performance Boost


### PR DESCRIPTION
The assignment of the regular token analogue for the reward token field on the pool is incorrect as this field wants to RewardToken entity id. The reward token id has an additional suffix which makes it different. 