### PR TITLE
Convex Finance: Fix spike in TVL

### DIFF
--- a/subgraphs/convex-finance/src/Prices/index.ts
+++ b/subgraphs/convex-finance/src/Prices/index.ts
@@ -25,6 +25,8 @@ export function getUsdPricePerToken(
   if (tokenAddr.toHex() == constants.ZERO_ADDRESS_STRING)
     return new CustomPriceType();
 
+  // Exception: Wrong prices of crvTriCrypto
+  // Ref: https://github.com/messari/subgraphs/pull/824
   if (
     tokenAddr.equals(constants.CRV_TRI_CRYPTO_ADDRESS) &&
     block.number.lt(BigInt.fromI32(12936339))

--- a/subgraphs/convex-finance/src/Prices/index.ts
+++ b/subgraphs/convex-finance/src/Prices/index.ts
@@ -1,8 +1,10 @@
 import {
   log,
   Address,
+  ethereum,
   BigDecimal,
   dataSource,
+  BigInt,
 } from "@graphprotocol/graph-ts";
 import * as constants from "./common/constants";
 import { CustomPriceType } from "./common/types";
@@ -15,11 +17,19 @@ import { getPriceUsdc as getPriceUsdcSushiswap } from "./routers/SushiSwapRouter
 import { getTokenPriceFromSushiSwap } from "./calculations/CalculationsSushiswap";
 import { getTokenPriceFromCalculationCurve } from "./calculations/CalculationsCurve";
 
-export function getUsdPricePerToken(tokenAddr: Address): CustomPriceType {
+export function getUsdPricePerToken(
+  tokenAddr: Address,
+  block: ethereum.Block
+): CustomPriceType {
   // Check if tokenAddr is a NULL Address
-  if (tokenAddr.toHex() == constants.ZERO_ADDRESS_STRING) {
+  if (tokenAddr.toHex() == constants.ZERO_ADDRESS_STRING)
     return new CustomPriceType();
-  }
+
+  if (
+    tokenAddr.equals(constants.CRV_TRI_CRYPTO_ADDRESS) &&
+    block.number.lt(BigInt.fromI32(12936339))
+  )
+    return new CustomPriceType();
 
   let network = dataSource.network();
 
@@ -28,7 +38,7 @@ export function getUsdPricePerToken(tokenAddr: Address): CustomPriceType {
   if (!forexPrice.reverted) {
     log.debug("[forexPrice] tokenAddress: {}, Price: {}", [
       tokenAddr.toHexString(),
-      forexPrice.usdPrice.div(forexPrice.decimalsBaseTen).toString()
+      forexPrice.usdPrice.div(forexPrice.decimalsBaseTen).toString(),
     ]);
     return forexPrice;
   }
@@ -38,7 +48,7 @@ export function getUsdPricePerToken(tokenAddr: Address): CustomPriceType {
   if (!yearnLensPrice.reverted) {
     log.debug("[YearnLensOracle] tokenAddress: {}, Price: {}", [
       tokenAddr.toHexString(),
-      yearnLensPrice.usdPrice.div(yearnLensPrice.decimalsBaseTen).toString()
+      yearnLensPrice.usdPrice.div(yearnLensPrice.decimalsBaseTen).toString(),
     ]);
     return yearnLensPrice;
   }
@@ -48,7 +58,7 @@ export function getUsdPricePerToken(tokenAddr: Address): CustomPriceType {
   if (!chainLinkPrice.reverted) {
     log.debug("[ChainLinkFeed] tokenAddress: {}, Price: {}", [
       tokenAddr.toHexString(),
-      chainLinkPrice.usdPrice.div(chainLinkPrice.decimalsBaseTen).toString()
+      chainLinkPrice.usdPrice.div(chainLinkPrice.decimalsBaseTen).toString(),
     ]);
     return chainLinkPrice;
   }
@@ -63,7 +73,7 @@ export function getUsdPricePerToken(tokenAddr: Address): CustomPriceType {
       tokenAddr.toHexString(),
       calculationsCurvePrice.usdPrice
         .div(calculationsCurvePrice.decimalsBaseTen)
-        .toString()
+        .toString(),
     ]);
     return calculationsCurvePrice;
   }
@@ -78,7 +88,7 @@ export function getUsdPricePerToken(tokenAddr: Address): CustomPriceType {
       tokenAddr.toHexString(),
       calculationsSushiSwapPrice.usdPrice
         .div(calculationsSushiSwapPrice.decimalsBaseTen)
-        .toString()
+        .toString(),
     ]);
     return calculationsSushiSwapPrice;
   }
@@ -88,7 +98,7 @@ export function getUsdPricePerToken(tokenAddr: Address): CustomPriceType {
   if (!curvePrice.reverted) {
     log.debug("[CurveRouter] tokenAddress: {}, Price: {}", [
       tokenAddr.toHexString(),
-      curvePrice.usdPrice.div(curvePrice.decimalsBaseTen).toString()
+      curvePrice.usdPrice.div(curvePrice.decimalsBaseTen).toString(),
     ]);
     return curvePrice;
   }
@@ -98,7 +108,7 @@ export function getUsdPricePerToken(tokenAddr: Address): CustomPriceType {
   if (!uniswapPrice.reverted) {
     log.debug("[UniswapRouter] tokenAddress: {}, Price: {}", [
       tokenAddr.toHexString(),
-      uniswapPrice.usdPrice.div(uniswapPrice.decimalsBaseTen).toString()
+      uniswapPrice.usdPrice.div(uniswapPrice.decimalsBaseTen).toString(),
     ]);
     return uniswapPrice;
   }
@@ -108,7 +118,7 @@ export function getUsdPricePerToken(tokenAddr: Address): CustomPriceType {
   if (!sushiswapPrice.reverted) {
     log.debug("[SushiSwapRouter] tokenAddress: {}, Price: {}", [
       tokenAddr.toHexString(),
-      sushiswapPrice.usdPrice.div(sushiswapPrice.decimalsBaseTen).toString()
+      sushiswapPrice.usdPrice.div(sushiswapPrice.decimalsBaseTen).toString(),
     ]);
     return sushiswapPrice;
   }
@@ -122,9 +132,10 @@ export function getUsdPricePerToken(tokenAddr: Address): CustomPriceType {
 
 export function getUsdPrice(
   tokenAddr: Address,
-  amount: BigDecimal
+  amount: BigDecimal,
+  block: ethereum.Block
 ): BigDecimal {
-  let tokenPrice = getUsdPricePerToken(tokenAddr);
+  let tokenPrice = getUsdPricePerToken(tokenAddr, block);
 
   if (!tokenPrice.reverted) {
     return tokenPrice.usdPrice.times(amount).div(tokenPrice.decimalsBaseTen);

--- a/subgraphs/convex-finance/src/mappings/rewardMappings.ts
+++ b/subgraphs/convex-finance/src/mappings/rewardMappings.ts
@@ -22,7 +22,10 @@ export function handleRewardAdded(event: RewardAdded): void {
   const crvRewardPoolAddress = event.address;
 
   let crvRewardTokenAddress = constants.CRV_TOKEN_ADDRESS;
-  let crvRewardTokenPrice = getUsdPricePerToken(crvRewardTokenAddress);
+  let crvRewardTokenPrice = getUsdPricePerToken(
+    crvRewardTokenAddress,
+    event.block
+  );
   let crvRewardTokenDecimals = utils.getTokenDecimals(crvRewardTokenAddress);
 
   const vault = getOrCreateVault(poolId, event.block);
@@ -40,7 +43,10 @@ export function handleRewardAdded(event: RewardAdded): void {
   let rewardsEarned = afterHistoricalRewards.minus(beforeHistoricalRewards);
 
   let cvxRewardTokenAddress = constants.CONVEX_TOKEN_ADDRESS;
-  let cvxRewardTokenPrice = getUsdPricePerToken(cvxRewardTokenAddress);
+  let cvxRewardTokenPrice = getUsdPricePerToken(
+    cvxRewardTokenAddress,
+    event.block
+  );
   let cvxRewardTokenDecimals = utils.getTokenDecimals(cvxRewardTokenAddress);
 
   let cvxRewardsEarned = utils.getConvexTokenMintAmount(rewardsEarned);

--- a/subgraphs/convex-finance/src/modules/Deposit.ts
+++ b/subgraphs/convex-finance/src/modules/Deposit.ts
@@ -86,7 +86,7 @@ export function Deposit(
   );
 
   let inputTokenAddress = Address.fromString(vault.inputToken);
-  let inputTokenPrice = getUsdPricePerToken(inputTokenAddress);
+  let inputTokenPrice = getUsdPricePerToken(inputTokenAddress, block);
   let inputTokenDecimals = utils.getTokenDecimals(inputTokenAddress);
 
   if (constants.MISSING_POOLS_MAP.get(inputTokenAddress)) {
@@ -94,7 +94,7 @@ export function Deposit(
       inputTokenAddress
     )!;
 
-    inputTokenPrice = getUsdPricePerToken(poolTokenAddress);
+    inputTokenPrice = getUsdPricePerToken(poolTokenAddress, block);
     inputTokenDecimals = utils.getTokenDecimals(poolTokenAddress);
   }
 

--- a/subgraphs/convex-finance/src/modules/Rewards.ts
+++ b/subgraphs/convex-finance/src/modules/Rewards.ts
@@ -178,7 +178,7 @@ export function updateRewardTokenEmissions(
   }
   let rewardTokenEmissionsUSD = vault.rewardTokenEmissionsUSD!;
 
-  const rewardTokenPrice = getUsdPricePerToken(rewardTokenAddress);
+  const rewardTokenPrice = getUsdPricePerToken(rewardTokenAddress, block);
   const rewardTokenDecimals = utils.getTokenDecimals(rewardTokenAddress);
 
   rewardTokenEmissionsAmount[rewardTokenIndex] = rewardTokenPerDay;

--- a/subgraphs/convex-finance/src/modules/Withdraw.ts
+++ b/subgraphs/convex-finance/src/modules/Withdraw.ts
@@ -85,7 +85,7 @@ export function withdraw(
   );
 
   let inputTokenAddress = Address.fromString(vault.inputToken);
-  let inputTokenPrice = getUsdPricePerToken(inputTokenAddress);
+  let inputTokenPrice = getUsdPricePerToken(inputTokenAddress, block);
   let inputTokenDecimals = utils.getTokenDecimals(inputTokenAddress);
 
   if (constants.MISSING_POOLS_MAP.get(inputTokenAddress)) {
@@ -93,7 +93,7 @@ export function withdraw(
       inputTokenAddress
     )!;
 
-    inputTokenPrice = getUsdPricePerToken(poolTokenAddress);
+    inputTokenPrice = getUsdPricePerToken(poolTokenAddress, block);
     inputTokenDecimals = utils.getTokenDecimals(poolTokenAddress);
   }
 


### PR DESCRIPTION
Disable `yearnLens` and `curveCalculation` in price lib for [crvTriCrypto](https://etherscan.io/address/0xca3d75ac011bf5ad07a98d02f18225f9bd9a6bdf) Token

![image](https://user-images.githubusercontent.com/47497931/185249962-95bd3455-64e1-480b-a297-7c0be58b77e3.png)
 