### PR TITLE
Fix (#patch); makerdao; fixed interest rates for snapshots; updated grafting and subgraphVersion

### DIFF
--- a/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
+++ b/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
@@ -4,8 +4,8 @@ schema:
 features:
   - grafting
 graft:
-  base: Qmb1SREc6WkV3zd2ZUxnJS5annr9DYnnKKt4Pa7zF6PGrR
-  block: 15382090
+  base: QmXH7PVEVxKxGhnoJsafP3Mm5eBzRMuTxXJ5dCUuhr5qwF
+  block: 15430532
 dataSources:
   # Vault
   - name: Vat

--- a/subgraphs/makerdao/src/common/constants.ts
+++ b/subgraphs/makerdao/src/common/constants.ts
@@ -7,7 +7,7 @@ import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
 export const PROTOCOL_NAME = "MakerDAO";
 export const PROTOCOL_SLUG = "makerdao";
 export const PROTOCOL_SCHEMA_VERSION = "1.3.0";
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.1";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.2";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.1.0";
 
 ////////////////////////

--- a/subgraphs/makerdao/src/common/getters.ts
+++ b/subgraphs/makerdao/src/common/getters.ts
@@ -456,3 +456,25 @@ export function getOwnerAddressFromProxy(proxy: string): string {
   }
   return owner;
 }
+
+// this is needed to prevent snapshot rates from being pointers to the current rate
+export function getSnapshotRates(rates: string[], timeSuffix: string): string[] {
+  let snapshotRates: string[] = [];
+  for (let i = 0; i < rates.length; i++) {
+    let rate = InterestRate.load(rates[i]);
+    if (!rate) {
+      log.warning("[getSnapshotRates] rate {} not found, should not happen", [rates[i]]);
+      continue;
+    }
+
+    // create new snapshot rate
+    let snapshotRateId = rates[i].concat("-").concat(timeSuffix);
+    let snapshotRate = new InterestRate(snapshotRateId);
+    snapshotRate.side = rate.side;
+    snapshotRate.type = rate.type;
+    snapshotRate.rate = rate.rate;
+    snapshotRate.save();
+    snapshotRates.push(snapshotRateId);
+  }
+  return snapshotRates;
+}

--- a/subgraphs/makerdao/src/common/helpers.ts
+++ b/subgraphs/makerdao/src/common/helpers.ts
@@ -17,6 +17,7 @@ import {
   getOrCreateLendingProtocol,
   getOrCreateUsageMetricsHourlySnapshot,
   getOrCreateUsageMetricsDailySnapshot,
+  getSnapshotRates,
 } from "./getters";
 import {
   BIGDECIMAL_ZERO,
@@ -219,6 +220,11 @@ export function snapshotMarket(
     log.error("[snapshotMarket]Failed to get marketsnapshot for {}", [marketID]);
     return;
   }
+  let hours = (event.block.timestamp.toI32()/SECONDS_PER_HOUR).toString()
+  let hourlySnapshotRates = getSnapshotRates(market.rates, hours)
+
+  let days = (event.block.timestamp.toI32()/SECONDS_PER_DAY).toString()
+  let dailySnapshotRates = getSnapshotRates(market.rates, days)
 
   marketHourlySnapshot.totalValueLockedUSD = market.totalValueLockedUSD;
   marketHourlySnapshot.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
@@ -232,7 +238,7 @@ export function snapshotMarket(
   marketHourlySnapshot.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
   marketHourlySnapshot.inputTokenBalance = market.inputTokenBalance;
   marketHourlySnapshot.inputTokenPriceUSD = market.inputTokenPriceUSD;
-  marketHourlySnapshot.rates = market.rates;
+  marketHourlySnapshot.rates = hourlySnapshotRates;
   //marketHourlySnapshot.outputTokenSupply = market.outputTokenSupply;
   //marketHourlySnapshot.outputTokenPriceUSD = market.outputTokenPriceUSD;
 
@@ -251,7 +257,7 @@ export function snapshotMarket(
   marketDailySnapshot.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
   marketDailySnapshot.inputTokenBalance = market.inputTokenBalance;
   marketDailySnapshot.inputTokenPriceUSD = market.inputTokenPriceUSD;
-  marketDailySnapshot.rates = market.rates;
+  marketDailySnapshot.rates = dailySnapshotRates;
   //marketDailySnapshot.outputTokenSupply = market.outputTokenSupply;
   //marketDailySnapshot.outputTokenPriceUSD = market.outputTokenPriceUSD;
 

--- a/subgraphs/makerdao/src/mapping.ts
+++ b/subgraphs/makerdao/src/mapping.ts
@@ -1018,6 +1018,7 @@ export function handlePotFileDsr(event: PotNoteEvent): void {
 
     market.rates = [interestRateID];
     market.save();
+    snapshotMarket(event, market);
 
     log.info("[handlePotFileDsr] dsr={}, rate={}, rateAnnualized={}", [
       dsr.toString(),


### PR DESCRIPTION
- fixed interest rates for snapshots. In current implementation, daily/hourly snapshots also point to the latest entry of the InterestRate entity. This PR fix this.
- updated subgraphVersion
- update grafting to QmXH7PVEVxKxGhnoJsafP3Mm5eBzRMuTxXJ5dCUuhr5qwF (https://api.thegraph.com/subgraphs/name/tnkrxyz/makerdao-ethereum)