### PR TITLE
[Gov] Daily snapshots of tokenHolders and votes, track totalTokenSupply

### DIFF
--- a/subgraphs/openzeppelin-governor/protocols/angle-governance/src/angle.ts
+++ b/subgraphs/openzeppelin-governor/protocols/angle-governance/src/angle.ts
@@ -33,6 +33,7 @@ export function handleTransfer(event: Transfer): void {
   _handleTransfer(
     event.params.from.toHexString(),
     event.params.to.toHexString(),
-    event.params.value
+    event.params.value,
+    event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/angle-governance/src/governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/angle-governance/src/governor.ts
@@ -24,7 +24,7 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
-  getOrCreateProposal,
+  getProposal,
   getGovernance,
 } from "../../../src/handlers";
 
@@ -88,7 +88,7 @@ function getLatestProposalValues(
   proposalId: string,
   contractAddress: Address
 ): Proposal {
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {

--- a/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-governor.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 import {
   ProposalCanceled,
   ProposalCreated,
@@ -36,7 +36,8 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
-  let quorumVotes = ArenaGovernor.bind(event.address).quorum(
+  let quorumVotes = getQuorumFromContract(
+    event.address,
     event.block.number.minus(BIGINT_ONE)
   );
 
@@ -97,9 +98,11 @@ function getLatestProposalValues(
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {
-    let contract = ArenaGovernor.bind(contractAddress);
     proposal.state = ProposalState.ACTIVE;
-    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+    proposal.quorumVotes = getQuorumFromContract(
+      contractAddress,
+      proposal.startBlock
+    );
 
     let governance = getGovernance();
     proposal.tokenHoldersAtStart = governance.currentTokenHolders;
@@ -161,4 +164,20 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
   }
 
   return governanceFramework;
+}
+
+function getQuorumFromContract(
+  contractAddress: Address,
+  blockNumber: BigInt
+): BigInt {
+  let contract = ArenaGovernor.bind(contractAddress);
+  let quorumVotes = contract.quorum(blockNumber);
+
+  let governanceFramework = getGovernanceFramework(
+    contractAddress.toHexString()
+  );
+  governanceFramework.quorumVotes = quorumVotes;
+  governanceFramework.save();
+
+  return quorumVotes;
 }

--- a/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-governor.ts
@@ -18,7 +18,7 @@ import {
   _handleProposalQueued,
   _handleVoteCast,
   _handleProposalExtended,
-  getOrCreateProposal,
+  getProposal,
   getGovernance,
 } from "../../../src/handlers";
 import { ArenaGovernor } from "../../../generated/ArenaGovernor/ArenaGovernor";
@@ -93,7 +93,7 @@ function getLatestProposalValues(
   proposalId: string,
   contractAddress: Address
 ): Proposal {
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {

--- a/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-token.ts
+++ b/subgraphs/openzeppelin-governor/protocols/code4rena-governance/src/arena-token.ts
@@ -33,6 +33,7 @@ export function handleTransfer(event: Transfer): void {
   _handleTransfer(
     event.params.from.toHexString(),
     event.params.to.toHexString(),
-    event.params.value
+    event.params.value,
+    event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-governor.ts
@@ -14,7 +14,7 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
-  getOrCreateProposal,
+  getProposal,
   getGovernance,
 } from "../../../src/handlers";
 import { ENSGovernor } from "../../../generated/ENSGovernor/ENSGovernor";
@@ -84,7 +84,7 @@ function getLatestProposalValues(
   proposalId: string,
   contractAddress: Address
 ): Proposal {
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {

--- a/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-governor.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 import {
   ProposalCanceled,
   ProposalCreated,
@@ -32,7 +32,8 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
-  let quorumVotes = ENSGovernor.bind(event.address).quorum(
+  let quorumVotes = getQuorumFromContract(
+    event.address,
     event.block.number.minus(BIGINT_ONE)
   );
 
@@ -88,9 +89,11 @@ function getLatestProposalValues(
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {
-    let contract = ENSGovernor.bind(contractAddress);
     proposal.state = ProposalState.ACTIVE;
-    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+    proposal.quorumVotes = getQuorumFromContract(
+      contractAddress,
+      proposal.startBlock
+    );
 
     let governance = getGovernance();
     proposal.tokenHoldersAtStart = governance.currentTokenHolders;
@@ -141,4 +144,20 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
   }
 
   return governanceFramework;
+}
+
+function getQuorumFromContract(
+  contractAddress: Address,
+  blockNumber: BigInt
+): BigInt {
+  let contract = ENSGovernor.bind(contractAddress);
+  let quorumVotes = contract.quorum(blockNumber);
+
+  let governanceFramework = getGovernanceFramework(
+    contractAddress.toHexString()
+  );
+  governanceFramework.quorumVotes = quorumVotes;
+  governanceFramework.save();
+
+  return quorumVotes;
 }

--- a/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-token.ts
+++ b/subgraphs/openzeppelin-governor/protocols/ens-governance/src/ens-token.ts
@@ -33,6 +33,7 @@ export function handleTransfer(event: Transfer): void {
   _handleTransfer(
     event.params.from.toHexString(),
     event.params.to.toHexString(),
-    event.params.value
+    event.params.value,
+    event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/euler-governance/src/eul.ts
+++ b/subgraphs/openzeppelin-governor/protocols/euler-governance/src/eul.ts
@@ -33,6 +33,7 @@ export function handleTransfer(event: Transfer): void {
   _handleTransfer(
     event.params.from.toHexString(),
     event.params.to.toHexString(),
-    event.params.value
+    event.params.value,
+    event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
+++ b/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
@@ -19,7 +19,7 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
-  getOrCreateProposal,
+  getProposal,
   getGovernance,
 } from "../../../src/handlers";
 import { GovernanceFramework, Proposal } from "../../../generated/schema";
@@ -95,7 +95,7 @@ function getLatestProposalValues(
   proposalId: string,
   contractAddress: Address
 ): Proposal {
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {

--- a/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
+++ b/subgraphs/openzeppelin-governor/protocols/euler-governance/src/governance.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 import {
   ProposalCanceled,
   ProposalCreated,
@@ -36,7 +36,8 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
-  let quorumVotes = Governance.bind(event.address).quorum(
+  let quorumVotes = getQuorumFromContract(
+    event.address,
     event.block.number.minus(BIGINT_ONE)
   );
 
@@ -99,9 +100,11 @@ function getLatestProposalValues(
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {
-    let contract = Governance.bind(contractAddress);
     proposal.state = ProposalState.ACTIVE;
-    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+    proposal.quorumVotes = getQuorumFromContract(
+      contractAddress,
+      proposal.startBlock
+    );
 
     let governance = getGovernance();
     proposal.tokenHoldersAtStart = governance.currentTokenHolders;
@@ -180,4 +183,20 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
   }
 
   return governanceFramework;
+}
+
+function getQuorumFromContract(
+  contractAddress: Address,
+  blockNumber: BigInt
+): BigInt {
+  let contract = Governance.bind(contractAddress);
+  let quorumVotes = contract.quorum(blockNumber);
+
+  let governanceFramework = getGovernanceFramework(
+    contractAddress.toHexString()
+  );
+  governanceFramework.quorumVotes = quorumVotes;
+  governanceFramework.save();
+
+  return quorumVotes;
 }

--- a/subgraphs/openzeppelin-governor/protocols/fei-governance/src/fei-dao.ts
+++ b/subgraphs/openzeppelin-governor/protocols/fei-governance/src/fei-dao.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 import {
   ProposalCanceled,
   ProposalCreated,
@@ -33,7 +33,8 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
-  let quorumVotes = FeiDAO.bind(event.address).quorum(
+  let quorumVotes = getQuorumFromContract(
+    event.address,
     event.block.number.minus(BIGINT_ONE)
   );
 
@@ -92,9 +93,11 @@ function getLatestProposalValues(
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {
-    let contract = FeiDAO.bind(contractAddress);
     proposal.state = ProposalState.ACTIVE;
-    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+    proposal.quorumVotes = getQuorumFromContract(
+      contractAddress,
+      proposal.startBlock
+    );
 
     let governance = getGovernance();
     proposal.tokenHoldersAtStart = governance.currentTokenHolders;
@@ -157,4 +160,20 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
   }
 
   return governanceFramework;
+}
+
+function getQuorumFromContract(
+  contractAddress: Address,
+  blockNumber: BigInt
+): BigInt {
+  let contract = FeiDAO.bind(contractAddress);
+  let quorumVotes = contract.quorum(blockNumber);
+
+  let governanceFramework = getGovernanceFramework(
+    contractAddress.toHexString()
+  );
+  governanceFramework.quorumVotes = quorumVotes;
+  governanceFramework.save();
+
+  return quorumVotes;
 }

--- a/subgraphs/openzeppelin-governor/protocols/fei-governance/src/fei-dao.ts
+++ b/subgraphs/openzeppelin-governor/protocols/fei-governance/src/fei-dao.ts
@@ -24,7 +24,7 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
-  getOrCreateProposal,
+  getProposal,
   getGovernance,
 } from "../../../src/handlers";
 
@@ -88,7 +88,7 @@ function getLatestProposalValues(
   proposalId: string,
   contractAddress: Address
 ): Proposal {
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {

--- a/subgraphs/openzeppelin-governor/protocols/fei-governance/src/tribe.ts
+++ b/subgraphs/openzeppelin-governor/protocols/fei-governance/src/tribe.ts
@@ -33,6 +33,7 @@ export function handleTransfer(event: Transfer): void {
   _handleTransfer(
     event.params.from.toHexString(),
     event.params.to.toHexString(),
-    event.params.amount
+    event.params.amount,
+    event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-governor.ts
@@ -14,7 +14,7 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
-  getOrCreateProposal,
+  getProposal,
   getGovernance,
 } from "../../../src/handlers";
 import { HOPGovernor } from "../../../generated/HOPGovernor/HOPGovernor";
@@ -78,7 +78,7 @@ function getLatestProposalValues(
   proposalId: string,
   contractAddress: Address
 ): Proposal {
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {

--- a/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-governor.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 import {
   ProposalCanceled,
   ProposalCreated,
@@ -30,7 +30,8 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
-  let quorumVotes = HOPGovernor.bind(event.address).quorum(
+  let quorumVotes = getQuorumFromContract(
+    event.address,
     event.block.number.minus(BIGINT_ONE)
   );
 
@@ -82,9 +83,11 @@ function getLatestProposalValues(
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {
-    let contract = HOPGovernor.bind(contractAddress);
     proposal.state = ProposalState.ACTIVE;
-    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+    proposal.quorumVotes = getQuorumFromContract(
+      contractAddress,
+      proposal.startBlock
+    );
 
     let governance = getGovernance();
     proposal.tokenHoldersAtStart = governance.currentTokenHolders;
@@ -134,4 +137,19 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
   }
 
   return governanceFramework;
+}
+function getQuorumFromContract(
+  contractAddress: Address,
+  blockNumber: BigInt
+): BigInt {
+  let contract = HOPGovernor.bind(contractAddress);
+  let quorumVotes = contract.quorum(blockNumber);
+
+  let governanceFramework = getGovernanceFramework(
+    contractAddress.toHexString()
+  );
+  governanceFramework.quorumVotes = quorumVotes;
+  governanceFramework.save();
+
+  return quorumVotes;
 }

--- a/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-token.ts
+++ b/subgraphs/openzeppelin-governor/protocols/hop-governance/src/hop-token.ts
@@ -32,6 +32,7 @@ export function handleTransfer(event: Transfer): void {
   _handleTransfer(
     event.params.from.toHexString(),
     event.params.to.toHexString(),
-    event.params.value
+    event.params.value,
+    event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governance-token.ts
+++ b/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governance-token.ts
@@ -33,6 +33,7 @@ export function handleTransfer(event: Transfer): void {
   _handleTransfer(
     event.params.from.toHexString(),
     event.params.to.toHexString(),
-    event.params.value
+    event.params.value,
+    event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governor.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 import {
   SiloGovernor,
   ProposalCanceled,
@@ -35,7 +35,8 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
-  let quorumVotes = SiloGovernor.bind(event.address).quorum(
+  let quorumVotes = getQuorumFromContract(
+    event.address,
     event.block.number.minus(BIGINT_ONE)
   );
 
@@ -97,9 +98,11 @@ function getLatestProposalValues(
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {
-    let contract = SiloGovernor.bind(contractAddress);
     proposal.state = ProposalState.ACTIVE;
-    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+    proposal.quorumVotes = getQuorumFromContract(
+      contractAddress,
+      proposal.startBlock
+    );
 
     let governance = getGovernance();
     proposal.tokenHoldersAtStart = governance.currentTokenHolders;
@@ -161,4 +164,20 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
   }
 
   return governanceFramework;
+}
+
+function getQuorumFromContract(
+  contractAddress: Address,
+  blockNumber: BigInt
+): BigInt {
+  let contract = SiloGovernor.bind(contractAddress);
+  let quorumVotes = contract.quorum(blockNumber);
+
+  let governanceFramework = getGovernanceFramework(
+    contractAddress.toHexString()
+  );
+  governanceFramework.quorumVotes = quorumVotes;
+  governanceFramework.save();
+
+  return quorumVotes;
 }

--- a/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/silo-governance/src/silo-governor.ts
@@ -18,7 +18,7 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
-  getOrCreateProposal,
+  getProposal,
   getGovernance,
 } from "../../../src/handlers";
 import { GovernanceFramework, Proposal } from "../../../generated/schema";
@@ -93,7 +93,7 @@ function getLatestProposalValues(
   proposalId: string,
   contractAddress: Address
 ): Proposal {
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {

--- a/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/dao-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/dao-governor.ts
@@ -18,7 +18,7 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
-  getOrCreateProposal,
+  getProposal,
   getGovernance,
 } from "../../../src/handlers";
 import { DaoGovernor } from "../../../generated/DaoGovernor/DaoGovernor";
@@ -88,7 +88,7 @@ function getLatestProposalValues(
   proposalId: string,
   contractAddress: Address
 ): Proposal {
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {

--- a/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/dao-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/dao-governor.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 import {
   ProposalCanceled,
   ProposalCreated,
@@ -34,7 +34,8 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 }
 
 export function handleProposalCreated(event: ProposalCreated): void {
-  let quorumVotes = DaoGovernor.bind(event.address).quorum(
+  let quorumVotes = getQuorumFromContract(
+    event.address,
     event.block.number.minus(BIGINT_ONE)
   );
 
@@ -92,9 +93,11 @@ function getLatestProposalValues(
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {
-    let contract = DaoGovernor.bind(contractAddress);
     proposal.state = ProposalState.ACTIVE;
-    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+    proposal.quorumVotes = getQuorumFromContract(
+      contractAddress,
+      proposal.startBlock
+    );
 
     let governance = getGovernance();
     proposal.tokenHoldersAtStart = governance.currentTokenHolders;
@@ -173,4 +176,20 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
   }
 
   return governanceFramework;
+}
+
+function getQuorumFromContract(
+  contractAddress: Address,
+  blockNumber: BigInt
+): BigInt {
+  let contract = DaoGovernor.bind(contractAddress);
+  let quorumVotes = contract.quorum(blockNumber);
+
+  let governanceFramework = getGovernanceFramework(
+    contractAddress.toHexString()
+  );
+  governanceFramework.quorumVotes = quorumVotes;
+  governanceFramework.save();
+
+  return quorumVotes;
 }

--- a/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/stk-tru-token.ts
+++ b/subgraphs/openzeppelin-governor/protocols/truefi-governance/src/stk-tru-token.ts
@@ -34,6 +34,7 @@ export function handleTransfer(event: Transfer): void {
   _handleTransfer(
     event.params.from.toHexString(),
     event.params.to.toHexString(),
-    event.params.value
+    event.params.value,
+    event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-discount-token-v-3.ts
+++ b/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-discount-token-v-3.ts
@@ -33,6 +33,7 @@ export function handleTransfer(event: Transfer): void {
   _handleTransfer(
     event.params.from.toHexString(),
     event.params.to.toHexString(),
-    event.params.value
+    event.params.value,
+    event
   );
 }

--- a/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
@@ -35,7 +35,8 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 
 // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
 export function handleProposalCreated(event: ProposalCreated): void {
-  let quorumVotes = UnlockProtocolGovernor.bind(event.address).quorum(
+  let quorumVotes = getQuorumFromContract(
+    event.address,
     event.block.number.minus(BIGINT_ONE)
   );
 
@@ -89,9 +90,11 @@ function getLatestProposalValues(
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {
-    let contract = UnlockProtocolGovernor.bind(contractAddress);
     proposal.state = ProposalState.ACTIVE;
-    proposal.quorumVotes = contract.quorum(proposal.startBlock);
+    proposal.quorumVotes = getQuorumFromContract(
+      contractAddress,
+      proposal.startBlock
+    );
 
     let governance = getGovernance();
     proposal.tokenHoldersAtStart = governance.currentTokenHolders;
@@ -158,4 +161,20 @@ function getGovernanceFramework(contractAddress: string): GovernanceFramework {
   }
 
   return governanceFramework;
+}
+
+function getQuorumFromContract(
+  contractAddress: Address,
+  blockNumber: BigInt
+): BigInt {
+  let contract = UnlockProtocolGovernor.bind(contractAddress);
+  let quorumVotes = contract.quorum(blockNumber);
+
+  let governanceFramework = getGovernanceFramework(
+    contractAddress.toHexString()
+  );
+  governanceFramework.quorumVotes = quorumVotes;
+  governanceFramework.save();
+
+  return quorumVotes;
 }

--- a/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
+++ b/subgraphs/openzeppelin-governor/protocols/unlock-governance/src/unlock-protocol-governor.ts
@@ -16,7 +16,7 @@ import {
   _handleProposalExecuted,
   _handleProposalQueued,
   _handleVoteCast,
-  getOrCreateProposal,
+  getProposal,
   getGovernance,
 } from "../../../src/handlers";
 import { UnlockProtocolGovernor } from "../../../generated/UnlockProtocolGovernor/UnlockProtocolGovernor";
@@ -85,7 +85,7 @@ function getLatestProposalValues(
   proposalId: string,
   contractAddress: Address
 ): Proposal {
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
 
   // On first vote, set state and quorum values
   if (proposal.state == ProposalState.PENDING) {

--- a/subgraphs/openzeppelin-governor/schema.graphql
+++ b/subgraphs/openzeppelin-governor/schema.graphql
@@ -3,7 +3,7 @@ type Governance @entity {
   id: ID!
 
   "Total Supply of token"
-  tokenTotalSupply: BigInt!
+  totalTokenSupply: BigInt!
   "Total number of token holders currently"
   currentTokenHolders: BigInt!
   "Total number of token holders"

--- a/subgraphs/openzeppelin-governor/schema.graphql
+++ b/subgraphs/openzeppelin-governor/schema.graphql
@@ -239,3 +239,22 @@ type TokenDailySnapshot @entity {
   "Timestamp of snapshot"
   timestamp: BigInt!
 }
+
+type VoteDailySnapshot @entity {
+  "Number of days from Unix epoch time"
+  id: ID!
+  "Proposal this snapshot is associated with"
+  proposal: Proposal!
+  "Weighted votes against the proposal at snapshot"
+  forWeightedVotes: BigInt!
+  "Weighted votes abstaining to the proposal at snapshot"
+  againstWeightedVotes: BigInt!
+  "Weighted votes for the proposal at snapshot"
+  abstainWeightedVotes: BigInt!
+  "Total weighted for/against/abstaining votes at snapshot"
+  totalWeightedVotes: BigInt!
+  "Block number of last block in snapshot"
+  blockNumber: BigInt!
+  "Timestamp of snapshot"
+  timestamp: BigInt!
+}

--- a/subgraphs/openzeppelin-governor/schema.graphql
+++ b/subgraphs/openzeppelin-governor/schema.graphql
@@ -2,6 +2,8 @@ type Governance @entity {
   "Unique entity used to keep track of common aggregated data"
   id: ID!
 
+  "Total Supply of token"
+  tokenTotalSupply: BigInt!
   "Total number of token holders currently"
   currentTokenHolders: BigInt!
   "Total number of token holders"
@@ -220,4 +222,20 @@ type Delegate @entity {
 
   "Proposals that the delegate has created"
   proposals: [Proposal!]! @derivedFrom(field: "proposer")
+}
+
+# Timeseries Data
+type TokenDailySnapshot @entity {
+  "Number of days from Unix epoch time"
+  id: ID!
+  "Total Supply at snapshot"
+  totalSupply: BigInt!
+  "Number of tokenholders at snapshot"
+  tokenHolders: BigInt!
+  "Number of delegates at snapshot"
+  totalDelegates: BigInt!
+  "Block number of last block in snapshot"
+  blockNumber: BigInt!
+  "Timestamp of snapshot"
+  timestamp: BigInt!
 }

--- a/subgraphs/openzeppelin-governor/src/handlers.ts
+++ b/subgraphs/openzeppelin-governor/src/handlers.ts
@@ -334,6 +334,7 @@ export function _handleVoteCast(
   dailySnapshot.forWeightedVotes = proposal.forWeightedVotes;
   dailySnapshot.againstWeightedVotes = proposal.againstWeightedVotes;
   dailySnapshot.abstainWeightedVotes = proposal.abstainWeightedVotes;
+  dailySnapshot.totalWeightedVotes = proposal.totalWeightedVotes;
   dailySnapshot.blockNumber = event.block.number;
   dailySnapshot.timestamp = event.block.timestamp;
   dailySnapshot.save();

--- a/subgraphs/openzeppelin-governor/src/handlers.ts
+++ b/subgraphs/openzeppelin-governor/src/handlers.ts
@@ -54,7 +54,6 @@ export function getVoteChoiceByValue(choiceValue: number): string {
 
 export function getGovernance(): Governance {
   let governance = Governance.load(GOVERNANCE_NAME);
-
   if (!governance) {
     governance = new Governance(GOVERNANCE_NAME);
     governance.proposals = BIGINT_ZERO;
@@ -72,41 +71,26 @@ export function getGovernance(): Governance {
   return governance;
 }
 
-export function getOrCreateProposal(
-  id: string,
-  createIfNotFound: boolean = true,
-  save: boolean = false
-): Proposal {
+export function getProposal(id: string): Proposal {
   let proposal = Proposal.load(id);
-
-  if (!proposal && createIfNotFound) {
+  if (!proposal) {
     proposal = new Proposal(id);
     proposal.tokenHoldersAtStart = BIGINT_ZERO;
     proposal.delegatesAtStart = BIGINT_ZERO;
-    if (save) {
-      proposal.save();
-    }
   }
 
   return proposal as Proposal;
 }
 
-export function getOrCreateDelegate(
-  address: string,
-  createIfNotFound: boolean = true,
-  save: boolean = true
-): Delegate {
+export function getOrCreateDelegate(address: string): Delegate {
   let delegate = Delegate.load(address);
-
-  if (!delegate && createIfNotFound) {
+  if (!delegate) {
     delegate = new Delegate(address);
     delegate.delegatedVotesRaw = BIGINT_ZERO;
     delegate.delegatedVotes = BIGDECIMAL_ZERO;
     delegate.tokenHoldersRepresentedAmount = 0;
     delegate.numberVotes = 0;
-    if (save) {
-      delegate.save();
-    }
+    delegate.save();
 
     if (address != ZERO_ADDRESS) {
       let governance = getGovernance();
@@ -118,22 +102,15 @@ export function getOrCreateDelegate(
   return delegate as Delegate;
 }
 
-export function getOrCreateTokenHolder(
-  address: string,
-  createIfNotFound: boolean = true,
-  save: boolean = true
-): TokenHolder {
+export function getOrCreateTokenHolder(address: string): TokenHolder {
   let tokenHolder = TokenHolder.load(address);
-
-  if (!tokenHolder && createIfNotFound) {
+  if (!tokenHolder) {
     tokenHolder = new TokenHolder(address);
     tokenHolder.tokenBalanceRaw = BIGINT_ZERO;
     tokenHolder.tokenBalance = BIGDECIMAL_ZERO;
     tokenHolder.totalTokensHeldRaw = BIGINT_ZERO;
     tokenHolder.totalTokensHeld = BIGDECIMAL_ZERO;
-    if (save) {
-      tokenHolder.save();
-    }
+    tokenHolder.save();
 
     if (address != ZERO_ADDRESS) {
       let governance = getGovernance();
@@ -159,8 +136,8 @@ export function _handleProposalCreated(
   quorum: BigInt,
   event: ethereum.Event
 ): void {
-  let proposal = getOrCreateProposal(proposalId);
-  let proposer = getOrCreateDelegate(proposerAddr, false);
+  let proposal = getProposal(proposalId);
+  let proposer = getOrCreateDelegate(proposerAddr);
 
   // Checking if the proposer was a delegate already accounted for, if not we should log an error
   // since it shouldn't be possible for a delegate to propose anything without first being "created"
@@ -211,7 +188,7 @@ export function _handleProposalCanceled(
   proposalId: string,
   event: ethereum.Event
 ): void {
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
   proposal.state = ProposalState.CANCELED;
   proposal.cancellationTxnHash = event.transaction.hash.toHexString();
   proposal.cancellationBlock = event.block.number;
@@ -229,7 +206,7 @@ export function _handleProposalExecuted(
   event: ethereum.Event
 ): void {
   // Update proposal status + execution metadata
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
   proposal.state = ProposalState.EXECUTED;
   proposal.executionTxnHash = event.transaction.hash.toHexString();
   proposal.executionBlock = event.block.number;
@@ -248,7 +225,7 @@ export function _handleProposalExtended(
   extendedDeadline: BigInt
 ): void {
   // Update proposal endBlock
-  let proposal = getOrCreateProposal(proposalId);
+  let proposal = getProposal(proposalId);
   proposal.endBlock = extendedDeadline;
   proposal.save();
 }
@@ -259,7 +236,7 @@ export function _handleProposalQueued(
   event: ethereum.Event
 ): void {
   // Update proposal status + execution metadata
-  let proposal = getOrCreateProposal(proposalId.toString());
+  let proposal = getProposal(proposalId.toString());
   proposal.state = ProposalState.QUEUED;
   proposal.queueTxnHash = event.transaction.hash.toHexString();
   proposal.queueBlock = event.block.number;

--- a/subgraphs/openzeppelin-governor/src/handlers.ts
+++ b/subgraphs/openzeppelin-governor/src/handlers.ts
@@ -60,7 +60,7 @@ export function getGovernance(): Governance {
   let governance = Governance.load(GOVERNANCE_NAME);
   if (!governance) {
     governance = new Governance(GOVERNANCE_NAME);
-    governance.tokenTotalSupply = BIGINT_ZERO;
+    governance.totalTokenSupply = BIGINT_ZERO;
     governance.proposals = BIGINT_ZERO;
     governance.currentTokenHolders = BIGINT_ZERO;
     governance.totalTokenHolders = BIGINT_ZERO;

--- a/subgraphs/openzeppelin-governor/src/handlers.ts
+++ b/subgraphs/openzeppelin-governor/src/handlers.ts
@@ -21,7 +21,10 @@ import {
   Proposal,
   TokenHolder,
   Vote,
+  TokenDailySnapshot,
 } from "../generated/schema";
+
+export const SECONDS_PER_DAY = 60 * 60 * 24;
 
 export function toDecimal(value: BigInt, decimals: number = 18): BigDecimal {
   return value.divDecimal(
@@ -56,6 +59,7 @@ export function getGovernance(): Governance {
   let governance = Governance.load(GOVERNANCE_NAME);
   if (!governance) {
     governance = new Governance(GOVERNANCE_NAME);
+    governance.tokenTotalSupply = BIGINT_ZERO;
     governance.proposals = BIGINT_ZERO;
     governance.currentTokenHolders = BIGINT_ZERO;
     governance.totalTokenHolders = BIGINT_ZERO;
@@ -121,6 +125,23 @@ export function getOrCreateTokenHolder(address: string): TokenHolder {
   }
 
   return tokenHolder as TokenHolder;
+}
+
+export function getOrCreateTokenDailySnapshot(
+  block: ethereum.Block
+): TokenDailySnapshot {
+  let snapshotId = (block.timestamp.toI64() / SECONDS_PER_DAY).toString();
+  let previousSnapshot = TokenDailySnapshot.load(snapshotId);
+
+  if (previousSnapshot != null) {
+    return previousSnapshot as TokenDailySnapshot;
+  }
+  let snapshot = new TokenDailySnapshot(snapshotId);
+  snapshot.totalSupply = BIGINT_ZERO;
+  snapshot.tokenHolders = BIGINT_ZERO;
+  snapshot.totalDelegates = BIGINT_ZERO;
+  snapshot.blockNumber = block.number;
+  return snapshot;
 }
 
 export function _handleProposalCreated(

--- a/subgraphs/openzeppelin-governor/src/tokenHandlers.ts
+++ b/subgraphs/openzeppelin-governor/src/tokenHandlers.ts
@@ -74,21 +74,13 @@ export function _handleTransfer(from: string, to: string, value: BigInt): void {
     }
 
     if (
-      fromHolder.tokenBalanceRaw == BIGINT_ZERO &&
-      fromHolderPreviousBalance > BIGINT_ZERO
+      fromHolderPreviousBalance > BIGINT_ZERO &&
+      fromHolder.tokenBalanceRaw == BIGINT_ZERO
     ) {
       governance.currentTokenHolders =
         governance.currentTokenHolders.minus(BIGINT_ONE);
       governance.save();
-    } else if (
-      fromHolder.tokenBalanceRaw > BIGINT_ZERO &&
-      fromHolderPreviousBalance == BIGINT_ZERO
-    ) {
-      governance.currentTokenHolders =
-        governance.currentTokenHolders.plus(BIGINT_ONE);
-      governance.save();
     }
-
     fromHolder.save();
   }
 
@@ -100,15 +92,8 @@ export function _handleTransfer(from: string, to: string, value: BigInt): void {
   toHolder.totalTokensHeld = toDecimal(toHolder.totalTokensHeldRaw);
 
   if (
-    toHolder.tokenBalanceRaw == BIGINT_ZERO &&
-    toHolderPreviousBalance > BIGINT_ZERO
-  ) {
-    governance.currentTokenHolders =
-      governance.currentTokenHolders.minus(BIGINT_ONE);
-    governance.save();
-  } else if (
-    toHolder.tokenBalanceRaw > BIGINT_ZERO &&
-    toHolderPreviousBalance == BIGINT_ZERO
+    toHolderPreviousBalance == BIGINT_ZERO &&
+    toHolder.tokenBalanceRaw > BIGINT_ZERO
   ) {
     governance.currentTokenHolders =
       governance.currentTokenHolders.plus(BIGINT_ONE);

--- a/subgraphs/openzeppelin-governor/src/tokenHandlers.ts
+++ b/subgraphs/openzeppelin-governor/src/tokenHandlers.ts
@@ -110,16 +110,16 @@ export function _handleTransfer(
 
   // Adjust token total supply if it changes
   if (isMint) {
-    governance.tokenTotalSupply = governance.tokenTotalSupply.plus(value);
+    governance.totalTokenSupply = governance.totalTokenSupply.plus(value);
     governance.save();
   } else if (isBurn) {
-    governance.tokenTotalSupply = governance.tokenTotalSupply.minus(value);
+    governance.totalTokenSupply = governance.totalTokenSupply.minus(value);
     governance.save();
   }
 
   // Take snapshot
   let dailySnapshot = getOrCreateTokenDailySnapshot(event.block);
-  dailySnapshot.totalSupply = governance.tokenTotalSupply;
+  dailySnapshot.totalSupply = governance.totalTokenSupply;
   dailySnapshot.tokenHolders = governance.currentTokenHolders;
   dailySnapshot.totalDelegates = governance.totalDelegates;
   dailySnapshot.blockNumber = event.block.number;


### PR DESCRIPTION
## Description

Extends the OpenZeppelin Governance subgraphs to index daily snapshots of totalSupply, tokenHolders, totalDelegates and votes. 

Largely adapted from the `TokenDailySnapshot` entities used in the erc20 subgraph.

See this subgraph for an example of the output
https://thegraph.com/hosted-service/subgraph/danielkhoo/truefi-governance

## Screenshots 
<img width="870" alt="image" src="https://user-images.githubusercontent.com/4507317/188164889-cbaadc01-f9a5-44dd-b32c-bca90bfa3ac5.png">
<img width="896" alt="image" src="https://user-images.githubusercontent.com/4507317/188165044-0d054975-57b8-4d05-9ab7-042bb8978807.png">


