### PR TITLE
fix(#patch) ERC721 Metadata; add JSON object check for non-standard NFT attribute metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,13 @@ This repo contains subgraphs defined using a set of standardized schemas. These 
 | ERC20 Tokens (2020) | 🛠 | 1.0.0 / 1.0.0 / 1.0.0 | [![ERC20 Ethereum](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/erc20-holders-2020) |
 | ERC20 Tokens (2021) | 🛠 | 1.0.0 / 1.0.0 / 1.0.0 | [![ERC20 Ethereum](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/erc20-holders-2021) |
 | ERC20 Tokens (2022) | 🛠 | 1.0.0 / 1.0.0 / 1.0.0 | [![ERC20 Ethereum](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/erc20-holders-2022) |
-| **NFT Subgraphs** | | |
-| OpenSea (Wyvern v1) | |
-| OpenSea (Wyvern v2) | 🔨 |
-| OpenSea (Seaport) | |
+| **ERC721 Subgraphs** | | |
+| ERC721 Holders | 🛠 | 1.0.0 / 1.0.0 / 1.0.0 | [![ERC721 Holders](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/erc721-holders) |
+| ERC721 Metadata | 🛠 | 1.0.0 / 1.0.0 / 1.0.0 | [![ERC721 Metadata](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/erc721-metadata) |
+| **NFT Marketplace Subgraphs** | | |
+| OpenSea v1 (Wyvern Exchange) | 🛠 | 1.0.0 / 1.0.0 / 1.0.0 | [![OpenSea v1](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/opensea-v1-ethereum) |
+| OpenSea v2 (Wyvern Exchange) | 🛠 | 1.0.0 / 1.0.0 / 1.0.0 | [![OpenSea v2](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/opensea-v2-ethereum) |
+| OpenSea (Seaport) | 🛠 | 1.0.0 / 1.0.0 / 1.0.0 | [![OpenSea Seaport](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/opensea-seaport-ethereum) |
 | LooksRare | 🛠 | 1.0.0 / 1.0.0 / 1.0.0 | [![LooksRare](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/looksrare-ethereum) |
 | X2Y2 | 🛠 | 1.0.0 / 1.0.0 / 1.0.0 | [![X2Y2](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/x2y2-ethereum) |
 

--- a/subgraphs/erc721-metadata/src/mappings/token.ts
+++ b/subgraphs/erc721-metadata/src/mappings/token.ts
@@ -6,6 +6,7 @@ import {
   json,
   JSONValue,
   JSONValueKind,
+  log,
 } from "@graphprotocol/graph-ts";
 import { ERC721 } from "../../generated/ERC721/ERC721";
 import { Token, Attribute, Collection } from "../../generated/schema";
@@ -80,7 +81,7 @@ export function updateTokenMetadata(contract: ERC721, token: Token): Token {
     return token;
   }
   let dataJson = json.try_fromBytes(data);
-  if (dataJson.isError) {
+  if (dataJson.isError || !dataJson.isOk) {
     return token;
   }
 
@@ -96,6 +97,10 @@ export function updateTokenMetadata(contract: ERC721, token: Token): Token {
 
   let attributes = valueToArray(dataObject.get("attributes"));
   for (let i = 0; i < attributes.length; i++) {
+    if (attributes[i].kind != JSONValueKind.OBJECT) {
+      log.warning("non-standard attributes field, token id: {}", [token.id]);
+      continue;
+    }
     let item = attributes[i].toObject();
     let trait = valueToString(item.get("trait_type"));
     if (trait == null) {

--- a/subgraphs/erc721-metadata/subgraph.yaml
+++ b/subgraphs/erc721-metadata/subgraph.yaml
@@ -1,6 +1,10 @@
 specVersion: 0.0.4
 features:
   - ipfsOnEthereumContracts
+  - grafting
+graft:
+  base: Qmcqm6Q5mzkv6sdmPMA169GaD1pffWfaPo6c8hyffF4Jrz
+  block: 12715763
 description: ERC721 Metadata
 schema:
   file: ./schema.graphql
@@ -18,7 +22,7 @@ dataSources:
       entities:
         - Token
         - Attribute
-        - ERC721Collection
+        - Collection
         - NonERC721Collection
       abis:
         - name: ERC721


### PR DESCRIPTION
subgraph status (grafting from block `12715763`): https://okgraph.xyz/?q=messari%2Ferc721-metadata
- fixes stalled deployment at block `12715764`
- removed `nonFatalErrors` flag in `subgraph.yaml`
- added JSON object check for non-standard NFT attribute metadata
  - faulty txn: https://etherscan.io/tx/0x14b62b53d227b2d5fd4c5e0fa0cefc0a8582d0662e2fe409657cddf549b44595
  - faulty token uri: https://gateway.pinata.cloud/ipfs/QmTYvhY2B36MVRtFC6EtSmKQ5tLY7mKwxHcocEixDPmhPK/001%20-%20%E5%89%AF%E6%9C%AC%20%281%29.json
  - reason: `attributes` array contained a `JSONValueKind.STRING` instead of an `JSONValueKind.OBJECT` of `trait_type` and `value`
