### PR TITLE
fix(#patch); compound forks; add transfer handler

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -785,7 +785,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -811,7 +811,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.4",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -837,7 +837,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.4",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -889,7 +889,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -915,7 +915,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.7.3",
+          "subgraph": "1.7.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -942,7 +942,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.4",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -961,7 +961,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.4",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -999,7 +999,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.4",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1025,7 +1025,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1044,7 +1044,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1063,7 +1063,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1082,7 +1082,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1101,7 +1101,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1120,7 +1120,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1146,7 +1146,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1165,7 +1165,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1185,7 +1185,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1211,7 +1211,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1230,7 +1230,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1275,7 +1275,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.4",
+          "subgraph": "1.1.6",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1301,7 +1301,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "deployment-ids": {
@@ -1327,7 +1327,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.4",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "deployment-ids": {

--- a/subgraphs/compound-forks/protocols/aurigami/config/templates/aurigami.template.yaml
+++ b/subgraphs/compound-forks/protocols/aurigami/config/templates/aurigami.template.yaml
@@ -80,4 +80,6 @@ templates:
           handler: handleAccrueInterest
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/aurigami/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/aurigami/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/aurigami/src/mapping.ts
@@ -17,6 +17,7 @@ import {
   LiquidateBorrow,
   AccrueInterest,
   NewReserveFactor,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 import { LendingProtocol, Token } from "../../../generated/schema";
 import {
@@ -45,6 +46,7 @@ import {
   getOrElse,
   _handleActionPaused,
   _handleMarketEntered,
+  _handleTransfer,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";
@@ -275,6 +277,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
   );
 }
 
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
+  );
+}
+
 function getOrCreateProtocol(): LendingProtocol {
   let comptroller = Comptroller.bind(comptrollerAddr);
   let protocolData = new ProtocolData(
@@ -282,7 +294,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Aurigami",
     "aurigami",
     "2.0.1",
-    "1.1.3",
+    "1.1.4",
     "1.0.0",
     Network.AURORA,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/protocols/banker-joe/config/templates/banker-joe.template.yaml
+++ b/subgraphs/compound-forks/protocols/banker-joe/config/templates/banker-joe.template.yaml
@@ -80,4 +80,6 @@ templates:
           handler: handleAccrueInterest
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/banker-joe/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/banker-joe/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/banker-joe/src/mapping.ts
@@ -17,6 +17,7 @@ import {
   LiquidateBorrow,
   AccrueInterest,
   NewReserveFactor,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 import {
   LendingProtocol,
@@ -51,6 +52,7 @@ import {
   _handleActionPaused,
   _handleMarketEntered,
   getMarketDailySnapshotID,
+  _handleTransfer,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";
@@ -295,6 +297,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
   );
 }
 
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
+  );
+}
+
 function getOrCreateProtocol(): LendingProtocol {
   let comptroller = Comptroller.bind(comptrollerAddr);
   let protocolData = new ProtocolData(
@@ -302,7 +314,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Banker Joe",
     "banker-joe",
     "2.0.1",
-    "1.1.4",
+    "1.1.5",
     "1.0.0",
     Network.AVALANCHE,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/protocols/bastion-protocol/config/templates/bastion-protocol.template.yaml
+++ b/subgraphs/compound-forks/protocols/bastion-protocol/config/templates/bastion-protocol.template.yaml
@@ -82,4 +82,6 @@ templates:
           handler: handleAccrueInterest
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/bastion-protocol/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/bastion-protocol/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/bastion-protocol/src/mapping.ts
@@ -17,6 +17,7 @@ import {
   LiquidateBorrow,
   AccrueInterest,
   NewReserveFactor,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 import {
   LendingProtocol,
@@ -57,6 +58,7 @@ import {
   getOrElse,
   _handleActionPaused,
   _handleMarketEntered,
+  _handleTransfer,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";
@@ -296,6 +298,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     totalBorrows,
     false, // do not update all market prices
     event
+  );
+}
+
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
   );
 }
 

--- a/subgraphs/compound-forks/protocols/benqi/config/templates/benqi.template.yaml
+++ b/subgraphs/compound-forks/protocols/benqi/config/templates/benqi.template.yaml
@@ -84,4 +84,6 @@ templates:
           handler: handleAccrueInterest
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/benqi/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/benqi/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/benqi/src/mapping.ts
@@ -23,6 +23,7 @@ import {
   LiquidateBorrow,
   AccrueInterest,
   NewReserveFactor,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 import {
   LendingProtocol,
@@ -61,6 +62,7 @@ import {
   getOrElse,
   _handleActionPaused,
   _handleMarketEntered,
+  _handleTransfer,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";
@@ -315,6 +317,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
   );
 }
 
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
+  );
+}
+
 function getOrCreateProtocol(): LendingProtocol {
   let comptroller = Comptroller.bind(comptrollerAddr);
   let protocolData = new ProtocolData(
@@ -322,7 +334,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "BENQI",
     "benqi",
     "2.0.1",
-    "1.1.3",
+    "1.1.4",
     "1.0.0",
     Network.AVALANCHE,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/protocols/compound-v2/config/templates/compound-v2.template.yaml
+++ b/subgraphs/compound-forks/protocols/compound-v2/config/templates/compound-v2.template.yaml
@@ -136,6 +136,8 @@ templates:
           handler: handleLiquidateBorrow
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
         - event: AccrueInterest(uint256,uint256,uint256,uint256)
           handler: handleAccrueInterestNew
   - name: CTokenOld

--- a/subgraphs/compound-forks/protocols/compound-v2/src/constants.ts
+++ b/subgraphs/compound-forks/protocols/compound-v2/src/constants.ts
@@ -129,7 +129,7 @@ export const CTUSD_ADDRESS = "0x12392f67bdf24fae0af363c24ac620a2f67dad86";
 
 export const PROTOCOL_NAME = "Compound v2";
 export const PROTOCOL_SLUG = "compound-v2";
-export const SUBGRAPH_VERSION = "1.7.3";
+export const SUBGRAPH_VERSION = "1.7.4";
 export const SCHEMA_VERSION = "2.0.1";
 export const METHODOLOGY_VERSION = "1.0.0";
 export const USDC_DECIMALS = 6;

--- a/subgraphs/compound-forks/protocols/compound-v2/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/compound-v2/src/mapping.ts
@@ -16,6 +16,7 @@ import {
   RepayBorrow,
   LiquidateBorrow,
   NewReserveFactor,
+  Transfer,
   AccrueInterest as AccrueInterestNew,
 } from "../../../generated/templates/CToken/CToken";
 import { AccrueInterest as AccrueInterestOld } from "../../../generated/templates/CTokenOld/CTokenOld";
@@ -70,6 +71,7 @@ import {
   _handleNewReserveFactor,
   _handleRedeem,
   _handleRepayBorrow,
+  _handleTransfer,
 } from "../../../src/mapping";
 import { CToken, CTokenOld } from "../../../generated/templates";
 import {
@@ -182,6 +184,16 @@ export function handleNewReserveFactor(event: NewReserveFactor): void {
   let marketID = event.address.toHexString();
   let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
   _handleNewReserveFactor(marketID, newReserveFactorMantissa);
+}
+
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
+  );
 }
 
 export function handleAccrueInterestNew(event: AccrueInterestNew): void {

--- a/subgraphs/compound-forks/protocols/cream-finance/config/deployments/cream-finance-arbitrum/configurations.json
+++ b/subgraphs/compound-forks/protocols/cream-finance/config/deployments/cream-finance-arbitrum/configurations.json
@@ -2,7 +2,7 @@
   "network": "arbitrum-one",
   "factoryAddress": "0xbadaC56c9aca307079e8B8FC699987AAc89813ee",
   "startBlock": 291895,
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "QmRxj82pgaGQcpmCRE8NnYnrhrtLs7SXkqzGbPkcht7orA",
   "graftStartBlock": 24291735
 }

--- a/subgraphs/compound-forks/protocols/cream-finance/config/deployments/cream-finance-bsc/configurations.json
+++ b/subgraphs/compound-forks/protocols/cream-finance/config/deployments/cream-finance-bsc/configurations.json
@@ -2,7 +2,7 @@
   "network": "bsc",
   "factoryAddress": "0x589de0f0ccf905477646599bb3e5c622c84cc0ba",
   "startBlock": 100320,
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "QmUWSMz3kFJ7CUQnv568epnoLaovvMMEpXXup5VnTfXjC1",
   "graftStartBlock": 21274756
 }

--- a/subgraphs/compound-forks/protocols/cream-finance/config/deployments/cream-finance-ethereum/configurations.json
+++ b/subgraphs/compound-forks/protocols/cream-finance/config/deployments/cream-finance-ethereum/configurations.json
@@ -2,7 +2,7 @@
   "network": "mainnet",
   "factoryAddress": "0x3d5BC3c8d13dcB8bF317092d84783c2697AE9258",
   "startBlock": 10579797,
-  "graftEnabled": true,
-  "subgraphId": "Qmd6jPLiZvemxYhiejRK1tCwvVAopa6oiyxDFfqxaRUBkj",
-  "graftStartBlock": 13499750
+  "graftEnabled": false,
+  "subgraphId": "QmSaWk5a8qNts2K7NohJWuPUdrV8JdtSG77VCCBjCrXL6d",
+  "graftStartBlock": 15522327
 }

--- a/subgraphs/compound-forks/protocols/cream-finance/config/deployments/cream-finance-polygon/configurations.json
+++ b/subgraphs/compound-forks/protocols/cream-finance/config/deployments/cream-finance-polygon/configurations.json
@@ -2,7 +2,7 @@
   "network": "matic",
   "factoryAddress": "0x20CA53E2395FA571798623F1cFBD11Fe2C114c24",
   "startBlock": 15815574,
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "QmWZ46fiJi45aNWUEnaaVrra9TUM23TsuPbYzfSR1gEXHo",
   "graftStartBlock": 33021649
 }

--- a/subgraphs/compound-forks/protocols/cream-finance/config/templates/cream-finance.template.yaml
+++ b/subgraphs/compound-forks/protocols/cream-finance/config/templates/cream-finance.template.yaml
@@ -132,4 +132,6 @@ templates:
           handler: handleAccrueInterest
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/cream-finance/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/cream-finance/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/cream-finance/src/mapping.ts
@@ -62,6 +62,8 @@ import {
   _handleMarketEntered,
   getTokenPriceUSD,
   _handleTransfer,
+  getOrCreateMarketDailySnapshot,
+  getOrCreateMarketHourlySnapshot,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";

--- a/subgraphs/compound-forks/protocols/cream-finance/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/cream-finance/src/mapping.ts
@@ -23,6 +23,7 @@ import {
   LiquidateBorrow,
   AccrueInterest,
   NewReserveFactor,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 import {
   FinancialsDailySnapshot,
@@ -60,8 +61,7 @@ import {
   _handleActionPaused,
   _handleMarketEntered,
   getTokenPriceUSD,
-  getOrCreateMarketDailySnapshot,
-  getOrCreateMarketHourlySnapshot,
+  _handleTransfer,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";
@@ -433,6 +433,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
     totalBorrows,
     false, // do not update all prices
     event
+  );
+}
+
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
   );
 }
 

--- a/subgraphs/compound-forks/protocols/dforce/config/templates/dforce.template.yaml
+++ b/subgraphs/compound-forks/protocols/dforce/config/templates/dforce.template.yaml
@@ -139,6 +139,8 @@ templates:
           handler: handleUpdateInterest
         - event: NewReserveRatio(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/dforce/src/mapping.ts
 
   - kind: ethereum/contract

--- a/subgraphs/compound-forks/protocols/dforce/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/dforce/src/mapping.ts
@@ -27,6 +27,7 @@ import {
   _handleActionPaused,
   snapshotFinancials,
   _handleMarketEntered,
+  _handleTransfer,
 } from "../../../src/mapping";
 import {
   cTokenDecimals,
@@ -96,6 +97,7 @@ import {
   LiquidateBorrow,
   UpdateInterest as AccrueInterest,
   NewReserveRatio,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 
 // Constant values
@@ -642,6 +644,16 @@ export function handleStablecoinTransfer(event: StablecoinTransfer): void {
   snapshot!.save();
 }
 
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
+  );
+}
+
 function getOrCreateProtocol(): LendingProtocol {
   let comptroller = Comptroller.bind(comptrollerAddr);
   let protocolData = new ProtocolData(
@@ -649,7 +661,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "dForce v2",
     "dforce-v2",
     "2.0.1",
-    "1.1.4",
+    "1.1.5",
     "1.0.0",
     network,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/protocols/iron-bank/config/templates/iron-bank.template.yaml
+++ b/subgraphs/compound-forks/protocols/iron-bank/config/templates/iron-bank.template.yaml
@@ -80,4 +80,6 @@ templates:
           handler: handleAccrueInterest
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/iron-bank/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/iron-bank/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/iron-bank/src/mapping.ts
@@ -17,6 +17,7 @@ import {
   LiquidateBorrow,
   AccrueInterest,
   NewReserveFactor,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 import { LendingProtocol, Token } from "../../../generated/schema";
 import { cTokenDecimals, BIGINT_ZERO } from "../../../src/constants";
@@ -40,6 +41,7 @@ import {
   getOrElse,
   _handleActionPaused,
   _handleMarketEntered,
+  _handleTransfer,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";
@@ -279,6 +281,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
   );
 }
 
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
+  );
+}
+
 function getOrCreateProtocol(): LendingProtocol {
   let comptroller = Comptroller.bind(comptrollerAddr);
   let protocolData = new ProtocolData(
@@ -286,7 +298,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Iron Bank",
     "iron-bank",
     "2.0.1",
-    "1.1.4",
+    "1.1.5",
     "1.0.0",
     network,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/protocols/moonwell/config/templates/moonwell.template.yaml
+++ b/subgraphs/compound-forks/protocols/moonwell/config/templates/moonwell.template.yaml
@@ -82,4 +82,6 @@ templates:
           handler: handleAccrueInterest
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/moonwell/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/moonwell/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/moonwell/src/mapping.ts
@@ -22,6 +22,7 @@ import {
   LiquidateBorrow,
   AccrueInterest,
   NewReserveFactor,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 import {
   LendingProtocol,
@@ -59,6 +60,7 @@ import {
   _handleAccrueInterest,
   getOrElse,
   _handleMarketEntered,
+  _handleTransfer,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";
@@ -324,6 +326,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
   );
 }
 
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
+  );
+}
+
 function getOrCreateProtocol(): LendingProtocol {
   let comptroller = Comptroller.bind(comptrollerAddr);
   let protocolData = new ProtocolData(
@@ -331,7 +343,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Moonwell",
     "moonwell",
     "2.0.1",
-    "1.1.3",
+    "1.1.4",
     "1.0.0",
     Network.MOONRIVER,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/protocols/rari-fuse/config/templates/rari-fuse.template.yaml
+++ b/subgraphs/compound-forks/protocols/rari-fuse/config/templates/rari-fuse.template.yaml
@@ -153,3 +153,5 @@ templates:
           handler: handleNewFuseFee
         - event: NewAdminFee(uint256,uint256)
           handler: handleNewAdminFee
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer

--- a/subgraphs/compound-forks/protocols/rari-fuse/src/mappings.ts
+++ b/subgraphs/compound-forks/protocols/rari-fuse/src/mappings.ts
@@ -32,6 +32,7 @@ import {
   getOrCreateMarketDailySnapshot,
   getOrCreateMarketHourlySnapshot,
   _handleMarketEntered,
+  _handleTransfer,
 } from "../../../src/mapping";
 import { PoolRegistered } from "../../../generated/FusePoolDirectory/FusePoolDirectory";
 import {
@@ -71,6 +72,7 @@ import {
   NewReserveFactor,
   Redeem,
   RepayBorrow,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 import {
   NewAdminFee,
@@ -609,6 +611,17 @@ export function handleNewReserveFactor(event: NewReserveFactor): void {
   let marketID = event.address.toHexString();
   let newReserveFactorMantissa = event.params.newReserveFactorMantissa;
   _handleNewReserveFactor(marketID, newReserveFactorMantissa);
+}
+
+export function handleTransfer(event: Transfer): void {
+  let factoryContract = Address.fromString(FACTORY_CONTRACT);
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    factoryContract
+  );
 }
 
 /////////////////

--- a/subgraphs/compound-forks/protocols/rari-fuse/src/rewards.ts
+++ b/subgraphs/compound-forks/protocols/rari-fuse/src/rewards.ts
@@ -202,9 +202,8 @@ export function getRewardsPerDay(
     unnormalizedBlockSpeed = BIGDECIMAL_ZERO;
   } else {
     unnormalizedBlockSpeed =
-    WINDOW_SIZE_SECONDS_BD.div(windowSecondsCount).times(windowBlocksCount);
+      WINDOW_SIZE_SECONDS_BD.div(windowSecondsCount).times(windowBlocksCount);
   }
-   
 
   // block speed converted to specified rate.
   let normalizedBlockSpeed = RATE_IN_SECONDS_BD.div(

--- a/subgraphs/compound-forks/protocols/scream/config/templates/scream.template.yaml
+++ b/subgraphs/compound-forks/protocols/scream/config/templates/scream.template.yaml
@@ -80,4 +80,6 @@ templates:
           handler: handleAccrueInterest
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/scream/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/scream/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/scream/src/mapping.ts
@@ -15,6 +15,7 @@ import {
   LiquidateBorrow,
   AccrueInterest,
   NewReserveFactor,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 import { LendingProtocol, Token } from "../../../generated/schema";
 import {
@@ -43,6 +44,7 @@ import {
   getOrElse,
   _handleActionPaused,
   _handleMarketEntered,
+  _handleTransfer,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";
@@ -264,6 +266,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
   );
 }
 
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
+  );
+}
+
 function getOrCreateProtocol(): LendingProtocol {
   let comptroller = Comptroller.bind(comptrollerAddr);
   let protocolData = new ProtocolData(
@@ -271,7 +283,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Scream",
     "scream",
     "2.0.1",
-    "1.1.3",
+    "1.1.4",
     "1.0.0",
     Network.FANTOM,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/protocols/tectonic/config/templates/tectonic.template.yaml
+++ b/subgraphs/compound-forks/protocols/tectonic/config/templates/tectonic.template.yaml
@@ -84,4 +84,6 @@ templates:
           handler: handleAccrueInterest
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/tectonic/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/tectonic/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/tectonic/src/mapping.ts
@@ -17,6 +17,7 @@ import {
   LiquidateBorrow,
   AccrueInterest,
   NewReserveFactor,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 
 import {
@@ -30,7 +31,6 @@ import {
   Network,
   BIGINT_ZERO,
   BIGDECIMAL_ZERO,
-  SECONDS_PER_YEAR,
   RewardTokenType,
   exponentToBigDecimal,
   DAYS_PER_YEAR,
@@ -56,6 +56,7 @@ import {
   getOrElse,
   _handleActionPaused,
   _handleMarketEntered,
+  _handleTransfer,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";
@@ -307,6 +308,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
   );
 }
 
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
+  );
+}
+
 function getOrCreateProtocol(): LendingProtocol {
   let comptroller = Comptroller.bind(comptrollerAddr);
   let protocolData = new ProtocolData(
@@ -314,7 +325,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Tectonic",
     "tectonic",
     "2.0.1",
-    "1.1.4",
+    "1.1.5",
     "1.0.0",
     Network.CRONOS,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/protocols/venus/config/templates/venus.template.yaml
+++ b/subgraphs/compound-forks/protocols/venus/config/templates/venus.template.yaml
@@ -80,4 +80,6 @@ templates:
           handler: handleAccrueInterest
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
       file: ./protocols/venus/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/venus/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/venus/src/mapping.ts
@@ -17,6 +17,7 @@ import {
   LiquidateBorrow,
   AccrueInterest,
   NewReserveFactor,
+  Transfer,
 } from "../../../generated/templates/CToken/CToken";
 import { LendingProtocol, Token } from "../../../generated/schema";
 import {
@@ -45,6 +46,7 @@ import {
   getOrElse,
   _handleActionPaused,
   _handleMarketEntered,
+  _handleTransfer,
 } from "../../../src/mapping";
 // otherwise import from the specific subgraph root
 import { CToken } from "../../../generated/Comptroller/CToken";
@@ -273,6 +275,16 @@ export function handleAccrueInterest(event: AccrueInterest): void {
   );
 }
 
+export function handleTransfer(event: Transfer): void {
+  _handleTransfer(
+    event,
+    event.address.toHexString(),
+    event.params.to,
+    event.params.from,
+    comptrollerAddr
+  );
+}
+
 function getOrCreateProtocol(): LendingProtocol {
   let comptroller = Comptroller.bind(comptrollerAddr);
   let protocolData = new ProtocolData(
@@ -280,7 +292,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Venus",
     "venus",
     "2.0.1",
-    "1.1.4",
+    "1.1.5",
     "1.0.0",
     Network.BSC,
     comptroller.try_liquidationIncentiveMantissa(),

--- a/subgraphs/compound-forks/src/constants.ts
+++ b/subgraphs/compound-forks/src/constants.ts
@@ -128,3 +128,9 @@ export function exponentToBigDecimal(decimals: i32): BigDecimal {
   }
   return result.toBigDecimal();
 }
+
+/////////////////////////////
+/////     Addresses     /////
+/////////////////////////////
+
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";

--- a/subgraphs/compound-forks/src/mapping.ts
+++ b/subgraphs/compound-forks/src/mapping.ts
@@ -116,7 +116,7 @@ export function _handleNewCollateralFactor(
   newCollateralFactorMantissa: BigInt
 ): void {
   let market = Market.load(marketID);
-  if (market == null) {
+  if (!market) {
     log.warning("[handleNewCollateralFactor] Market not found: {}", [marketID]);
     return;
   }
@@ -1051,7 +1051,7 @@ export function _handleNewReserveFactor(
   newReserveFactorMantissa: BigInt
 ): void {
   let market = Market.load(marketID);
-  if (market == null) {
+  if (!market) {
     log.warning("[handleNewReserveFactor] Market not found: {}", [marketID]);
     return;
   }
@@ -1070,14 +1070,14 @@ export function _handleTransfer(
   comptrollerAddr: Address
 ): void {
   let protocol = LendingProtocol.load(comptrollerAddr.toHexString());
-  if (protocol == null) {
+  if (!protocol) {
     log.warning("[_handleTransfer] protocol not found: {}", [
       comptrollerAddr.toHexString(),
     ]);
     return;
   }
   let market = Market.load(marketID);
-  if (market == null) {
+  if (!market) {
     log.warning("[_handleTransfer] market not found: {}", [
       event.address.toHexString(),
     ]);

--- a/subgraphs/compound-forks/src/mapping.ts
+++ b/subgraphs/compound-forks/src/mapping.ts
@@ -1084,13 +1084,20 @@ export function _handleTransfer(
     return;
   }
 
+  // if to / from - marketID then the transfer is associated with another event
+  // ie, a mint, redeem, borrow, repay, liquidateBorrow
+  // we want to skip these and let the event handlers take care of updates
+  if (
+    to.toHexString().toLowerCase() == marketID.toLowerCase() ||
+    from.toHexString().toLowerCase() == marketID.toLowerCase()
+  ) {
+    return;
+  }
+
   // grab accounts
   let toAccount = Account.load(to.toHexString());
   if (!toAccount) {
-    if (
-      to == Address.fromString(ZERO_ADDRESS) ||
-      to.toHexString().toLowerCase() == marketID.toLowerCase()
-    ) {
+    if (to == Address.fromString(ZERO_ADDRESS)) {
       toAccount = null;
     } else {
       toAccount = createAccount(to.toHexString());
@@ -1103,10 +1110,7 @@ export function _handleTransfer(
 
   let fromAccount = Account.load(from.toHexString());
   if (!fromAccount) {
-    if (
-      from == Address.fromString(ZERO_ADDRESS) ||
-      from.toHexString().toLowerCase() == marketID.toLowerCase()
-    ) {
+    if (from == Address.fromString(ZERO_ADDRESS)) {
       fromAccount = null;
     } else {
       fromAccount = createAccount(from.toHexString());


### PR DESCRIPTION
Adding the transfer handler allows us to properly track all positions in the protocol and not miss any.

incremented patch version of every compound-fork

This is not going to be a change for protocol metrics for mainnet. However, this will affect jacob anderson's whale watchers data app for mainnet.