### PR TITLE
fix (#minor); Sushiswap Ethereum; Blacklisted MIS token

### DIFF
--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/ethereum/ethereum.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/ethereum/ethereum.ts
@@ -141,6 +141,7 @@ export class SushiswapMainnetConfigurations implements Configurations {
       "0xd417144312dbf50465b1c641d016962017ef6240", // Covalent query Token
       "0xe9f84de264e91529af07fa2c746e934397810334", // Sake Token
       "0x1337def16f9b486faed0293eb623dc8395dfe46a", // Armor Token
+      "0x4b4d2e899658fb59b1d518b68fe836b100ee8958", // MIS
     ];
   }
   getMinimumLiquidityThresholdTrackVolume(): BigDecimal {


### PR DESCRIPTION
**Context:** 
Sushiswap Ethereum had failed in deployment. It is unclear why this occurred since it booted itself back up with a TVL error. I blacklisted the token causing the error and re-deployed the subgraph with a graft. 