### PR TITLE
[GOV] fix(#patch); Capture current delegates instead of total delegates in OZ snapshot

### DIFF
--- a/subgraphs/openzeppelin-governor/schema.graphql
+++ b/subgraphs/openzeppelin-governor/schema.graphql
@@ -233,7 +233,7 @@ type TokenDailySnapshot @entity {
   "Number of tokenholders at snapshot"
   tokenHolders: BigInt!
   "Number of delegates at snapshot"
-  totalDelegates: BigInt!
+  delegates: BigInt!
   "Block number of last block in snapshot"
   blockNumber: BigInt!
   "Timestamp of snapshot"

--- a/subgraphs/openzeppelin-governor/src/tokenHandlers.ts
+++ b/subgraphs/openzeppelin-governor/src/tokenHandlers.ts
@@ -121,7 +121,7 @@ export function _handleTransfer(
   let dailySnapshot = getOrCreateTokenDailySnapshot(event.block);
   dailySnapshot.totalSupply = governance.totalTokenSupply;
   dailySnapshot.tokenHolders = governance.currentTokenHolders;
-  dailySnapshot.totalDelegates = governance.totalDelegates;
+  dailySnapshot.delegates = governance.currentDelegates;
   dailySnapshot.blockNumber = event.block.number;
   dailySnapshot.timestamp = event.block.timestamp;
   dailySnapshot.save();


### PR DESCRIPTION
##Description

Our OZ daily snapshots mistakenly capture `totalDelegates` i.e. the all time count of delegates instead of the `currentDelegates` at time of snapshot