### PR TITLE
fix(#patch); bancor v3; fix tvl calculation

### DIFF
--- a/subgraphs/bancor-v3/src/constants.ts
+++ b/subgraphs/bancor-v3/src/constants.ts
@@ -76,5 +76,9 @@ export let oneBD = new BigDecimal(BigInt.fromI32(1));
 export let hundredBD = new BigDecimal(BigInt.fromI32(100));
 
 export function exponentToBigDecimal(n: i32): BigDecimal {
-  return BigDecimal.fromString(Math.pow(10, n).toString());
+  return exponentToBigInt(n).toBigDecimal();
+}
+
+export function exponentToBigInt(n: i32): BigInt {
+  return BigInt.fromI32(10).pow(n as u8);
 }


### PR DESCRIPTION
Synced deployment https://okgraph.xyz/?q=0xbe1%2Fbancor-v3-mainnet is verified against my bancor-v3 script https://github.com/0xbe1/tvl.sh/tree/master/bancor-v3 which gives similar results as https://analytics.bancor.network/

---

BancorNetworkInfo offers a `tradeOutputBySourceAmount` method that I leverage to derive token price. If `tradeOutputBySourceAmount(ETH, DAI, 10000) == 5` then i can tell ETH price = $2000.

However, if `tradeOutputBySourceAmount(ETH, DAI, 10,000,000) = 10,000` we shouldn't assume ETH price = $1000, because a large swap causes large slippage.

Therefore, I fix the code s.t. when calling `tradeOutputBySourceAmount` I always pass in just 1 unit of token. For example, 10^18 for ETH, 10^6 for USDC.