### PR TITLE
fix(#patch): uniswap-forks; fixed breaking change preventing grafts

### DIFF
--- a/deployment/deployment.dev.json
+++ b/deployment/deployment.dev.json
@@ -3100,7 +3100,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.5",
+          "subgraph": "1.1.7",
           "methodology": "1.0.0"
         },
         "deployment-ids": {

--- a/subgraphs/uniswap-forks/protocols/trader-joe/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/trader-joe/src/common/constants.ts
@@ -4,7 +4,7 @@ import { BigInt } from "@graphprotocol/graph-ts";
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.6";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.7";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "Trader Joe";
 export const PROTOCOL_SLUG = "trader-joe";

--- a/subgraphs/uniswap-forks/protocols/trader-joe/src/common/handlers/rewarderRate/rewardRateCalculator.ts
+++ b/subgraphs/uniswap-forks/protocols/trader-joe/src/common/handlers/rewarderRate/rewardRateCalculator.ts
@@ -280,7 +280,7 @@ export class RewarderCalculator {
       return BIGINT_ZERO;
     }
 
-    let c = MasterChefV2TraderJoe.bind(Address.fromString(this.mc.address)); // v2 and v3 have the same definition for this method.
+    let c = MasterChefV2TraderJoe.bind(Address.fromString(this.mc.address!)); // v2 and v3 have the same definition for this method.
     let call = c.try_userInfo(BigInt.fromString(pid), user);
     if (call.reverted) {
       log.error("unable to get user staked lp: {}", [user.toHexString()]);

--- a/subgraphs/uniswap-forks/schema.graphql
+++ b/subgraphs/uniswap-forks/schema.graphql
@@ -808,7 +808,7 @@ type _MasterChef @entity {
   id: ID!
 
   " Address of the masterchef contract "
-  address: String!
+  address: String
 
   " Total allocation point of all staking pools "
   totalAllocPoint: BigInt!

--- a/subgraphs/uniswap-forks/src/common/masterchef/helpers.ts
+++ b/subgraphs/uniswap-forks/src/common/masterchef/helpers.ts
@@ -42,17 +42,26 @@ export function getOrCreateMasterChef(
 ): _MasterChef {
   let masterChef = _MasterChef.load(masterChefType);
 
-  if (!masterChef) {
-    masterChef = new _MasterChef(masterChefType);
+  if (masterChef) {
+    if (masterChef.address) {
+      return masterChef;
+    }
+
     masterChef.address = event.address.toHexString();
-    masterChef.totalAllocPoint = BIGINT_ZERO;
-    masterChef.rewardTokenInterval = NetworkConfigs.getRewardIntervalType();
-    masterChef.rewardTokenRate = NetworkConfigs.getRewardTokenRate();
-    log.warning("MasterChef Type: " + masterChefType, []);
-    masterChef.adjustedRewardTokenRate = NetworkConfigs.getRewardTokenRate();
-    masterChef.lastUpdatedRewardRate = BIGINT_ZERO;
     masterChef.save();
+    return masterChef;
   }
+
+  masterChef = new _MasterChef(masterChefType);
+  masterChef.address = event.address.toHexString();
+  masterChef.totalAllocPoint = BIGINT_ZERO;
+  masterChef.rewardTokenInterval = NetworkConfigs.getRewardIntervalType();
+  masterChef.rewardTokenRate = NetworkConfigs.getRewardTokenRate();
+  log.warning("MasterChef Type: " + masterChefType, []);
+  masterChef.adjustedRewardTokenRate = NetworkConfigs.getRewardTokenRate();
+  masterChef.lastUpdatedRewardRate = BIGINT_ZERO;
+  masterChef.save();
+
   return masterChef;
 }
 


### PR DESCRIPTION

I recently introduced a breaking change by adding a required field to MasterChef entity in the schema. This field was not being set before and makes grafting from a previous version impossible:

<img width="1113" alt="Screenshot 2022-09-13 at 17 10 41" src="https://user-images.githubusercontent.com/17258946/189938757-a68c6086-d777-489e-94aa-f044b0a0d47e.png">

I've made the field optional, and when fetching the entity, if it is not set, it will be set and saved. This way we can still ensure it will always be present while making the schema compatible.

I've also updated the trader-joe version (the one I was trying to graft :D )
