### PR TITLE
patch(#minor); Uniswap V3; Updated usage metrics for swaps, and removed unnecessary log

### DIFF
--- a/subgraphs/uniswap-v3/protocols/uniswap-v3/src/common/constants.ts
+++ b/subgraphs/uniswap-v3/protocols/uniswap-v3/src/common/constants.ts
@@ -2,7 +2,7 @@
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.1";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.2";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "Uniswap V3";
 export const PROTOCOL_SLUG = "uniswap-v3";

--- a/subgraphs/uniswap-v3/src/common/price/price.ts
+++ b/subgraphs/uniswap-v3/src/common/price/price.ts
@@ -105,7 +105,6 @@ export function updateNativeTokenPriceInUSD(): Token {
     nativeToken.lastPriceUSD = largestPool.tokenPrices[tokenIndicator];
   }
 
-  log.warning("NATIVE PRICE: " + nativeToken.lastPriceUSD!.toString(), []);
   return nativeToken;
 }
 

--- a/subgraphs/uniswap-v3/src/mappings/core.ts
+++ b/subgraphs/uniswap-v3/src/mappings/core.ts
@@ -1,4 +1,5 @@
 // import { log } from '@graphprotocol/graph-ts'
+import { log } from "@graphprotocol/graph-ts";
 import {
   Burn as BurnEvent,
   Initialize,
@@ -69,5 +70,5 @@ export function handleSwap(event: SwapEvent): void {
   );
   updateFinancials(event);
   updatePoolMetrics(event);
-  updateUsageMetrics(event, event.params.sender, UsageType.SWAP);
+  updateUsageMetrics(event, event.transaction.from, UsageType.SWAP);
 }

--- a/subgraphs/uniswap-v3/src/mappings/core.ts
+++ b/subgraphs/uniswap-v3/src/mappings/core.ts
@@ -1,5 +1,4 @@
-// import { log } from '@graphprotocol/graph-ts'
-import { log } from "@graphprotocol/graph-ts";
+// import { log } from "@graphprotocol/graph-ts";
 import {
   Burn as BurnEvent,
   Initialize,


### PR DESCRIPTION
**Context:**
Usage metrics are pretty inconsistent with defillama. This is because the usage on the swaps are being recorded incorrectly. This PR fixes that by updating the user for usage metrics. Also, there is the remove of an unnecessary log in this PR. 