### PR TITLE
fix: husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-git stash -k -u
 npx pretty-quick --staged
-git add .
-git stash pop


### PR DESCRIPTION

It seems we didn't need to get too smart with the pre-commit hook running the prettier.

`npx pretty-quick --staged` is smart enough to know which of the staged files it modifies, and stages them again after prettying.