### PR TITLE
fix (#minor); Build Checker Workflow Runner; Swap Ubuntu for Mac OS

### DIFF
--- a/.github/workflows/build-checker.yaml
+++ b/.github/workflows/build-checker.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   Deployment: 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps: 
       - id: files
         uses: Ana06/get-changed-files@v1.2


### PR DESCRIPTION
**Actions:**
- [x] Updated runner for `ubuntu-latest` to `macos-latest` in `build-checker` workflow.

**Context:**

There had been some instances of the build checker workflow failing, because the Ubuntu VM used to execute the Github actions is case sensitive - Linux's file system is case sensitive. There are developers, like myself, developing on Mac OS which has a case insensitive file system (Windows is as well). Unfortunately, it is not feasible to just turn case sensitivity on or off since it is a property of the file system. 

Ideally, this type of check would be supported by Typescript Eslint libraries, but I have not found any libraries that support this sort of linting for case sensitivity. They do have it for javascript within `eslint-config-dependencies`. 

Another potential route was typescript compiler options. However, since subgraphs are written in AssemblyScript, trying to turn on case sensitive file names in the `tsconfig.json` does not work either. 

For these reasons and difficulties, I am putting up this PR to simply swap out the runner from Ubuntu to Mac OS. I tested the GH Actions on a few subgraphs, and it worked fine on the Mac OS runner. 