### PR TITLE
fix (#minor); VVS Finance; Changed reward interval from NONE to BLOCK

### DIFF
--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/harmony/harmony.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/networks/harmony/harmony.ts
@@ -69,7 +69,7 @@ export class SushiswapHarmonyConfigurations implements Configurations {
     return FeeSwitch.ON;
   }
   getRewardIntervalType(): string {
-    return RewardIntervalType.NONE;
+    return RewardIntervalType.TIMESTAMP;
   }
   getRewardTokenRate(): BigInt {
     return BIGINT_ZERO;

--- a/subgraphs/uniswap-forks/protocols/vvs-finance/config/networks/cronos/cronos.ts
+++ b/subgraphs/uniswap-forks/protocols/vvs-finance/config/networks/cronos/cronos.ts
@@ -64,7 +64,7 @@ export class VSSFinanceCronosConfigurations implements Configurations {
     return FeeSwitch.ON;
   }
   getRewardIntervalType(): string {
-    return RewardIntervalType.NONE;
+    return RewardIntervalType.BLOCK;
   }
   getRewardTokenRate(): BigInt {
     return BIGINT_ZERO;

--- a/subgraphs/uniswap-forks/protocols/vvs-finance/config/networks/cronos/cronos.ts
+++ b/subgraphs/uniswap-forks/protocols/vvs-finance/config/networks/cronos/cronos.ts
@@ -64,7 +64,7 @@ export class VSSFinanceCronosConfigurations implements Configurations {
     return FeeSwitch.ON;
   }
   getRewardIntervalType(): string {
-    return RewardIntervalType.BLOCK;
+    return RewardIntervalType.NONE;
   }
   getRewardTokenRate(): BigInt {
     return BIGINT_ZERO;

--- a/subgraphs/uniswap-forks/src/common/rewards.ts
+++ b/subgraphs/uniswap-forks/src/common/rewards.ts
@@ -64,6 +64,7 @@ export const CIRCULAR_BUFFER = "CIRCULAR_BUFFER";
 export namespace RewardIntervalType {
   export const BLOCK = "BLOCK";
   export const TIMESTAMP = "TIMESTAMP";
+  export const NONE = "NONE";
 }
 
 // Forecast period. This gives you the time period that you want to estimate count of blocks per interval, based on moving average block speed.
@@ -96,6 +97,11 @@ export function getRewardsPerDay(
   rewardRate: BigDecimal,
   rewardType: string
 ): BigDecimal {
+  if (rewardType == RewardIntervalType.NONE) {
+    log.warning("Reward type is NONE. Returning 0.", []);
+    return BIGDECIMAL_ZERO;
+  }
+
   let circularBuffer = getOrCreateCircularBuffer();
 
   // Create entity for the current block


### PR DESCRIPTION
**Context:** 
The reward interval VVS Finance was set to NONE, but the reward interval is by block. This change does not actually impact the rewards emissions for VVS finance due to the way the rewards calculator was configured. Sushiswap Harmony was also incorrect - updated reward interval from NONE to TIMESTAMP. This will require a re-deployment.

**Fix:**
- [x] Updated NONE to BLOCK for reward interval in VVS Finance configurations. Updated NONE to TIMESTAMP for Sushiswap Harmony reward interval. 
- [x] Added logic to log a warning and return zero when interval is NONE.