### PR TITLE
fix(#patch): euler finance; fix market rate calculation & divide by 0

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -455,7 +455,7 @@
       "euler": {
         "ethereum": {
           "template": "euler.template.yaml",
-          "deploy-on-merge": false
+          "deploy-on-merge": true
         }
       }
     },

--- a/subgraphs/euler/src/common/constants.ts
+++ b/subgraphs/euler/src/common/constants.ts
@@ -8,7 +8,7 @@ import { Address, BigDecimal, BigInt } from "@graphprotocol/graph-ts";
 export const PROTOCOL_NAME = "Euler";
 export const PROTOCOL_SLUG = "euler";
 export const PROTOCOL_SCHEMA_VERSION = "1.2.1";
-export const PROTOCOL_SUBGRAPH_VERSION = "1.0.2";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.0.3";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 
 ////////////////////////

--- a/subgraphs/euler/src/mappings/helpers.ts
+++ b/subgraphs/euler/src/mappings/helpers.ts
@@ -366,10 +366,10 @@ export function syncWithEulerGeneralView(
 
         market.outputTokenPriceUSD = eTokenPriceUSD;
         market.outputTokenSupply = eTokenTotalSupply;
-        market.exchangeRate = eTokenTotalSupply
+        market.exchangeRate = eulerViewMarket.totalBalances
           .toBigDecimal()
-          .div(eTokenPrecision)
-          .div(eulerViewMarket.totalBalances.toBigDecimal().div(tokenPrecision));
+          .div(tokenPrecision)
+          .div(eTokenTotalSupply.toBigDecimal().div(eTokenPrecision));
       }
     }
 


### PR DESCRIPTION

It seems we were calculating the `depositToken<>outputToken` exchangeRate the other way around.

If `exchangeRate` is the amount of input tokens a full share of output tokens is worth, then it should be `total deposited input tokens / output token supply`. We were calculating the inverse instead. 

This was causing syncing errors becuase of eventually dividing by 0, when a pool is left empty.

I checked other protocols to see if it was our own particular way of calculating it, but no, it is wrong 😅 
Maple finance, for example, [does it right.](https://github.com/messari/subgraphs/blob/master/subgraphs/maple-finance/src/common/mappingHelpers/update/intervalUpdate.ts#L84)