### PR TITLE
patch(#minor); Uniswap Forks; Updated protocol getter to update versions on get.

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2671,7 +2671,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2690,7 +2690,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2716,7 +2716,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.0.2",
+          "subgraph": "1.0.3",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2735,7 +2735,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.0.1",
+          "subgraph": "1.0.3",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2761,7 +2761,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.0.3",
+          "subgraph": "1.0.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2787,7 +2787,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.4",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2813,7 +2813,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2839,7 +2839,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.4",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2865,7 +2865,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2884,7 +2884,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2903,7 +2903,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2922,7 +2922,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2941,7 +2941,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2960,7 +2960,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2979,7 +2979,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2998,7 +2998,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.8",
+          "subgraph": "1.1.9",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -3017,7 +3017,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.8",
+          "subgraph": "1.1.9",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -3036,7 +3036,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -3055,7 +3055,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -3074,7 +3074,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -3100,7 +3100,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.6",
+          "subgraph": "1.1.7",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -3126,7 +3126,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.0.2",
+          "subgraph": "1.0.3",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -3152,7 +3152,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.5",
+          "subgraph": "1.1.6",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -3178,7 +3178,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -3204,7 +3204,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.7",
+          "subgraph": "1.1.8",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -3230,7 +3230,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.0.3",
+          "subgraph": "1.0.4",
           "methodology": "1.0.1"
         },
         "deployment-ids": {
@@ -3249,7 +3249,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.0.3",
+          "subgraph": "1.0.4",
           "methodology": "1.0.1"
         },
         "deployment-ids": {

--- a/subgraphs/uniswap-forks/protocols/apeswap/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/apeswap/src/common/constants.ts
@@ -2,9 +2,7 @@
 //////Versions//////
 ////////////////////
 
-import { log } from "@graphprotocol/graph-ts";
-
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.7";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.8";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "ApeSwap";
 export const PROTOCOL_SLUG = "apeswap";

--- a/subgraphs/uniswap-forks/protocols/honeyswap/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/honeyswap/src/common/constants.ts
@@ -2,7 +2,7 @@
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.0.3";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.0.4";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "Honeyswap";
 export const PROTOCOL_SLUG = "honeyswap";

--- a/subgraphs/uniswap-forks/protocols/mm-finance/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/mm-finance/src/common/constants.ts
@@ -2,7 +2,7 @@
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.0.2";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.0.3";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "MM Finance";
 export const PROTOCOL_SLUG = "mm-finance";

--- a/subgraphs/uniswap-forks/protocols/quickswap/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/quickswap/src/common/constants.ts
@@ -2,7 +2,7 @@
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.0.3";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.0.4";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "QuickSwap";
 export const PROTOCOL_SLUG = "quickswap";

--- a/subgraphs/uniswap-forks/protocols/solarbeam/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/solarbeam/src/common/constants.ts
@@ -2,7 +2,7 @@
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.4";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.5";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "Solarbeam";
 export const PROTOCOL_SLUG = "solarbeam";

--- a/subgraphs/uniswap-forks/protocols/spiritswap/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/spiritswap/src/common/constants.ts
@@ -2,7 +2,7 @@
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.4";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.5";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "SpiritSwap";
 export const PROTOCOL_SLUG = "spiritswap";

--- a/subgraphs/uniswap-forks/protocols/spookyswap/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/spookyswap/src/common/constants.ts
@@ -2,7 +2,7 @@
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.5";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.6";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "SpookySwap";
 export const PROTOCOL_SLUG = "spookyswap";

--- a/subgraphs/uniswap-forks/protocols/sushiswap/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/src/common/constants.ts
@@ -4,7 +4,7 @@ import { BigInt } from "@graphprotocol/graph-ts";
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.8";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.9";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "SushiSwap";
 export const PROTOCOL_SLUG = "sushiswap";

--- a/subgraphs/uniswap-forks/protocols/trader-joe/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/trader-joe/src/common/constants.ts
@@ -4,7 +4,7 @@ import { BigInt } from "@graphprotocol/graph-ts";
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.6";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.7";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "Trader Joe";
 export const PROTOCOL_SLUG = "trader-joe";

--- a/subgraphs/uniswap-forks/protocols/trisolaris/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/trisolaris/src/common/constants.ts
@@ -2,7 +2,7 @@
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.0.2";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.0.3";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "Trisolaris";
 export const PROTOCOL_SLUG = "trisolaris";

--- a/subgraphs/uniswap-forks/protocols/ubeswap/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/ubeswap/src/common/constants.ts
@@ -2,9 +2,7 @@
 //////Versions//////
 ////////////////////
 
-import { log } from "@graphprotocol/graph-ts";
-
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.6";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.7";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "Ubeswap";
 export const PROTOCOL_SLUG = "ubeswap";

--- a/subgraphs/uniswap-forks/protocols/uniswap-v2/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/protocols/uniswap-v2/src/common/constants.ts
@@ -2,9 +2,7 @@
 //////Versions//////
 ////////////////////
 
-import { log } from "@graphprotocol/graph-ts";
-
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.7";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.8";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "Uniswap V2";
 export const PROTOCOL_SLUG = "uniswap-v2";

--- a/subgraphs/uniswap-forks/src/common/getters.ts
+++ b/subgraphs/uniswap-forks/src/common/getters.ts
@@ -51,6 +51,11 @@ export function getOrCreateDex(): DexAmmProtocol {
 
     protocol.save();
   }
+
+  protocol.schemaVersion = NetworkConfigs.getSchemaVersion();
+  protocol.subgraphVersion = NetworkConfigs.getSubgraphVersion();
+  protocol.methodologyVersion = NetworkConfigs.getMethodologyVersion();
+  
   return protocol;
 }
 

--- a/subgraphs/uniswap-forks/src/common/getters.ts
+++ b/subgraphs/uniswap-forks/src/common/getters.ts
@@ -48,13 +48,12 @@ export function getOrCreateDex(): DexAmmProtocol {
     protocol.network = NetworkConfigs.getNetwork();
     protocol.type = ProtocolType.EXCHANGE;
     protocol.totalPoolCount = INT_ZERO;
-
-    protocol.save();
   }
 
   protocol.schemaVersion = NetworkConfigs.getSchemaVersion();
   protocol.subgraphVersion = NetworkConfigs.getSubgraphVersion();
   protocol.methodologyVersion = NetworkConfigs.getMethodologyVersion();
+  protocol.save();
   
   return protocol;
 }


### PR DESCRIPTION
**Context:**
The protocol entity gets created at the beginning of indexing, and when you graft on top, even though you change the version, the protocol entity still displays the older version. This will happen unless the versions get reset in the protocol getters. This fix sets the version after each get. 