### PR TITLE
fix(#minor); uniswap forks; updated reference tokens and stable pools for Sushiswap BSC and Polygon - Issue #612

### DIFF
--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/bsc/bsc.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/bsc/bsc.ts
@@ -75,7 +75,7 @@ export class SushiswapBscConfigurations implements Configurations {
     return BIGINT_ZERO;
   }
   getReferenceToken(): string {
-    return toLowerCase("0x2170Ed0880ac9A755fd29B2688956BD959F933F8");
+    return toLowerCase("0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c"); // wBNB
   }
   getRewardToken(): string {
     return toLowerCase("0x947950BcC74888a40Ffa2593C5798F11Fc9124C4");
@@ -100,9 +100,8 @@ export class SushiswapBscConfigurations implements Configurations {
   }
   getStableOraclePools(): string[] {
     return toLowerCaseList([
-      "0xc7632b7b2d768bbb30a404e13e1de48d1439ec21", // wETH/USDC
-      "0x2905817b020fd35d9d09672946362b62766f0d69", // wETH/USDT
-      "0xe6cf29055e747e95c058f64423d984546540ede5", // wETH/DAI
+      "0x2905817b020fd35d9d09672946362b62766f0d69", // wBNB/USDT
+      "0xdc558d64c29721d74c4456cfb4363a6e6660a9bb", // wBNB/bUSD
     ]);
   }
   getUntrackedPairs(): string[] {

--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/polygon/polygon.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/polygon/polygon.ts
@@ -4,7 +4,6 @@ import {
   BIGINT_ZERO,
   FeeSwitch,
   MINIMUM_LIQUIDITY_FIVE_THOUSAND,
-  MINIMUM_LIQUIDITY_ONE_HUNDRED_THOUSAND,
   MINIMUM_LIQUIDITY_TEN_THOUSAND,
   Network,
   PROTOCOL_SCHEMA_VERSION,
@@ -100,9 +99,9 @@ export class SushiswapMaticConfigurations implements Configurations {
   }
   getStableOraclePools(): string[] {
     return toLowerCaseList([
-      "0x2791bca1f2de4661ed88a30c99a7a9449aa84174", // wETH/USDC
-      "0xc2132d05d31c914a87c6611c10748aeb04b58e8f", // wETH/USDT
-      "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063", // wETH/DAI
+      "0x34965ba0ac2451a34a0471f04cca3f990b8dea27", // wETH/USDC
+      "0xc2755915a85c6f6c1c0f3a86ac8c058f11caa9c9", // wETH/USDT
+      "0x6ff62bfb8c12109e8000935a6de54dad83a4f39f", // wETH/DAI
     ]);
   }
   getUntrackedPairs(): string[] {

--- a/subgraphs/uniswap-forks/protocols/sushiswap/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/src/common/constants.ts
@@ -4,7 +4,7 @@ import { BigInt } from "@graphprotocol/graph-ts";
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.6";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.7";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "SushiSwap";
 export const PROTOCOL_SLUG = "sushiswap";


### PR DESCRIPTION
Issue #612 

- The final things left from this issue are with Sushiswap BSC and Polygon. 
- The pricing was way off because the reference token was getting priced poorly on both. 
- Updated reference token and or stable oracle pools to improve pricing. 
- Polygon was using the wrong oracle pools, and BSC needed to use BNB as its reference token since Eth was low volume. 