### PR TITLE
fix(#patch); iron bank; skip bad ctoken

### DIFF
--- a/subgraphs/compound-forks/protocols/iron-bank/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/iron-bank/src/mapping.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, log } from "@graphprotocol/graph-ts";
+import { Address, BigInt, dataSource, log } from "@graphprotocol/graph-ts";
 // import from the generated at root in order to reuse methods from root
 import {
   NewPriceOracle,
@@ -87,6 +87,20 @@ export function handleMarketListed(event: MarketListed): void {
   if (cToken != null) {
     return;
   }
+
+  // handle edge case
+  // iron bank (ethereum) has 2 cySUSD tokens: 0x4e3a36a633f63aee0ab57b5054ec78867cb3c0b8 (deployed earlier) and 0xa7c4054AFD3DbBbF5bFe80f41862b89ea05c9806 (in use)
+  // the former totalBorrows is unreasonably huge for some reason
+  // according to iron bank dashboard https://app.ib.xyz/markets/Ethereum we should use the newer one instead, which has reasonable totalBorrows number
+  // since the bad version only exists for 20+ blocks, it is fine to skip it
+  if (
+    dataSource.network() == "mainnet" &&
+    cTokenAddr ==
+      Address.fromString("0x4e3a36a633f63aee0ab57b5054ec78867cb3c0b8")
+  ) {
+    return;
+  }
+
   // this is a new cToken, a new underlying token, and a new market
 
   let protocol = getOrCreateProtocol();
@@ -272,7 +286,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Iron Bank",
     "iron-bank",
     "2.0.1",
-    "1.1.2",
+    "1.1.3",
     "1.0.0",
     network,
     comptroller.try_liquidationIncentiveMantissa(),


### PR DESCRIPTION
Syncing deployment: https://okgraph.xyz/?q=0xbe1%2Firon-bank-subgraph-mainnet

See comments in code. This should fix both the totalBorrows as well as the TVL.

QA spec mentions a few other issues:
- latest events are months old: I don't think that's right, since events from subgraphs are very up-to-date, e.g. https://api.thegraph.com/subgraphs/id/QmR5xWsyobfRGoWUr5YJqm1mtuuHQ3egEgK1cnWodUgEoL/graphql?query=%7B%0A++borrows%28orderBy%3Atimestamp%2CorderDirection%3Adesc%29%7B%0A++++id%0A++++timestamp%0A++%7D%0A%7D
- totalPoolCount (40) more than ironbank dashboard (24): I believe ironbank simply picks certain pools to render :) we can hardcode the 24 pools in subgraphs and only index those markets, but I am not sure if we want to do that. Thoughts? @this-username-is-taken 