### PR TITLE
fix/refactor(#major); Balancer Forks; Fix bugs with rewards fields, vault mappings, and Balancer Emissions.

### DIFF
--- a/subgraphs/balancer-forks/.gitignore
+++ b/subgraphs/balancer-forks/.gitignore
@@ -1,0 +1,1 @@
+subgraph.yaml

--- a/subgraphs/balancer-forks/README.md
+++ b/subgraphs/balancer-forks/README.md
@@ -1,4 +1,29 @@
-# Balancer v2 Subgraph
+# Balancer Forks
+
+## Rewards
+
+- The GaugeController contract is only used on the Ethereum blockchain for Balancer V2. The other deployments, except Beethoven X Fantom, use the childChainLiquidityGauge contract.
+- The same abi is used for both of these contract types. The ABI named GaugeController uses events from both the GaugeController and childChainLiquidityGauge contracts - an event from the childChainLiquidityGauge is transported of to the GaugeController abi (RewardsOnlyGaugeCreated).
+- The only other example is Beethoven X Fantom which does not use the GaugeController abi. It instead uses the MasterChef V2 contract like Sushiswap to emit rewards to stakers.
+- The updateFactoryRewards() is used to pull all reward tokens and their rates. There can be multiple reward tokens for each Gauge and they can all have separate rates.
+
+## BalancerV2
+
+- Ethereum
+  - Uses the GaugeController contract for creating Gauges
+  - The updateControllerRewards() in rewards.ts will only update rewards for Balancer V2 on ethereum. This function only handles rewards for the BAL token. The starting inflation rate on Ethereum only is 145000 BAL. All other rewards are calculated in the updateFactoryRewards() function.
+  - **NOTE:** BAL can be emitted as a reward on other chains, however, unlike on Ethereum for Balancer V2, it will be calculated along with other reward tokens in the updateFactoryRewards() function.
+- Arbitrum
+  - Uses the childChainLiquidityPool contract for creating Gauges.
+- Polygon
+  - Uses the childChainLiquidityPool contract for creating Gauges.
+
+## Beethoven X
+
+- Fantom
+  - Uses the same logic for liquidity pools as Balancer V2, however it uses a separate mechanism for rewards. Instead of using Gauges, it uses the MasterChef V2 contract.
+- Optimism
+  - Again, uses the same logic for liquidity pools as Balancer V2, and it shares the same reward mechanisms as Balancer V2 on Arbitrum and Polygon.
 
 ## Calculation Methodology v1.0.0
 
@@ -46,6 +71,7 @@ Count of Unique Addresses which have interacted with the protocol via any transa
 `Withdraws`
 
 ### Reward Token Emissions Amount
+
 Note: Currently, 145,000 BAL tokens, or approximately 7.5M per year, are distributed every week through the Liquidity Mining program.
 
 ### Protocol Controlled Value

--- a/subgraphs/balancer-forks/abis/balancer-v2/BalancerTokenAdmin.json
+++ b/subgraphs/balancer-forks/abis/balancer-v2/BalancerTokenAdmin.json
@@ -1,0 +1,243 @@
+[
+  {
+    "inputs": [
+      { "internalType": "contract IVault", "name": "vault", "type": "address" },
+      {
+        "internalType": "contract IBalancerToken",
+        "name": "balancerToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "supply",
+        "type": "uint256"
+      }
+    ],
+    "name": "MiningParametersUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "INITIAL_RATE",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RATE_DENOMINATOR",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RATE_REDUCTION_COEFFICIENT",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RATE_REDUCTION_TIME",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "activate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "available_supply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "futureEpochTimeWrite",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "future_epoch_time_write",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes4", "name": "selector", "type": "bytes4" }
+    ],
+    "name": "getActionId",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAuthorizer",
+    "outputs": [
+      { "internalType": "contract IAuthorizer", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAvailableSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBalancerToken",
+    "outputs": [
+      {
+        "internalType": "contract IBalancerToken",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFutureEpochTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getInflationRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMiningEpoch",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStartEpochSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStartEpochTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVault",
+    "outputs": [
+      { "internalType": "contract IVault", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "start", "type": "uint256" },
+      { "internalType": "uint256", "name": "end", "type": "uint256" }
+    ],
+    "name": "mintableInTimeframe",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "start", "type": "uint256" },
+      { "internalType": "uint256", "name": "end", "type": "uint256" }
+    ],
+    "name": "mintable_in_timeframe",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "snapshot",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startEpochTimeWrite",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "start_epoch_time_write",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "updateMiningParameters",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "update_mining_parameters",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/subgraphs/balancer-forks/protocols/balancer-v2/config/networks/arbitrum/arbitrum.json
+++ b/subgraphs/balancer-forks/protocols/balancer-v2/config/networks/arbitrum/arbitrum.json
@@ -12,9 +12,10 @@
 
   "protocolFeesCollectorAddress": "0xce88686553686DA562CE7Cea497CE749DA109f9F",
   "protocolTokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+  "protocolTokenStartingInflationPerIntervalUnit": 0,
+  "inflationInterval": "NONE",
 
-  "rewardTokenInterval": "NONE",
-  "rewardTokenRate": 0,
+  "usesBalancerTokenAdmin": false,
 
   "graftEnabled": false,
   "subgraphId": "",

--- a/subgraphs/balancer-forks/protocols/balancer-v2/config/networks/ethereum/ethereum.json
+++ b/subgraphs/balancer-forks/protocols/balancer-v2/config/networks/ethereum/ethereum.json
@@ -12,9 +12,12 @@
 
   "protocolFeesCollectorAddress": "0xce88686553686DA562CE7Cea497CE749DA109f9F",
   "protocolTokenAddress": "0xba100000625a3754423978a60c9317c58a424e3D",
+  "protocolTokenStartingInflationPerIntervalUnit": 0.23974867724,
+  "inflationInterval": "TIMESTAMP",
 
-  "rewardTokenInterval": "NONE",
-  "rewardTokenRate": 0,
+  "balancerTokenAdmin": "0xf302f9f50958c5593770fdf4d4812309ff77414f",
+  "balancerTokenAdminStartBlock": 14456738,
+  "usesBalancerTokenAdmin": true,
 
   "graftEnabled": false,
   "subgraphId": "",

--- a/subgraphs/balancer-forks/protocols/balancer-v2/config/networks/polygon/polygon.json
+++ b/subgraphs/balancer-forks/protocols/balancer-v2/config/networks/polygon/polygon.json
@@ -12,9 +12,10 @@
 
   "protocolFeesCollectorAddress": "0xce88686553686DA562CE7Cea497CE749DA109f9F",
   "protocolTokenAddress": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3",
+  "protocolTokenStartingInflationPerIntervalUnit": 0,
+  "inflationInterval": "NONE",
 
-  "rewardTokenInterval": "NONE",
-  "rewardTokenRate": 0,
+  "usesBalancerTokenAdmin": false,
 
   "graftEnabled": false,
   "subgraphId": "",

--- a/subgraphs/balancer-forks/protocols/balancer-v2/config/templates/balancer.v2.template.yaml
+++ b/subgraphs/balancer-forks/protocols/balancer-v2/config/templates/balancer.v2.template.yaml
@@ -80,7 +80,6 @@ dataSources:
           handler: handleSwap
       file: ./src/mappings/vaultMappings.ts
 
-
   - kind: ethereum/contract
     name: GaugeController
     network: {{network}}
@@ -146,7 +145,28 @@ dataSources:
         - event: RewardsOnlyGaugeCreated(indexed address,indexed address,address)
           handler: handleRewardsOnlyGaugeCreated
       file: ./src/mappings/GaugeControllerMappings.ts
-
+{{#usesBalancerTokenAdmin}} 
+  - kind: ethereum/contract
+    name: BalancerTokenAdmin
+    network: {{network}}
+    source:
+      address: "{{balancerTokenAdmin}}"
+      abi: BalancerTokenAdmin
+      startBlock: {{balancerTokenAdminStartBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - DexAmmProtocol
+      abis:
+        - name: BalancerTokenAdmin
+          file: ./abis/balancer-v2/BalancerTokenAdmin.json
+      eventHandlers:
+        - event: MiningParametersUpdated(uint256,uint256)
+          handler: handleMiningParametersUpdated
+      file: ./src/mappings/balancerTokenAdminMappings.ts
+{{/usesBalancerTokenAdmin}} 
 templates:
   - kind: ethereum/contract
     name: WeightedPool

--- a/subgraphs/balancer-forks/protocols/beethoven-x/config/networks/fantom/fantom.json
+++ b/subgraphs/balancer-forks/protocols/beethoven-x/config/networks/fantom/fantom.json
@@ -14,8 +14,8 @@
   "protocolFeesCollectorAddress": "0xc6920d3a369e7c8bd1a22dbe385e11d1f7af948f",
 
   "protocolTokenAddress": "0xF24Bcf4d1e507740041C9cFd2DddB29585aDCe1e",
-  "rewardTokenInterval": "TIMESTAMP",
-  "rewardTokenRate": 0,
+  "protocolTokenStartingInflationPerIntervalUnit": 0,
+  "inflationInterval": "TIMESTAMP",
 
   "gaugeControllerAddress": "0x0000000000000000000000000000000000000000",
 

--- a/subgraphs/balancer-forks/protocols/beethoven-x/config/networks/optimism/optimism.json
+++ b/subgraphs/balancer-forks/protocols/beethoven-x/config/networks/optimism/optimism.json
@@ -13,8 +13,8 @@
   "protocolFeesCollectorAddress": "0xce88686553686DA562CE7Cea497CE749DA109f9F",
 
   "protocolTokenAddress": "0x97513e975a7fA9072c72C92d8000B0dB90b163c5",
-  "rewardTokenInterval": "TIMESTAMP",
-  "rewardTokenRate": 0,
+  "protocolTokenStartingInflationPerIntervalUnit": 0,
+  "inflationInterval": "TIMESTAMP",
 
   "graftEnabled": false,
   "subgraphId": "",

--- a/subgraphs/balancer-forks/schema.graphql
+++ b/subgraphs/balancer-forks/schema.graphql
@@ -72,6 +72,12 @@ type RewardToken @entity {
 
   " The type of the reward token "
   type: RewardTokenType!
+
+  " The rate of inflation of this reward token "
+  _inflationRate: BigDecimal
+
+  " The amount of inflation per day of this reward token "
+  _inflationPerDay: BigDecimal
 }
 
 # Note that trading fee is the fee paid *by* the users, whereas LP fee and

--- a/subgraphs/balancer-forks/src/common/constants.mustache
+++ b/subgraphs/balancer-forks/src/common/constants.mustache
@@ -130,15 +130,11 @@ export const BIGDECIMAL_HUNDRED = BigDecimal.fromString("100");
 export const BIGDECIMAL_NEGATIVE_ONE = BigDecimal.fromString("-1");
 export const BIGDECIMAL_POINT_FOUR = BigDecimal.fromString("0.4");
 
-export const FEE_DENOMINATOR = BigDecimal.fromString("1000000000000000000");
+export const DEFAULT_DECIMALS_DENOMINATOR = BigDecimal.fromString("1000000000000000000");
+export const FEE_DENOMINATOR = DEFAULT_DECIMALS_DENOMINATOR;
 
 export const USDC_DECIMALS = 6;
 export const USDC_DENOMINATOR = BigDecimal.fromString("1000000");
-
-export const WEEKLY_BAL_EMISSIONS = BigDecimal.fromString("145000");
-export const DAILY_BAL_EMISSIONS = WEEKLY_BAL_EMISSIONS.div(
-  BigDecimal.fromString("7")
-);
 
 export const ETH_AVERAGE_BLOCK_PER_HOUR = BigInt.fromI32(3756);
 
@@ -159,5 +155,5 @@ export const GAUGE_CONTROLLER_ADDRESS = Address.fromString(
   "{{gaugeControllerAddress}}"
 );
 
-export const REWARD_TOKEN_INTERVAL = "{{rewardTokenInterval}}";
-export const REWARD_TOKEN_RATE = BigInt.fromI32({{rewardTokenRate}});
+export const INFLATION_INTERVAL = "{{inflationInterval}}";
+export const STARTING_INFLATION_RATE = BigDecimal.fromString(({{protocolTokenStartingInflationPerIntervalUnit}}).toString()).times(DEFAULT_DECIMALS_DENOMINATOR);

--- a/subgraphs/balancer-forks/src/common/constants.ts
+++ b/subgraphs/balancer-forks/src/common/constants.ts
@@ -93,9 +93,9 @@ export namespace NULL {
 }
 
 export namespace Protocol {
-  export const NAME = "Balancer v2";
-  export const SLUG = "balancer-v2";
-  export const NETWORK = Network.MAINNET;
+  export const NAME = "Beethoven X";
+  export const SLUG = "beethoven-x";
+  export const NETWORK = Network.FANTOM;
   export const SCHEMA_VERSION = "1.3.0";
   export const SUBGRAPH_VERSION = "1.1.0";
   export const METHODOLOGY_VERSION = "1.0.0";
@@ -130,15 +130,13 @@ export const BIGDECIMAL_HUNDRED = BigDecimal.fromString("100");
 export const BIGDECIMAL_NEGATIVE_ONE = BigDecimal.fromString("-1");
 export const BIGDECIMAL_POINT_FOUR = BigDecimal.fromString("0.4");
 
-export const FEE_DENOMINATOR = BigDecimal.fromString("1000000000000000000");
+export const DEFAULT_DECIMALS_DENOMINATOR = BigDecimal.fromString(
+  "1000000000000000000"
+);
+export const FEE_DENOMINATOR = DEFAULT_DECIMALS_DENOMINATOR;
 
 export const USDC_DECIMALS = 6;
 export const USDC_DENOMINATOR = BigDecimal.fromString("1000000");
-
-export const WEEKLY_BAL_EMISSIONS = BigDecimal.fromString("145000");
-export const DAILY_BAL_EMISSIONS = WEEKLY_BAL_EMISSIONS.div(
-  BigDecimal.fromString("7")
-);
 
 export const ETH_AVERAGE_BLOCK_PER_HOUR = BigInt.fromI32(3756);
 
@@ -147,17 +145,19 @@ export const ETH_AVERAGE_BLOCK_PER_HOUR = BigInt.fromI32(3756);
 /////////////////////////////////////
 
 export const VAULT_ADDRESS = Address.fromString(
-  "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
+  "0x20dd72Ed959b6147912C2e529F0a0C651c33c9ce"
 );
 export const PROTOCOL_FEES_COLLECTOR_ADDRESS = Address.fromString(
-  "0xce88686553686DA562CE7Cea497CE749DA109f9F"
+  "0xc6920d3a369e7c8bd1a22dbe385e11d1f7af948f"
 );
 export const PROTOCOL_TOKEN_ADDRESS = Address.fromString(
-  "0xba100000625a3754423978a60c9317c58a424e3D"
+  "0xF24Bcf4d1e507740041C9cFd2DddB29585aDCe1e"
 );
 export const GAUGE_CONTROLLER_ADDRESS = Address.fromString(
-  "0xC128468b7Ce63eA702C1f104D55A2566b13D3ABD"
+  "0x0000000000000000000000000000000000000000"
 );
 
-export const REWARD_TOKEN_INTERVAL = "NONE";
-export const REWARD_TOKEN_RATE = BigInt.fromI32(0);
+export const INFLATION_INTERVAL = "TIMESTAMP";
+export const STARTING_INFLATION_RATE = BigDecimal.fromString(
+  (0).toString()
+).times(DEFAULT_DECIMALS_DENOMINATOR);

--- a/subgraphs/balancer-forks/src/common/masterchef/helpers.ts
+++ b/subgraphs/balancer-forks/src/common/masterchef/helpers.ts
@@ -1,4 +1,10 @@
-import { ethereum, BigInt, Address, log } from "@graphprotocol/graph-ts";
+import {
+  ethereum,
+  BigInt,
+  Address,
+  log,
+  BigDecimal,
+} from "@graphprotocol/graph-ts";
 import {
   LiquidityPool,
   _MasterChef,
@@ -8,8 +14,8 @@ import {
   BIGINT_ONE,
   BIGINT_ZERO,
   PROTOCOL_TOKEN_ADDRESS,
-  REWARD_TOKEN_INTERVAL,
-  REWARD_TOKEN_RATE,
+  INFLATION_INTERVAL,
+  STARTING_INFLATION_RATE,
 } from "../constants";
 import { getOrCreateToken } from "../initializers";
 
@@ -52,10 +58,14 @@ export function getOrCreateMasterChef(
   if (!masterChef) {
     masterChef = new _MasterChef(masterChefType);
     masterChef.totalAllocPoint = BIGINT_ZERO;
-    masterChef.rewardTokenInterval = REWARD_TOKEN_INTERVAL;
-    masterChef.rewardTokenRate = REWARD_TOKEN_RATE;
+    masterChef.rewardTokenInterval = INFLATION_INTERVAL;
+    masterChef.rewardTokenRate = BigInt.fromString(
+      STARTING_INFLATION_RATE.toString()
+    );
     log.warning("MasterChef Type: " + masterChefType, []);
-    masterChef.adjustedRewardTokenRate = REWARD_TOKEN_RATE;
+    masterChef.adjustedRewardTokenRate = BigInt.fromString(
+      STARTING_INFLATION_RATE.toString()
+    );
     masterChef.lastUpdatedRewardRate = BIGINT_ZERO;
     masterChef.save();
   }

--- a/subgraphs/balancer-forks/src/common/utils.ts
+++ b/subgraphs/balancer-forks/src/common/utils.ts
@@ -1,5 +1,4 @@
 import {
-  log,
   BigInt,
   Address,
   ethereum,
@@ -12,13 +11,11 @@ import {
   getOrCreateDexAmmProtocol,
   getOrCreateLiquidityPoolFee,
 } from "./initializers";
-import { getUsdPricePerToken } from "../prices";
 import * as constants from "../common/constants";
 import { PoolFeesType, PoolTokensType } from "./types";
 import { Token, LiquidityPool } from "../../generated/schema";
 import { Vault as VaultContract } from "../../generated/Vault/Vault";
 import { ERC20 as ERC20Contract } from "../../generated/Vault/ERC20";
-import { Gauge as LiquidityGaugeContract } from "../../generated/templates/gauge/Gauge";
 import { WeightedPool as WeightedPoolContract } from "../../generated/templates/WeightedPool/WeightedPool";
 import { FeesCollector as FeesCollectorContract } from "../../generated/templates/WeightedPool/FeesCollector";
 import {
@@ -112,19 +109,6 @@ export function getOutputTokenPriceUSD(
   outputToken.save();
 
   return outputTokenPriceUSD;
-}
-
-export function getPoolFromGauge(gaugeAddress: Address): Address | null {
-  const gaugeContract = LiquidityGaugeContract.bind(gaugeAddress);
-
-  let poolAddress = readValue<Address>(
-    gaugeContract.try_lp_token(),
-    constants.NULL.TYPE_ADDRESS
-  );
-
-  if (poolAddress.equals(constants.NULL.TYPE_ADDRESS)) return null;
-
-  return poolAddress;
 }
 
 export function calculateAverage(prices: BigDecimal[]): BigDecimal {

--- a/subgraphs/balancer-forks/src/mappings/balancerTokenAdminMappings.ts
+++ b/subgraphs/balancer-forks/src/mappings/balancerTokenAdminMappings.ts
@@ -1,0 +1,25 @@
+import { BigDecimal } from "@graphprotocol/graph-ts";
+import { MiningParametersUpdated } from "../../generated/BalancerTokenAdmin/BalancerTokenAdmin";
+import * as constants from "../common/constants";
+import { getOrCreateRewardToken } from "../common/initializers";
+import { getRewardsPerDay } from "../common/rewards";
+
+export function handleMiningParametersUpdated(
+  event: MiningParametersUpdated
+): void {
+  let protocolToken = getOrCreateRewardToken(
+    constants.PROTOCOL_TOKEN_ADDRESS,
+    constants.RewardTokenType.DEPOSIT,
+    event.block
+  );
+  protocolToken._inflationRate = BigDecimal.fromString(
+    event.params.rate.toString()
+  );
+  protocolToken._inflationPerDay = getRewardsPerDay(
+    event.block.timestamp,
+    event.block.number,
+    protocolToken._inflationRate!,
+    constants.INFLATION_INTERVAL
+  );
+  protocolToken.save();
+}

--- a/subgraphs/balancer-forks/src/mappings/gaugeMappings.ts
+++ b/subgraphs/balancer-forks/src/mappings/gaugeMappings.ts
@@ -4,6 +4,7 @@ import {
   updateUsageMetrics,
 } from "../modules/Metrics";
 import {
+  getPoolFromGauge,
   updateControllerRewards,
   updateFactoryRewards,
 } from "../modules/Rewards";
@@ -17,7 +18,7 @@ import {
 export function handleDeposit(event: Deposit): void {
   const gaugeAddress = event.address;
   const provider = event.params.provider;
-  const poolAddress = utils.getPoolFromGauge(gaugeAddress);
+  const poolAddress = getPoolFromGauge(gaugeAddress);
 
   if (!poolAddress) return;
 
@@ -32,7 +33,7 @@ export function handleDeposit(event: Deposit): void {
 export function handleWithdraw(event: Withdraw): void {
   const gaugeAddress = event.address;
   const provider = event.params.provider;
-  const poolAddress = utils.getPoolFromGauge(gaugeAddress);
+  const poolAddress = getPoolFromGauge(gaugeAddress);
 
   if (!poolAddress) return;
 
@@ -46,7 +47,7 @@ export function handleWithdraw(event: Withdraw): void {
 
 export function handleUpdateLiquidityLimit(event: UpdateLiquidityLimit): void {
   const gaugeAddress = event.address;
-  const poolAddress = utils.getPoolFromGauge(gaugeAddress);
+  const poolAddress = getPoolFromGauge(gaugeAddress);
 
   if (!poolAddress) return;
 

--- a/subgraphs/balancer-forks/src/mappings/vaultMappings.ts
+++ b/subgraphs/balancer-forks/src/mappings/vaultMappings.ts
@@ -45,6 +45,9 @@ export function handleTokensRegistered(event: TokensRegistered): void {
   let inputTokens: string[] = [];
   let inputTokenLength = tokens.length;
   for (let idx = 0; idx < inputTokenLength; idx++) {
+    // Exception: StablePoolFactory added poolAddress in event params token
+    if (tokens.at(idx).equals(poolAddress)) continue;
+
     inputTokens.push(getOrCreateToken(tokens.at(idx), event.block.number).id);
   }
 

--- a/subgraphs/balancer-forks/src/modules/Rewards.ts
+++ b/subgraphs/balancer-forks/src/modules/Rewards.ts
@@ -10,7 +10,7 @@ import { getRewardsPerDay } from "../common/rewards";
 import { log, BigInt, Address, ethereum } from "@graphprotocol/graph-ts";
 import { Gauge as LiquidityGaugeContract } from "../../generated/templates/gauge/Gauge";
 import { GaugeController as GaugeControllereContract } from "../../generated/GaugeController/GaugeController";
-import { RewardTokenType } from "../common/constants";
+import { readValue } from "../common/utils";
 
 export function getRewardsData(gaugeAddress: Address): RewardsInfoType {
   let rewardRates: BigInt[] = [];
@@ -194,4 +194,17 @@ export function updateRewardTokenEmissions(
   pool.rewardTokenEmissionsUSD = rewardTokenEmissionsUSD;
 
   pool.save();
+}
+
+export function getPoolFromGauge(gaugeAddress: Address): Address | null {
+  const gaugeContract = LiquidityGaugeContract.bind(gaugeAddress);
+
+  let poolAddress = readValue<Address>(
+    gaugeContract.try_lp_token(),
+    constants.NULL.TYPE_ADDRESS
+  );
+
+  if (poolAddress.equals(constants.NULL.TYPE_ADDRESS)) return null;
+
+  return poolAddress;
 }

--- a/subgraphs/balancer-forks/src/modules/Rewards.ts
+++ b/subgraphs/balancer-forks/src/modules/Rewards.ts
@@ -73,8 +73,8 @@ export function updateControllerRewards(
     constants.RewardTokenType.DEPOSIT,
     block
   );
-  // Daily BAL emissions is currently known as a static value, but it may be changed in the future.
-  // FOLLOW UP: How to keep track of the daily emission rate?
+
+  // Get the rewards per day for this gauge
   let protocolTokenRewardEmissionsPerDay =
     protocolToken._inflationPerDay!.times(gaugeRelativeWeight);
 

--- a/subgraphs/balancer-forks/src/modules/masterChefV2Rewards.ts
+++ b/subgraphs/balancer-forks/src/modules/masterChefV2Rewards.ts
@@ -10,6 +10,7 @@ import {
   INT_ZERO,
   MasterChef,
   PROTOCOL_TOKEN_ADDRESS,
+  RewardTokenType,
 } from "../../src/common/constants";
 import {
   convertTokenToDecimal,
@@ -38,7 +39,11 @@ export function updateMasterChef(
     event.block.number
   );
   pool.rewardTokens = [
-    getOrCreateRewardToken(PROTOCOL_TOKEN_ADDRESS, event.block.number).id,
+    getOrCreateRewardToken(
+      PROTOCOL_TOKEN_ADDRESS,
+      RewardTokenType.DEPOSIT,
+      event.block
+    ).id,
   ];
 
   // Calculate Reward Emission per second to a specific pool

--- a/subgraphs/balancer-forks/subgraph.yaml
+++ b/subgraphs/balancer-forks/subgraph.yaml
@@ -1,34 +1,38 @@
-specVersion: 0.0.5
+specVersion: 0.0.4
 repository: https://github.com/messari/subgraphs
 schema:
   file: ./schema.graphql
+features:
+  - grafting
 dataSources:
   - kind: ethereum/contract
     name: Vault
-    network: mainnet
+    network: fantom
     source:
-      address: "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
+      address: "0x20dd72Ed959b6147912C2e529F0a0C651c33c9ce"
       abi: Vault
-      startBlock: 12272146
+      startBlock: 16896079
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
       language: wasm/assemblyscript
+      file: ./src/mappings/vaultMappings.ts
       entities:
         - DexAmmProtocol
+        - Token
+        - LiquidityPool
+        - Swap
+        - DailyActiveAccount
+        - Account
       abis:
         - name: Vault
-          file: ./abis/balancer-v2/Vault.json
+          file: ./abis/beethoven-x/Vault.json
         - name: WeightedPool
-          file: ./abis/balancer-v2/WeightedPool.json
-        - name: Gauge
-          file: ./abis/balancer-v2/Gauge.json
-        - name: GaugeController
-          file: ./abis/balancer-v2/GaugeController.json
+          file: ./abis/beethoven-x/WeightedPool.json
         - name: FeesCollector
-          file: ./abis/balancer-v2/ProtocolFeesCollector.json
+          file: ./abis/beethoven-x/ProtocolFeesCollector.json
         - name: ERC20
-          file: ./abis/balancer-v2/ERC20.json
+          file: ./abis/beethoven-x/ERC20.json
 
         ###########################################
         ############## Price Oracle ###############
@@ -71,35 +75,29 @@ dataSources:
           handler: handlePoolBalanceChanged
         - event: Swap(indexed bytes32,indexed address,indexed address,uint256,uint256)
           handler: handleSwap
-      file: ./src/mappings/vaultMappings.ts
-
 
   - kind: ethereum/contract
-    name: GaugeController
-    network: mainnet
+    name: MasterChefV2
+    network: fantom
     source:
-      address: "0xC128468b7Ce63eA702C1f104D55A2566b13D3ABD"
-      abi: GaugeController
-      startBlock: 14457014
+      address: "0x8166994d9ebBe5829EC86Bd81258149B87faCfd3"
+      abi: MasterChefV2
+      startBlock: 18508347
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
       language: wasm/assemblyscript
+      file: ./src/mappings/masterChefV2Mappings.ts
       entities:
-        - DexAmmProtocol
+        - MasterChefV2
+        - Pool
+        - User
+        - Rewarder
       abis:
-        - name: GaugeController
-          file: ./abis/balancer-v2/GaugeController.json
-        - name: Gauge
-          file: ./abis/balancer-v2/Gauge.json
-        - name: Vault
-          file: ./abis/balancer-v2/Vault.json
-        - name: WeightedPool
-          file: ./abis/balancer-v2/WeightedPool.json
-        - name: FeesCollector
-          file: ./abis/balancer-v2/ProtocolFeesCollector.json
+        - name: MasterChefV2
+          file: ./abis/beethoven-x/masterchef/MasterChefV2.json
         - name: ERC20
-          file: ./abis/balancer-v2/ERC20.json
+          file: ./abis/beethoven-x/ERC20.json
 
         ###########################################
         ############## Price Oracle ###############
@@ -133,40 +131,41 @@ dataSources:
           file: ./abis/Prices/SushiSwap/Pair.json
         - name: CalculationsSushiSwap
           file: ./abis/Prices/Calculations/SushiSwap.json
+        
       eventHandlers:
-        - event: NewGauge(address,int128,uint256)
-          handler: handleNewGauge
-        - event: RewardsOnlyGaugeCreated(indexed address,indexed address,address)
-          handler: handleRewardsOnlyGaugeCreated
-      file: ./src/mappings/GaugeControllerMappings.ts
+        - event: Deposit(indexed address,indexed uint256,uint256,indexed address)
+          handler: handleDeposit
+        - event: Withdraw(indexed address,indexed uint256,uint256,indexed address)
+          handler: handleWithdraw
+        - event: EmergencyWithdraw(indexed address,indexed uint256,uint256,indexed address)
+          handler: handleEmergencyWithdraw
+        - event: LogSetPool(indexed uint256,uint256,indexed address,bool)
+          handler: handleLogSetPool
+        - event: LogPoolAddition(indexed uint256,uint256,indexed address,indexed address)
+          handler: handleLogPoolAddition
+        - event: UpdateEmissionRate(indexed address,uint256)
+          handler: handleUpdateEmissionRate
 
 templates:
   - kind: ethereum/contract
     name: WeightedPool
-    network: mainnet
+    network: fantom
     source:
       abi: WeightedPool
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
       language: wasm/assemblyscript
+      file: ./src/mappings/poolMappings.ts
       entities:
         - WeightedPool
         - LiquidityPoolFee
       abis:
         - name: WeightedPool
-          file: ./abis/balancer-v2/WeightedPool.json
-        - name: Vault
-          file: ./abis/balancer-v2/Vault.json
+          file: ./abis/beethoven-x/WeightedPool.json
         - name: FeesCollector
-          file: ./abis/balancer-v2/ProtocolFeesCollector.json
-        - name: Gauge
-          file: ./abis/balancer-v2/Gauge.json
-        - name: GaugeController
-          file: ./abis/balancer-v2/GaugeController.json
-        - name: ERC20
-          file: ./abis/balancer-v2/ERC20.json
-        
+          file: ./abis/beethoven-x/ProtocolFeesCollector.json
+
         ###########################################
         ############## Price Oracle ###############
         ###########################################
@@ -199,74 +198,7 @@ templates:
           file: ./abis/Prices/SushiSwap/Pair.json
         - name: CalculationsSushiSwap
           file: ./abis/Prices/Calculations/SushiSwap.json
+          
       eventHandlers:
         - event: SwapFeePercentageChanged(uint256)
-          handler: handleSwapFeePercentageChanged
-      file: ./src/mappings/poolMappings.ts
-
-  - kind: ethereum/contract
-    name: Gauge
-    network: mainnet
-    source:
-      abi: Gauge
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      entities:
-        - WeightedPool
-        - LiquidityPoolFee
-      abis:
-        - name: Gauge
-          file: ./abis/balancer-v2/Gauge.json
-        - name: GaugeController
-          file: ./abis/balancer-v2/GaugeController.json
-        - name: Vault
-          file: ./abis/balancer-v2/Vault.json
-        - name: WeightedPool
-          file: ./abis/balancer-v2/WeightedPool.json
-        - name: FeesCollector
-          file: ./abis/balancer-v2/ProtocolFeesCollector.json
-        - name: ERC20
-          file: ./abis/balancer-v2/ERC20.json
-        
-        ###########################################
-        ############## Price Oracle ###############
-        ###########################################
-        # Curve Contracts
-        - name: CurveRegistry
-          file: ./abis/Prices/Curve/Registry.json
-        - name: CurvePoolRegistry
-          file: ./abis/Prices/Curve/PoolRegistry.json
-        - name: CalculationsCurve
-          file: ./abis/Prices/Calculations/Curve.json
-        # YearnLens Contracts
-        - name: YearnLensContract
-          file: ./abis/Prices/YearnLens.json
-        # ChainLink Contracts
-        - name: ChainLinkContract
-          file: ./abis/Prices/ChainLink.json
-        # Uniswap Contracts
-        - name: UniswapRouter
-          file: ./abis/Prices/Uniswap/Router.json
-        - name: UniswapFactory
-          file: ./abis/Prices/Uniswap/Factory.json
-        - name: UniswapPair
-          file: ./abis/Prices/Uniswap/Pair.json
-        # SushiSwap Contracts
-        - name: SushiSwapRouter
-          file: ./abis/Prices/SushiSwap/Router.json
-        - name: SushiSwapFactory
-          file: ./abis/Prices/SushiSwap/Factory.json
-        - name: SushiSwapPair
-          file: ./abis/Prices/SushiSwap/Pair.json
-        - name: CalculationsSushiSwap
-          file: ./abis/Prices/Calculations/SushiSwap.json
-      eventHandlers:
-        - event: Deposit(indexed address,uint256)
-          handler: handleDeposit
-        - event: Withdraw(indexed address,uint256)
-          handler: handleWithdraw
-        - event: UpdateLiquidityLimit(indexed address,uint256,uint256,uint256,uint256)
-          handler: handleUpdateLiquidityLimit
-      file: ./src/mappings/gaugeMappings.ts
+          handler: handleSwapFeePercentageChange


### PR DESCRIPTION
**Beethoven X Fantom is set to deploy on merging this PR. We should consider re-deploying all of Balancer V2 as well since the stakedOutputTokenAmount and rewardEmissions will be off.**


**Bug Fixes:**
- The calculation of the LiquidityPool stakedOutputTokenAmount field needed to be done in the updateFactoryRewards function. This way the staked token amount will be calculated properly for all gauges on all networks. Before it was only working for Balancer V2 on Ethereum.
- Needed to add an exception here as per Phoenix's request for registering tokens in vault mappings -> https://github.com/harsh9200/subgraphs/blob/Balancer-v2--Polygon-and-Arbitrium-support/subgraphs/balancer-forks/src/mappings/vaultMappings.ts#L47-L48
- Balancer emissions from the gauge controller were assumed to be static at 145,000 per week. With the introduction of veBAL, however, these emissions are set to decrease over time and updatable through governance. I added 2 fields to the RewardToken entity to track the rates. You can watch for updates in the MiningParametersUpdated event in this contract -> https://etherscan.io/address/0xf302f9f50958c5593770fdf4d4812309ff77414f#readContract. Learn more about this here -> https://forum.balancer.fi/t/introducing-vebal-tokenomics/2512#new-proposed-bal-inflation-schedule-4.
- Fixed reward token id to include the type in front of the address separated by a hyphen.
- Moved getPoolFromGauge() function out of utils so Beethoven X Fantom can deploy. This function requires loading in the gauge contract which Beethoven X Fantom does not use.