### PR TITLE
fix(#minor); Uniswap V3; Removed unused fields from the liquidity pool entity - RE: PR 778

### DIFF
--- a/subgraphs/uniswap-v3/.gitignore
+++ b/subgraphs/uniswap-v3/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+subgraph.yaml
+configure.ts

--- a/subgraphs/uniswap-v3/src/common/creators.ts
+++ b/subgraphs/uniswap-v3/src/common/creators.ts
@@ -73,11 +73,6 @@ export function createLiquidityPool(
     BIGDECIMAL_ONE.div(BIGDECIMAL_TWO),
   ];
   pool.outputTokenSupply = BIGINT_ZERO;
-  pool.outputTokenPriceUSD = BIGDECIMAL_ZERO;
-  pool.rewardTokens = [NetworkConfigs.getRewardToken()];
-  pool.stakedOutputTokenAmount = BIGINT_ZERO;
-  pool.rewardTokenEmissionsAmount = [BIGINT_ZERO, BIGINT_ZERO];
-  pool.rewardTokenEmissionsUSD = [BIGDECIMAL_ZERO, BIGDECIMAL_ZERO];
   pool.fees = createPoolFees(poolAddress, fees);
   pool.createdTimestamp = event.block.timestamp;
   pool.createdBlockNumber = event.block.number;


### PR DESCRIPTION
**Context**
There are some fields related to rewards emissions, and the price of the output token which are not applicable to Uniswap V3. There are no rewards emission for Uniswap V3, and because the protocol mints NFTs that represent positions, we do not price the OutputTokens (NFTs).

I am not sure why this happened, but when I force pushed in PR #778 I accidentally push no commits and then it just merged in. This is a redo of that PR.