### PR TITLE
patch(#minor); Uniswap V3; Updated protocol getter to update versions on get.

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2410,7 +2410,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.2",
+          "subgraph": "1.1.3",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2429,7 +2429,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.2",
+          "subgraph": "1.1.3",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2448,7 +2448,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.2",
+          "subgraph": "1.1.3",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2467,7 +2467,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.2",
+          "subgraph": "1.1.3",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -2486,7 +2486,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.2",
+          "subgraph": "1.1.3",
           "methodology": "1.0.0"
         },
         "deployment-ids": {

--- a/subgraphs/uniswap-v3/protocols/uniswap-v3/src/common/constants.ts
+++ b/subgraphs/uniswap-v3/protocols/uniswap-v3/src/common/constants.ts
@@ -2,7 +2,7 @@
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.2";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.3";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "Uniswap V3";
 export const PROTOCOL_SLUG = "uniswap-v3";

--- a/subgraphs/uniswap-v3/src/common/getters.ts
+++ b/subgraphs/uniswap-v3/src/common/getters.ts
@@ -48,8 +48,13 @@ export function getOrCreateDex(): DexAmmProtocol {
     protocol.type = ProtocolType.EXCHANGE;
     protocol.totalPoolCount = INT_ZERO;
     protocol._regenesis = false;
-    protocol.save();
   }
+
+  protocol.schemaVersion = NetworkConfigs.getSchemaVersion();
+  protocol.subgraphVersion = NetworkConfigs.getSubgraphVersion();
+  protocol.methodologyVersion = NetworkConfigs.getMethodologyVersion();
+  protocol.save();
+
   return protocol;
 }
 


### PR DESCRIPTION
Context:
Relate to PR #1003 

The protocol entity gets created at the beginning of indexing, and when you graft on top, even though you change the version, the protocol entity still displays the older version. This will happen unless the versions get reset in the protocol getters. This fix sets the version after each get.