### PR TITLE
fix(#minor); Sushiswap; Fixed reference token for BSC and stable pools for polygon

### DIFF
--- a/subgraphs/uniswap-forks/configurations/configure.ts
+++ b/subgraphs/uniswap-forks/configurations/configure.ts
@@ -3,7 +3,7 @@ import { getNetworkConfigurations } from "./configurations/configurations";
 import { Deploy } from "./configurations/deploy";
 
 // Select the deployment protocol and network
-let deployment = Deploy.SOLARBEAM_MOONRIVER;
+let deployment = Deploy.SUSHISWAP_POLYGON;
 
 // export const NetworkConfigs = configurationsMap.get(deployment)!
 export const NetworkConfigs = getNetworkConfigurations(deployment);

--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/bsc/bsc.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/bsc/bsc.ts
@@ -100,8 +100,9 @@ export class SushiswapBscConfigurations implements Configurations {
   }
   getStableOraclePools(): string[] {
     return toLowerCaseList([
-      "0x2905817b020fd35d9d09672946362b62766f0d69", // wBNB/USDT
-      "0xdc558d64c29721d74c4456cfb4363a6e6660a9bb", // wBNB/bUSD
+      "0xc7632b7b2d768bbb30a404e13e1de48d1439ec21", // USDC/wBNB
+      "0xe6cf29055e747e95c058f64423d984546540ede5", // DAI/wBNB
+      "0x2905817b020fd35d9d09672946362b62766f0d69", // USDT/wBNB
     ]);
   }
   getUntrackedPairs(): string[] {

--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/polygon/polygon.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/polygon/polygon.ts
@@ -5,6 +5,7 @@ import {
   FeeSwitch,
   MINIMUM_LIQUIDITY_FIVE_THOUSAND,
   MINIMUM_LIQUIDITY_TEN_THOUSAND,
+  MINIMUM_LIQUIDITY_TWENTY_FIVE_THOUSAND,
   Network,
   PROTOCOL_SCHEMA_VERSION,
   RewardIntervalType,
@@ -111,9 +112,9 @@ export class SushiswapMaticConfigurations implements Configurations {
     return [];
   }
   getMinimumLiquidityThresholdTrackVolume(): BigDecimal {
-    return MINIMUM_LIQUIDITY_TEN_THOUSAND;
+    return MINIMUM_LIQUIDITY_TWENTY_FIVE_THOUSAND;
   }
   getMinimumLiquidityThresholdTrackPrice(): BigDecimal {
-    return MINIMUM_LIQUIDITY_FIVE_THOUSAND;
+    return MINIMUM_LIQUIDITY_TWENTY_FIVE_THOUSAND;
   }
 }

--- a/subgraphs/uniswap-forks/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/src/common/constants.ts
@@ -120,9 +120,10 @@ export const BIGINT_TEN = BigInt.fromI32(10);
 export const BIGINT_FIFTY = BigInt.fromI32(50);
 export const BIGINT_HUNDRED = BigInt.fromI32(100);
 export const BIGINT_THOUSAND = BigInt.fromI32(1000);
+export const BIGINT_THREE_THOUSAND = BigInt.fromI32(3000);
 export const BIGINT_FIVE_THOUSAND = BigInt.fromI32(5000);
 export const BIGINT_TEN_THOUSAND = BigInt.fromI32(10000);
-export const BIGINT_THREE_THOUSAND = BigInt.fromI32(25000);
+export const BIGINT_TWENTY_FIVE_THOUSAND = BigInt.fromI32(25000);
 export const BIGINT_ONE_HUNDRED_THOUSAND = BigInt.fromI32(100000);
 export const BIGINT_TWO_HUNDRED_FIFTY_THOUSAND = BigInt.fromI32(250000);
 export const BIGINT_FOUR_HUNDRED_THOUSAND = BigInt.fromI32(400000);
@@ -163,6 +164,9 @@ export const MINIMUM_LIQUIDITY_FIVE_THOUSAND = new BigDecimal(
 );
 export const MINIMUM_LIQUIDITY_TEN_THOUSAND = new BigDecimal(
   BIGINT_TEN_THOUSAND
+);
+export const MINIMUM_LIQUIDITY_TWENTY_FIVE_THOUSAND = new BigDecimal(
+  BIGINT_TWENTY_FIVE_THOUSAND
 );
 export const MINIMUM_LIQUIDITY_ONE_THOUSAND = new BigDecimal(BIGINT_THOUSAND);
 export const MINIMUM_LIQUIDITY_ONE_HUNDRED_THOUSAND = new BigDecimal(

--- a/subgraphs/uniswap-forks/subgraph.yaml
+++ b/subgraphs/uniswap-forks/subgraph.yaml
@@ -1,14 +1,14 @@
-specVersion: 0.0.2
+specVersion: 0.0.4
 schema:
   file: ./schema.graphql
 dataSources:
   - kind: ethereum
     name: Factory
-    network: moonriver
+    network: matic
     source:
-      address: "0x049581aEB6Fe262727f290165C29BDAB065a1B68"
+      address: "0xc35dadb65012ec5796536bd9864ed8773abc74c4"
       abi: Factory
-      startBlock: 424144
+      startBlock: 11333218
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -16,42 +16,48 @@ dataSources:
       entities: []
       abis:
         - name: Factory
-          file: ./abis/solarbeam/Factory.json
+          file: ./abis/sushiswap/Factory.json
         - name: TokenABI
-          file: ./abis/solarbeam/ERC20.json
+          file: ./abis/sushiswap/ERC20.json
       eventHandlers:
         - event: PairCreated(indexed address,indexed address,address,uint256)
           handler: handlePairCreated
       file: ./src/mappings/factory.ts
   - kind: ethereum
-    name: MasterChef
-    network: moonriver
+    name: MiniChef
+    network: matic
     source:
-      address: "0x0329867a8c457e9f75e25b0685011291cd30904f"
-      abi: SolarDistributorV2
-      startBlock: 991038
+      address: "0x0769fd68dFb93167989C6f7254cd0D766Fb2841F"
+      abi: MiniChefSushiswap
+      startBlock: 13911377
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
       language: wasm/assemblyscript
       entities: []
       abis:
-        - name: SolarDistributorV2
-          file: ./abis/solarbeam/SolarDistributorV2.json
+        - name: MiniChefSushiswap
+          file: ./abis/sushiswap/MiniChefSushiswap.json
         - name: TokenABI
-          file: ./abis/solarbeam/ERC20.json
+          file: ./abis/sushiswap/ERC20.json
       eventHandlers:
-        - event: Deposit(indexed address,indexed uint256,uint256)
+        - event: Deposit(indexed address,indexed uint256,uint256,indexed address)
           handler: handleDeposit
-        - event: Withdraw(indexed address,indexed uint256,uint256)
+        - event: Withdraw(indexed address,indexed uint256,uint256,indexed address)
           handler: handleWithdraw
-        - event: EmergencyWithdraw(indexed address,indexed uint256,uint256)
+        - event: EmergencyWithdraw(indexed address,indexed uint256,uint256,indexed address)
           handler: handleEmergencyWithdraw
-      file: ./protocols/solarbeam/src/mappings/masterchef/reward.ts
+        - event: LogSetPool(indexed uint256,uint256,indexed address,bool)
+          handler: handleLogSetPool
+        - event: LogPoolAddition(indexed uint256,uint256,indexed address,indexed address)
+          handler: handleLogPoolAddition
+        - event: LogSushiPerSecond(uint256)
+          handler: handleLogSushiPerSecond
+      file: ./protocols/sushiswap/src/mappings/masterchef/rewardMini.ts
 templates:
   - kind: ethereum/contract
     name: Pair
-    network: moonriver
+    network: matic
     source:
       abi: Pair
     mapping:
@@ -62,11 +68,11 @@ templates:
       entities: []
       abis:
         - name: Pair
-          file: ./abis/solarbeam/Pair.json
+          file: ./abis/sushiswap/Pair.json
         - name: Factory
-          file: ./abis/solarbeam/Factory.json
+          file: ./abis/sushiswap/Factory.json
         - name: TokenABI
-          file: ./abis/solarbeam/ERC20.json
+          file: ./abis/sushiswap/ERC20.json
       eventHandlers:
         - event: Mint(indexed address,uint256,uint256)
           handler: handleMint
@@ -78,4 +84,3 @@ templates:
           handler: handleTransfer
         - event: Sync(uint112,uint112)
           handler: handleSync
-          


### PR DESCRIPTION
**Context**
Updated minimum liquidity for Sushiswap on polygon due to TVL errors, and updated stable oracle pools for Sushiswap on BSC for TVL issues as well. 

**Results:**
Issue #612 - Passed!
Sushiswap BSC and Polygon have already been re-deployed and validated.
