### PR TITLE
fix(#patch); rari fuse; FLOAT exploit

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This repo contains subgraphs defined using a set of standardized schemas. These 
 | [Moonwell Finance](https://moonwell.fi/) | ✅ | 2.0.1 / 1.1.1 / 1.0.0 | [![Moonwell Moonriver](./docs/images/chains/moonriver.png)](https://thegraph.com/hosted-service/subgraph/messari/moonwell-moonriver) [![Moonwell Moonbeam](./docs/images/chains/moonbeam.png)](https://thegraph.com/hosted-service/subgraph/messari/moonwell-moonbeam) |
 | Notional Finance | 🔨 | | |
 | Radiant | 🔨 | | |
-| [Rari Fuse](https://app.rari.capital/fuse) | 🛠 | 2.0.1 / 1.1.4 / 1.0.0 | [![Rari Fuse Ethereum](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/rari-fuse-ethereum) [![Rari Fuse Arbitrum](./docs/images/chains/arbitrum.png)](https://thegraph.com/hosted-service/subgraph/messari/rari-fuse-arbitrum) |
+| [Rari Fuse](https://app.rari.capital/fuse) | 🛠 | 2.0.1 / 1.1.5 / 1.0.0 | [![Rari Fuse Ethereum](./docs/images/chains/ethereum.png)](https://thegraph.com/hosted-service/subgraph/messari/rari-fuse-ethereum) [![Rari Fuse Arbitrum](./docs/images/chains/arbitrum.png)](https://thegraph.com/hosted-service/subgraph/messari/rari-fuse-arbitrum) |
 | [SCREAM](https://scream.sh/) | ✅ | 2.0.1 / 1.1.3 / 1.0.0 | [![SCREAM Fantom](./docs/images/chains/fantom.png)](https://thegraph.com/hosted-service/subgraph/messari/scream-fantom) |
 | TrueFi | 🔨 | | |
 | [Tectonic](https://tectonic.finance/) | ✅ | 2.0.1 / 1.1.4 / 1.0.0 | [![Tectonic Cronos](./docs/images/chains/cronos.png)](https://graph.cronoslabs.com/subgraphs/name/messari/tectonic/graphql) |

--- a/deployment/deployment.dev.json
+++ b/deployment/deployment.dev.json
@@ -1275,7 +1275,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {

--- a/subgraphs/compound-forks/protocols/dforce/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/dforce/src/mapping.ts
@@ -3,7 +3,7 @@ import {
   BigInt,
   log,
   BigDecimal,
-  dataSource
+  dataSource,
 } from "@graphprotocol/graph-ts";
 // import from the generated at root in order to reuse methods from root
 import {
@@ -26,7 +26,7 @@ import {
   getOrElse,
   _handleActionPaused,
   snapshotFinancials,
-  _handleMarketEntered
+  _handleMarketEntered,
 } from "../../../src/mapping";
 import {
   cTokenDecimals,
@@ -35,7 +35,7 @@ import {
   exponentToBigDecimal,
   BIGDECIMAL_ZERO,
   SECONDS_PER_DAY,
-  Network
+  Network,
 } from "../../../src/constants";
 import {
   LendingProtocol,
@@ -43,7 +43,7 @@ import {
   Market,
   _DforceMarketStatus,
   RewardToken,
-  FinancialsDailySnapshot
+  FinancialsDailySnapshot,
 } from "../../../generated/schema";
 import { ERC20 } from "../../../generated/Comptroller/ERC20";
 
@@ -52,7 +52,7 @@ import { CToken } from "../../../generated/Comptroller/CToken";
 import { PriceOracle } from "../../../generated/Comptroller/PriceOracle";
 import {
   CToken as CTokenTemplate,
-  Reward as RewardTemplate
+  Reward as RewardTemplate,
 } from "../../../generated/templates";
 import {
   getNetworkSpecificConstant,
@@ -63,16 +63,16 @@ import {
   PRICE_BASE,
   DISTRIBUTIONFACTOR_BASE,
   DF_ADDRESS,
-  MKR_ADDRESS
+  MKR_ADDRESS,
 } from "./constants";
 import {
   RewardDistributor,
   RewardDistributed,
-  NewRewardToken
+  NewRewardToken,
 } from "../../../generated/templates/Reward/RewardDistributor";
 import {
   stablecoin,
-  Transfer as StablecoinTransfer
+  Transfer as StablecoinTransfer,
 } from "../../../generated/USX/stablecoin";
 import {
   NewPriceOracle,
@@ -86,7 +86,7 @@ import {
   TransferPaused,
   Comptroller,
   MarketEntered,
-  MarketExited
+  MarketExited,
 } from "../../../generated/Comptroller/Comptroller";
 import {
   Mint,
@@ -95,7 +95,7 @@ import {
   RepayBorrow,
   LiquidateBorrow,
   UpdateInterest as AccrueInterest,
-  NewReserveRatio
+  NewReserveRatio,
 } from "../../../generated/templates/CToken/CToken";
 
 // Constant values
@@ -240,7 +240,7 @@ export function handleMintPaused(event: MintPaused): void {
   market.isActive = !anyTrue([
     _marketStatus.mintPaused,
     _marketStatus.redeemPaused,
-    _marketStatus.transferPaused
+    _marketStatus.transferPaused,
   ]);
 
   market.save();
@@ -263,7 +263,7 @@ export function handleRedeemPaused(event: RedeemPaused): void {
   market.isActive = !anyTrue([
     _marketStatus.mintPaused,
     _marketStatus.redeemPaused,
-    _marketStatus.transferPaused
+    _marketStatus.transferPaused,
   ]);
 
   market.save();
@@ -289,7 +289,7 @@ export function handleTransferPaused(event: TransferPaused): void {
     market.isActive = !anyTrue([
       _marketStatus.mintPaused,
       _marketStatus.redeemPaused,
-      _marketStatus.transferPaused
+      _marketStatus.transferPaused,
     ]);
 
     market.save();
@@ -517,7 +517,7 @@ export function handleRewardDistributed(event: RewardDistributed): void {
   let rewardToken = Token.load(rewardTokenId);
   if (rewardToken == null) {
     log.warning("[handleRewardDistributed] Token not found: {}", [
-      rewardTokenId
+      rewardTokenId,
     ]);
     return;
   }

--- a/subgraphs/compound-forks/protocols/rari-fuse/README.md
+++ b/subgraphs/compound-forks/protocols/rari-fuse/README.md
@@ -84,6 +84,7 @@ Fuse has had a number of hacks throughout it's life. There are numerous price or
   - This new price is calculated from our price library if the token price is outside of the threshold ($0.50-$2.00) as a backup
 - There was a weak price oracle exploit done on a FLOAT market on Janruary 14th, 2022. https://twitter.com/FloatProtocol/status/1482113645903446019
   - To fix the uncharacteristic spike we use another price oracle to get the price.
+  - Transaction: https://etherscan.io/tx/0x40db7bd89d2a3f7df2793ba4f5be9a2ca93463d6bb6af024e5cd1b73ff827248
 
 ## Reference and Useful Links
 

--- a/subgraphs/compound-forks/protocols/rari-fuse/README.md
+++ b/subgraphs/compound-forks/protocols/rari-fuse/README.md
@@ -82,6 +82,8 @@ Fuse has had a number of hacks throughout it's life. There are numerous price or
 - Vesper pool (0x2914e8c1c2c54e5335dc9554551438c59373e807) exhibited price oracle manipulation on 11/2/2021 and 12/30/2021
   - To correct the erroneous prices we override the pricing during those points in time to prevent unrealilistic numbers in our subgraph
   - This new price is calculated from our price library if the token price is outside of the threshold ($0.50-$2.00) as a backup
+- There was a weak price oracle exploit done on a FLOAT market on Janruary 14th, 2022. https://twitter.com/FloatProtocol/status/1482113645903446019
+  - To fix the uncharacteristic spike we use another price oracle to get the price.
 
 ## Reference and Useful Links
 

--- a/subgraphs/compound-forks/protocols/rari-fuse/config/networks/ethereum/ethereum.json
+++ b/subgraphs/compound-forks/protocols/rari-fuse/config/networks/ethereum/ethereum.json
@@ -2,7 +2,7 @@
   "network": "mainnet",
   "fusePoolDirectoryAddress": "0x835482FE0532f169024d5E9410199369aAD5C77E",
   "startBlock": 12060007,
-  "graftEnabled": false,
-  "subgraphId": "QmWqNBqSuMYDZ7VK2YfjfwBT7w74CLJAfqN6gRh92zL7CT",
-  "graftStartBlock": 13380833
+  "graftEnabled": true,
+  "subgraphId": "QmaxJioqmCB9DPLhDYAPRwbQjqDu8nfSZYUWgNsVpERSVa",
+  "graftStartBlock": 14006050
 }

--- a/subgraphs/compound-forks/protocols/rari-fuse/src/constants.ts
+++ b/subgraphs/compound-forks/protocols/rari-fuse/src/constants.ts
@@ -57,6 +57,9 @@ export const GOHM_ADDRESS = "0x0ab87046fBb341D058F17CBC4c1133F25a20a52f";
 export const FMIM_ADDRESS = "0xd9444bab79720e8223b83e5d913d00c679b44b65";
 export const VESPER_V_DOLLAR_ADDRESS =
   "0x2914e8c1c2c54e5335dc9554551438c59373e807";
+export const FLOAT_MARKET_ADDRESS =
+  "0x898beab27b8d44501de79b946f8d4c67918e1c47";
+export const FLOAT_ADDRESS = "0xb05097849bca421a3f51b249ba6cca4af4b97cb9";
 
 ///////////////////////////
 //// Protocol Specific ////
@@ -64,6 +67,6 @@ export const VESPER_V_DOLLAR_ADDRESS =
 
 export const PROTOCOL_NAME = "Rari Fuse";
 export const PROTOCOL_SLUG = "rari-fuse";
-export const SUBGRAPH_VERSION = "1.1.4";
+export const SUBGRAPH_VERSION = "1.1.5";
 export const SCHEMA_VERSION = "2.0.1";
 export const METHODOLOGY_VERSION = "1.0.0";

--- a/subgraphs/compound-forks/protocols/rari-fuse/src/mappings.ts
+++ b/subgraphs/compound-forks/protocols/rari-fuse/src/mappings.ts
@@ -38,6 +38,8 @@ import {
   ETH_ADDRESS,
   ETH_NAME,
   ETH_SYMBOL,
+  FLOAT_ADDRESS,
+  FLOAT_MARKET_ADDRESS,
   FMIM_ADDRESS,
   getNetworkSpecificConstant,
   GOHM_ADDRESS,
@@ -735,6 +737,17 @@ function updateMarket(
     let customPrice = getUsdPricePerToken(
       Address.fromString(market.inputToken)
     );
+    underlyingTokenPriceUSD = customPrice.usdPrice.div(
+      customPrice.decimalsBaseTen
+    );
+  }
+
+  // fix FLOAT price exploit and high dailyDeposit at block number 14006054
+  if (
+    marketID.toLowerCase() == FLOAT_MARKET_ADDRESS.toLowerCase() &&
+    blockNumber.toI32() == 14006054
+  ) {
+    let customPrice = getUsdPricePerToken(Address.fromString(FLOAT_ADDRESS));
     underlyingTokenPriceUSD = customPrice.usdPrice.div(
       customPrice.decimalsBaseTen
     );


### PR DESCRIPTION
$FLOAT price oracle was exploited at this transaction https://etherscan.io/tx/0x40db7bd89d2a3f7df2793ba4f5be9a2ca93463d6bb6af024e5cd1b73ff827248 and to fix this we use our own price oracle to get the price at that block. Increment the version to `1.1.4`

Testing: https://okgraph.xyz/?q=dmelotik%2Ffuse-mainnet