### PR TITLE
fix(#minor); Solarbeam; Updated reward interval

### DIFF
--- a/subgraphs/uniswap-forks/protocols/solarbeam/config/networks/moonriver/moonriver.ts
+++ b/subgraphs/uniswap-forks/protocols/solarbeam/config/networks/moonriver/moonriver.ts
@@ -69,7 +69,7 @@ export class SolarbeamMoonriverConfigurations implements Configurations {
     return FeeSwitch.ON;
   }
   getRewardIntervalType(): string {
-    return RewardIntervalType.BLOCK;
+    return RewardIntervalType.TIMESTAMP;
   }
   getRewardTokenRate(): BigInt {
     return BIGINT_ZERO;


### PR DESCRIPTION
**Context:**
Response to issue #547. The reward token emissions were much lower than expected. This was because the reward interval was set to block and not timestamp.