### PR TITLE
fix(#patch); cream finance; handle oracle that returns price in eth

### DIFF
--- a/subgraphs/compound-forks/src/mapping.ts
+++ b/subgraphs/compound-forks/src/mapping.ts
@@ -1873,6 +1873,7 @@ export function getOrCreateMarketHourlySnapshot(
   return snapshot;
 }
 
+// Return price in USD
 function getTokenPriceUSD(
   getUnderlyingPriceResult: ethereum.CallResult<BigInt>,
   underlyingDecimals: i32


### PR DESCRIPTION
Syncing deployment: https://okgraph.xyz/?q=messari%2Fcream-finance-ethereum

The current issue with cream finance being:
- We use compound fork framework to handle cream finance
- The framework expects oracle to return price in USD, however cream finance uses an oracle that returns price in ETH instead

To work around the issue, we could:
- Derive ETH price
- Multiply the oracle price by ETH price before passing the number down to the compound fork framework

**NOTICE** This patch only fixes cream finance on Ethereum. Let us verify the patch works before fixing this for the rest networks (BNB, Polygon, etc)