### PR TITLE
feat(#minor); CI/CD; Add capability to deploy only and add action to test builds on pushing to the remote branched in this repo.

### DIFF
--- a/.github/workflows/build-checker.yaml
+++ b/.github/workflows/build-checker.yaml
@@ -1,7 +1,7 @@
 on: 
   push:
-    branches:
-      master
+    branches-ignore:
+        - master
 
 jobs:
   Deployment: 
@@ -12,20 +12,10 @@ jobs:
         continue-on-error: true
 
       - uses: actions/checkout@v2
-      - uses: steegecs/Action-Subgraph-Deployment@main
+      - uses: steegecs/Subgraph-Build-Checker@main
         with: 
           HOSTED_SERVICE_ACCESS_TOKEN: ${{ secrets.HOSTED_SERVICE_ACCESS_TOKEN }}
           CHANGED_FILES: "${{ steps.files.outputs.all }}"
           ABSOLUTE_PATH: ${{ github.workspace }}
           GRAPH_DEPLOYMENT_LOCATION: messari
-
-      # - uses: steegecs/Messari-Deployment-Config-Reset@main
-      #   with: 
-      #     ABSOLUTE_PATH: ${{ github.workspace }}
-
-      # - uses: EndBug/add-and-commit@v9
-      #   with:
-      #     add: '.'
-      #     commit: --signoff
-      #     push: true
-
+          

--- a/deployment/deployment.js
+++ b/deployment/deployment.js
@@ -19,7 +19,8 @@ if (
   args.network === undefined ||
   args.location === undefined ||
   args.printlogs === undefined ||
-  args.merge === undefined
+  args.merge === undefined ||
+  args.type === undefined
 ) {
   console.log(
     "Usage: node deployment.js --subgraph=" +
@@ -33,13 +34,20 @@ if (
       " --printlogs=" +
       args.printlogs +
       " --merge=" +
-      args.merge
+      args.merge +
+      " --type=" +
+      args.type
   );
   console.log(
     "Please check subgraph:deploy script in package.json. Make sure it matches example script in the deployments folder. "
   );
 } else if (!args.subgraph || !args.location) {
   console.log("Please provide at least --SUBGRAPH and --LOCATION");
+} else if (
+  args.type &&
+  !["build", "deploy"].includes(args.type.toLowerCase())
+) {
+  console.log("Please provide --TYPE=build or --TYPE=deploy");
 } else if (args.subgraph && args.protocol && args.network && args.location) {
   if (args.subgraph in protocolNetworkMap == false) {
     console.log(
@@ -92,7 +100,14 @@ if (
     } else {
       allScripts.set(
         location,
-        scripts(protocol, network, template, location, prepareConstants)
+        scripts(
+          protocol,
+          network,
+          template,
+          location,
+          prepareConstants,
+          args.type
+        )
       );
     }
     runCommands(allScripts, results, args, function (results) {});
@@ -140,13 +155,21 @@ if (
             "deploy-on-merge"
           ]
         ) &&
-        ["true", "t"].includes(args.merge.toLowerCase())
+        ["true", "t"].includes(args.merge.toLowerCase()) &&
+        args.deploy != "build"
       ) {
         results += "Ignored in Deployment Configurations: " + location + "\n";
       } else {
         allScripts.set(
           location,
-          scripts(protocol, network, template, location, prepareConstants)
+          scripts(
+            protocol,
+            network,
+            template,
+            location,
+            prepareConstants,
+            args.type
+          )
         );
       }
     }
@@ -198,7 +221,14 @@ if (
         } else {
           allScripts.set(
             location,
-            scripts(protocol, network, template, location, prepareConstants)
+            scripts(
+              protocol,
+              network,
+              template,
+              location,
+              prepareConstants,
+              args.type
+            )
           );
         }
       }

--- a/deployment/deployment.js
+++ b/deployment/deployment.js
@@ -43,10 +43,7 @@ if (
   );
 } else if (!args.subgraph || !args.location) {
   console.log("Please provide at least --SUBGRAPH and --LOCATION");
-} else if (
-  args.type &&
-  !["build", "deploy"].includes(args.type.toLowerCase())
-) {
+} else if (!["build", "deploy", ""].includes(args.type.toLowerCase())) {
   console.log("Please provide --TYPE=build or --TYPE=deploy");
 } else if (args.subgraph && args.protocol && args.network && args.location) {
   if (args.subgraph in protocolNetworkMap == false) {

--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -778,13 +778,13 @@
           "template": "apeswap.bsc.template.yaml",
           "steegecs": "steegecs/apeswap-bsc",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "polygon": {
           "template": "apeswap.matic.template.yaml",
           "steegecs": "steegecs/apeswap-matic",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "mm-finance": {
@@ -792,7 +792,7 @@
           "template": "mm.finance.template.yaml",
           "messari": "messari/mm-finance-polygon",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "quickswap": {
@@ -801,7 +801,7 @@
           "steegecs": "steegecs/quickswap-matic",
           "messari": "messari/quickswap-polygon",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "solarbeam": {
@@ -810,7 +810,7 @@
           "steegecs": "steegecs/solarbeam-moonriver",
           "messari": "messari/solarbeam-moonriver",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "spiritswap": {
@@ -819,7 +819,7 @@
           "steegecs": "steegecs/spiritswap-fantom",
           "messari": "messari/spiritswap-fantom",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "spookyswap": {
@@ -828,24 +828,24 @@
           "steegecs": "steegecs/spookyswap-fantom",
           "messari": "messari/spookyswap-fantom",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "sushiswap": {
         "arbitrum": {
           "template": "sushiswap.alt.template.yaml",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "avalanche": {
           "template": "uniswap.v2.template.yaml",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "bsc": {
           "template": "uniswap.v2.template.yaml",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "celo": {
           "template": "sushiswap.alt.template.yaml",
@@ -855,44 +855,44 @@
         "fantom": {
           "template": "sushiswap.alt.template.yaml",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "fuse": {
           "template": "sushiswap.alt.template.yaml",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "ethereum": {
           "template": "sushiswap.mainnet.template.yaml",
           "steegecs": "steegecs/sushiswap-mainnet",
           "messari": "messari/sushiswap-ethereum",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "polygon": {
           "template": "sushiswap.alt.template.yaml",
           "steegecs": "steegecs/sushiswap-matic",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "moonbeam": {
           "template": "sushiswap.alt.template.yaml",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "moonriver": {
           "template": "sushiswap.alt.template.yaml",
           "steegecs": "steegecs/sushiswap-moonriver",
           "messari": "messari/sushiswap-moonriver",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "gnosis": {
           "template": "sushiswap.alt.template.yaml",
           "steegecs": "steegecs/sushiswap-xdai",
           "messari": "messari/sushiswap-gnosis",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "trader-joe": {
@@ -901,7 +901,7 @@
           "steegecs": "steegecs/trader-joe-avalanche",
           "messari": "messari/trader-joe-avalanche",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "trisolaris": {
@@ -910,7 +910,7 @@
           "steegecs": "steegecs/trisolaris-aurora",
           "messari": "messari/trisolaris-aurora",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "ubeswap": {
@@ -920,7 +920,7 @@
           "messari": "messari/ubeswap-celo",
           "sevenshi": "sevenshi/ubeswap_celo",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "uniswap-v2": {
@@ -928,7 +928,7 @@
           "template": "uniswap.v2.template.yaml",
           "steegecs": "steegecs/uniswap-v2",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "vvs-finance": {
@@ -937,7 +937,7 @@
           "steegecs": "steegecs/trisolaris-aurora",
           "messari": "messari/trisolaris-aurora",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       },
       "honeyswap": {
@@ -946,13 +946,13 @@
           "mrbrianhobo": "mrbrianhobo/honeyswap-xdai",
           "messari": "messari/honeyswap-gnosis",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         },
         "polygon": {
           "template": "honeyswap.matic.template.yaml",
           "mrbrianhobo": "mrbrianhobo/honeyswap-polygon",
           "deploy-on-merge": false,
-          "prepare:constants": false
+          "prepare:constants": true
         }
       }
     },

--- a/deployment/execution.js
+++ b/deployment/execution.js
@@ -41,10 +41,15 @@ function scripts(protocol, network, template, location, constants, type) {
   }
   scripts.push(codegen);
 
-  if (type == "build") {
+  // Null value for type assumes you want to deploy
+  if (type == null) {
+    scripts.push(deployment);
+  } else if (type == "deploy") {
+    scripts.push(deployment);
+  } else if (type == "build") {
     scripts.push(build);
   } else {
-    scripts.push(deployment);
+    console.log("Error: invalid type - Neither build nor deploy");
   }
 
   return scripts;

--- a/deployment/execution.js
+++ b/deployment/execution.js
@@ -7,8 +7,10 @@ const fs = require("fs");
  * @param {string} template - Template location that will be used to create subgraph.yaml
  * @param {string} location - Location in the subgraph will be deployed to {e.g. messari/uniswap-v2-ethereum}
  */
-function scripts(protocol, network, template, location, constants) {
+function scripts(protocol, network, template, location, constants, type) {
   let scripts = [];
+  let removeGenerated = "rm -rf generated";
+  let removeBuild = "rm -rf build";
   let removeResults = "rm -rf results.txt";
   let removeConfig = "rm -rf configurations/configure.ts";
   let removeSubgraphYaml = "rm -rf subgraph.yaml";
@@ -25,8 +27,11 @@ function scripts(protocol, network, template, location, constants) {
     " --NETWORK=" +
     network;
   let codegen = "graph codegen";
+  let build = "graph build";
   let deployment = "npm run deploy:subgraph --LOCATION=" + location;
 
+  scripts.push(removeGenerated);
+  scripts.push(removeBuild);
   scripts.push(removeResults);
   scripts.push(removeConfig);
   scripts.push(removeSubgraphYaml);
@@ -35,7 +40,12 @@ function scripts(protocol, network, template, location, constants) {
     scripts.push(prepareConstants);
   }
   scripts.push(codegen);
-  scripts.push(deployment);
+
+  if (type == "build") {
+    scripts.push(build);
+  } else {
+    scripts.push(deployment);
+  }
 
   return scripts;
 }
@@ -98,8 +108,17 @@ async function runCommands(allScripts, results, args, callback) {
               );
             } else {
               logs = logs + "Exec error: " + error;
-              results +=
-                "Deployment Failed: " + allDeployments[deploymentIndex] + "\n";
+
+              if (args.type == "build") {
+                results +=
+                  "Build Failed: " + allDeployments[deploymentIndex] + "\n";
+              } else {
+                results +=
+                  "Deployment Failed: " +
+                  allDeployments[deploymentIndex] +
+                  "\n";
+              }
+
               console.log(error);
               deploymentIndex++;
               scriptIndex = 0;
@@ -109,8 +128,15 @@ async function runCommands(allScripts, results, args, callback) {
             scriptIndex ==
             allScripts.get(allDeployments[deploymentIndex]).length
           ) {
-            results +=
-              "Deployment Successful: " + allDeployments[deploymentIndex] + "\n";
+            if ((args.type = "build")) {
+              results +=
+                "Build Successful: " + allDeployments[deploymentIndex] + "\n";
+            } else {
+              results +=
+                "Deployment Successful: " +
+                allDeployments[deploymentIndex] +
+                "\n";
+            }
             deploymentIndex++;
             scriptIndex = 0;
             httpCounter = 1;

--- a/deployment/execution.js
+++ b/deployment/execution.js
@@ -42,11 +42,9 @@ function scripts(protocol, network, template, location, constants, type) {
   scripts.push(codegen);
 
   // Null value for type assumes you want to deploy
-  if (type == null) {
+  if (["deploy", ""].includes(type.toLowerCase())) {
     scripts.push(deployment);
-  } else if (type == "deploy") {
-    scripts.push(deployment);
-  } else if (type == "build") {
+  } else if (type.toLowerCase() == "build") {
     scripts.push(build);
   } else {
     console.log("Error: invalid type - Neither build nor deploy");
@@ -133,7 +131,7 @@ async function runCommands(allScripts, results, args, callback) {
             scriptIndex ==
             allScripts.get(allDeployments[deploymentIndex]).length
           ) {
-            if ((args.type = "build")) {
+            if (args.type == "build") {
               results +=
                 "Build Successful: " + allDeployments[deploymentIndex] + "\n";
             } else {

--- a/deployment/package.json
+++ b/deployment/package.json
@@ -7,7 +7,7 @@
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --deploy=$(npm_config_deploy)"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.28.0",

--- a/subgraphs/aave-governance/package.json
+++ b/subgraphs/aave-governance/package.json
@@ -9,7 +9,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ danielkhoo/aave-governance",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 danielkhoo/aave-governance",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-ts": "0.27.0"

--- a/subgraphs/aave-v2-forks/package.json
+++ b/subgraphs/aave-v2-forks/package.json
@@ -7,7 +7,7 @@
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "prepare:build": "graph codegen && graph build",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-ts": "^0.27.0",

--- a/subgraphs/aave-v3/package.json
+++ b/subgraphs/aave-v3/package.json
@@ -8,7 +8,7 @@
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:build": "graph codegen && graph build",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}",
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}",
     "create-local": "graph create --node http://localhost:8020/ aave-v3",
     "remove-local": "graph remove --node http://localhost:8020/ aave-v3",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 aave-v3"

--- a/subgraphs/abracadabra/package.json
+++ b/subgraphs/abracadabra/package.json
@@ -7,7 +7,7 @@
     "build": "graph build",
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.33.0",

--- a/subgraphs/arrakis-finance/package.json
+++ b/subgraphs/arrakis-finance/package.json
@@ -4,12 +4,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.30.1",

--- a/subgraphs/badgerdao/package.json
+++ b/subgraphs/badgerdao/package.json
@@ -4,12 +4,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-    
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
-    
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.32.0",

--- a/subgraphs/balancer-forks/package.json
+++ b/subgraphs/balancer-forks/package.json
@@ -9,7 +9,7 @@
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json src/common/constants.mustache > src/common/constants.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
     "deploy:local": "yarn prepare:yaml &&  yarn prepare:constants &&    node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.32.0",

--- a/subgraphs/bancor-v3/package.json
+++ b/subgraphs/bancor-v3/package.json
@@ -6,12 +6,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-ts": "0.27.0"

--- a/subgraphs/beefy-finance/package.json
+++ b/subgraphs/beefy-finance/package.json
@@ -7,7 +7,7 @@
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.29.2",

--- a/subgraphs/belt-finance/package.json
+++ b/subgraphs/belt-finance/package.json
@@ -4,15 +4,12 @@
   "scripts": {
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint \"src/**/*.ts\" --fix",
-
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.28.0",

--- a/subgraphs/compound-forks/package.json
+++ b/subgraphs/compound-forks/package.json
@@ -7,7 +7,7 @@
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "prepare:build": "graph codegen && graph build",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-ts": "^0.27.0",

--- a/subgraphs/convex-finance/package.json
+++ b/subgraphs/convex-finance/package.json
@@ -4,12 +4,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.32.0",

--- a/subgraphs/curve-finance/package.json
+++ b/subgraphs/curve-finance/package.json
@@ -6,7 +6,7 @@
     "build": "graph build",
     "prepare:yaml": "mustache protocols/curve-finance/networks/mainnet/mainnet.json protocols/curve-finance/templates/curve.template.yaml > subgraph.yaml",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.32.0",

--- a/subgraphs/ellipsis-finance/package.json
+++ b/subgraphs/ellipsis-finance/package.json
@@ -2,17 +2,13 @@
   "name": "ellipsis",
   "license": "UNLICENSED",
   "type": "module",
-
   "scripts": {
     "prettier": "prettier --config ./.prettierrc.json --write \"**/*.{js,json,md,ts}\"",
-    
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.28.0",

--- a/subgraphs/erc20/package.json
+++ b/subgraphs/erc20/package.json
@@ -6,7 +6,7 @@
     "build": "graph build",
     "prepare:constants": "mustache protocols/erc20/config/networks/${npm_config_network}/${npm_config_year}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "npm run prepare:constants && npm run deploy:subgraph"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.32.0",

--- a/subgraphs/erc721-holders/package.json
+++ b/subgraphs/erc721-holders/package.json
@@ -6,7 +6,7 @@
     "build": "graph build",
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.32.0",

--- a/subgraphs/erc721-metadata/package.json
+++ b/subgraphs/erc721-metadata/package.json
@@ -6,7 +6,7 @@
     "build": "graph build",
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.32.0",

--- a/subgraphs/euler-finance/package.json
+++ b/subgraphs/euler-finance/package.json
@@ -10,7 +10,7 @@
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.33.0",

--- a/subgraphs/gamma-strategies/package.json
+++ b/subgraphs/gamma-strategies/package.json
@@ -4,12 +4,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.33.0",

--- a/subgraphs/inverse-finance/package.json
+++ b/subgraphs/inverse-finance/package.json
@@ -4,12 +4,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.30.1",

--- a/subgraphs/lido/package.json
+++ b/subgraphs/lido/package.json
@@ -7,7 +7,7 @@
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.30.4",

--- a/subgraphs/liquity/package.json
+++ b/subgraphs/liquity/package.json
@@ -7,7 +7,7 @@
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.32.0",

--- a/subgraphs/makerdao/package.json
+++ b/subgraphs/makerdao/package.json
@@ -7,7 +7,7 @@
     "build": "graph build",
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.30.4",

--- a/subgraphs/maple-finance/package.json
+++ b/subgraphs/maple-finance/package.json
@@ -6,7 +6,7 @@
         "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
         "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
         "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-        "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+        "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
     },
     "dependencies": {
         "@graphprotocol/graph-cli": "^0.29.0",

--- a/subgraphs/network/package.json
+++ b/subgraphs/network/package.json
@@ -4,15 +4,12 @@
   "description": "A subgraph that gathers L1 data for EVM chains",
   "scripts": {
     "format": "npx prettier --write .",
-
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-ts": "^0.27.0",

--- a/subgraphs/opensea-v2/package.json
+++ b/subgraphs/opensea-v2/package.json
@@ -5,7 +5,7 @@
     "format": "npx prettier --write .",
     "codegen": "graph codegen",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ mrbrianhobo/opensea-v2-wyvern",
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}",
     "create-local": "graph create --node http://localhost:8020/ mrbrianhobo/opensea-v2-wyvern",
     "remove-local": "graph remove --node http://localhost:8020/ mrbrianhobo/opensea-v2-wyvern",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 mrbrianhobo/opensea-v2-wyvern"

--- a/subgraphs/openzeppelin-governor/package.json
+++ b/subgraphs/openzeppelin-governor/package.json
@@ -10,7 +10,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ ${npm_config_name}",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 ${npm_config_name}",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-ts": "^0.27.0",

--- a/subgraphs/platypus-finance/package.json
+++ b/subgraphs/platypus-finance/package.json
@@ -9,7 +9,7 @@
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}",
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}",
     "create-local": "graph create --node http://localhost:8020/ uniswap-v2",
     "remove-local": "graph remove --node http://localhost:8020/ uniswap-v2",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 uniswap-v2"

--- a/subgraphs/qidao/package.json
+++ b/subgraphs/qidao/package.json
@@ -5,11 +5,9 @@
     "format": "npx prettier --write .",
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}",
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}",
     "create-local": "graph create --node http://localhost:8020/ qidao",
     "remove-local": "graph remove --node http://localhost:8020/ qidao",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 qidao"

--- a/subgraphs/rari-vaults/package.json
+++ b/subgraphs/rari-vaults/package.json
@@ -7,7 +7,7 @@
     "build": "graph build",
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.32.0",

--- a/subgraphs/saddle-finance/package.json
+++ b/subgraphs/saddle-finance/package.json
@@ -8,7 +8,7 @@
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.33.0",

--- a/subgraphs/stakedao/package.json
+++ b/subgraphs/stakedao/package.json
@@ -4,12 +4,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.27.0",

--- a/subgraphs/tokemak/package.json
+++ b/subgraphs/tokemak/package.json
@@ -3,15 +3,12 @@
   "license": "UNLICENSED",
   "scripts": {
     "format": "npx prettier --write .",
-    
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.29.2",

--- a/subgraphs/uniswap-forks/package.json
+++ b/subgraphs/uniswap-forks/package.json
@@ -7,7 +7,7 @@
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.28.0",

--- a/subgraphs/uniswap-v3/package.json
+++ b/subgraphs/uniswap-v3/package.json
@@ -4,12 +4,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.27.0",

--- a/subgraphs/vesper-finance/package.json
+++ b/subgraphs/vesper-finance/package.json
@@ -4,12 +4,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-    
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
-    
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.32.0",

--- a/subgraphs/yearn-v2/package.json
+++ b/subgraphs/yearn-v2/package.json
@@ -4,12 +4,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-
     "prepare:yaml": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json protocols/${npm_config_protocol}/config/templates/${npm_config_template} > subgraph.yaml",
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/networks/${npm_config_network}/${npm_config_network}.json configurations/configure.template.ts > configurations/configure.ts",
     "deploy:subgraph": "graph deploy --product hosted-service ${npm_config_location}",
-
-    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge}"
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.32.0",

--- a/subgraphs/yeti-finance/package.json
+++ b/subgraphs/yeti-finance/package.json
@@ -5,7 +5,7 @@
     "format": "npx prettier --write .",
     "codegen": "graph codegen",
     "build": "graph build",
-    "deploy": "graph deploy --product hosted-service amritkumarj/yeti-finance",
+    "deploy": "node ../../deployment/deployment.js --subgraph=${npm_config_subgraph} --protocol=${npm_config_protocol} --network=${npm_config_network} --location=${npm_config_location} --printlogs=${npm_config_printlogs} --merge=${npm_config_merge} --type=${npm_config_type}",
     "create-local": "graph create --node http://localhost:8020/ yeti-finance",
     "remove-local": "graph remove --node http://localhost:8020/ yeti-finance",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 yeti-finance"


### PR DESCRIPTION
**Context:**
- There have been many instances where subgraphs fail to deploy upon merging into the master repository. This has often been due to build failing for various reasons at the time of merge. We wanted to add the capability to build only in the script, and test the builds on pushing to the repo before merging. 
- These changes will require an update to the deployment.js and execution.js files in the deployment folder, the creation of a new action, and updating the npm deploy script in each subgraph folder to include a new parameter for specifying the action (just building or deploying.)