### PR TITLE
docs(); Updated README to include comments on best practices for protocol version updates. 

### DIFF
--- a/docs/Mapping.md
+++ b/docs/Mapping.md
@@ -12,6 +12,10 @@ There are couple things you can do to significantly improve your indexing speed:
 - Avoid call handlers and block handlers. Also depending on the Ethereum node ran by an indexer, call handlers and block handlers may or may not be supported (esp. on alt-EVM chains).
 - Limit the number of contract calls you perform. If you do need to perform contract calls, save the data, so you won't have to do repeated calls.
 
+### Versions and Grafting
+
+- When fetching a protocol entity, it important that that the versions get updated at regular intervals such as at the time of fetching the protocol entity (Recommended). The 3 versions that should be updated are subgraph version, schema version, and methodology version. If the version is not updated, the subgraph will not be able to fetch the latest version of the protocol entity in cases where indexing is rebooted using the grafting feature.
+
 ### Forks and Multichain
 
 - You should put fork/network-specific configs in the `config` folder of each subgraph.
@@ -118,7 +122,7 @@ If you're having issues with the subgraph sync failing and no error messages sho
 
 1. Check your graph health here https://graphiql-online.com/. Where it says "Enter the GraphQL endpoint" copy paste this endpoint https://api.thegraph.com/index-node/graphql
 2. After running this, copy the sample query in section 5 of the graph docs here https://thegraph.com/docs/en/developer/quick-start/#5-check-your-logs into the window
-3. Replace the part where it says subgraphs: ["Qm..."]  with your deployment id (you will see this in the studio)
+3. Replace the part where it says subgraphs: ["Qm..."] with your deployment id (you will see this in the studio)
 4. Run the query, you will see if your subgraph had any indexing errors!
 
 ### Running Locally
@@ -134,8 +138,9 @@ A [video tutorial](https://youtu.be/nH_pZWgQb7g) on how to run the graph-node lo
 ### Postgres troubleshooting
 
 For those new to Postgres, the local node can be confusing when it comes to database authentication and general configuration. Here are a few things to check if the Postgres aspect of setting up the local node is giving you issues.
-> *Note*: the graph-node will not run properly on Windows. You must use WSL/WSL2  
-> *Note*: depending on your OS, the commands may vary
+
+> _Note_: the graph-node will not run properly on Windows. You must use WSL/WSL2  
+> _Note_: depending on your OS, the commands may vary
 
 1. If calling the initdb command to initialize a database returns errors regarding non existent files, make sure that the directory returned from command `pg_config --pkglibdir` was installed correctly and actually contains the files required by the database initialization process. If it doesn't, the Postgres installation failed and must be reinstalled.
 
@@ -145,7 +150,7 @@ For those new to Postgres, the local node can be confusing when it comes to data
 
 4. Unless you have set some other default, the database system initialized from initdb is owned by the username on your system (along with the databases created within this system such as "graph-node"). However, this username from the system has not yet been made as a Postgres role that has read, write etc permissions in the Postgres system. If you try to connect to a database with this role/username, authentication will fail. You must add the user as a Postgres superuser role (there are queries you can run to just give this role permissions for one database rather than as a superuser, but for simplicity sake I wont get into that here).
 
-5. Start the Postgres cli with command `sudo -i -u postgres` followed by command `psql`. If inside the shell you run `\l`, you will see a list of databases, which "graph-node" will have an owner of the same name as your system user name. At this point, back out and run query `\du` to check if the owner of 'graph-node' database is in this list of roles. If not, run query `CREATE ROLE `*`myUser `*` WITH SUPERUSER CREATEDB CREATEROLE LOGIN ENCRYPTED PASSWORD `*`'password'`*`;`. This creates a superuser role with the proper name and will allow you to connect to the database with this user/password combo. Missing this step can cause authentication issues when attempting to build the node.
+5. Start the Postgres cli with command `sudo -i -u postgres` followed by command `psql`. If inside the shell you run `\l`, you will see a list of databases, which "graph-node" will have an owner of the same name as your system user name. At this point, back out and run query `\du` to check if the owner of 'graph-node' database is in this list of roles. If not, run query `CREATE ROLE `_`myUser `_`WITH SUPERUSER CREATEDB CREATEROLE LOGIN ENCRYPTED PASSWORD`_`'password'`_`;`. This creates a superuser role with the proper name and will allow you to connect to the database with this user/password combo. Missing this step can cause authentication issues when attempting to build the node.
 
 Useful links for troubleshooting:
 
@@ -175,11 +180,11 @@ Here are some known issues with subgraph tooling that you may run into:
 
 ### Subgraph Issues
 
-- Using a `derivedFrom` field in the graph code gives no compile time issues but fails when the graph syncs with error `unexpected null	wasm` ([Github Issue](https://github.com/graphprotocol/graph-ts/issues/219))
+- Using a `derivedFrom` field in the graph code gives no compile time issues but fails when the graph syncs with error `unexpected null wasm` ([Github Issue](https://github.com/graphprotocol/graph-ts/issues/219))
 - Event data can be different from contract call data as event data are calculated amid execution of a block whereas contract call data are calculated at the end of a block.
 - Note that **call-handlers** are not available on some EVM sidechains (e.g. Avalanche, Harmony, Polygon, etc). So you won't be able to use **call-handlers** in your subgraphs when indexing on these chains.
 - As of [`graph-cli v0.26.0`](https://github.com/graphprotocol/graph-node/releases/tag/v0.26.0) there is a new enviornment variable called `GRAPH_MAX_GAS_PER_HANDLER`. This sets a maximum gas limit on handlers. This does not refer to on-chain gas limits, but a measure of the computation exerted per handler. You will get a subgraph error if this limit is exceeded.
-  >A place you may find this is using the built-in `.pow()` with large numbers.
+  > A place you may find this is using the built-in `.pow()` with large numbers.
 - Different graph-cli versions handle missing required fields defined in schema differently. Deploying a subgraph with missing required field with [`graph-cli v0.30.1`](https://github.com/graphprotocol/graph-node/releases/tag/v0.30.1) will fail with error `missing value for non-nullable field`, while it will succeed with [`graph-cli v0.26.0`](https://github.com/graphprotocol/graph-node/releases/tag/v0.26.0) as it automatically sets default values for those missing fields.
 
 ### AssemblyScript Issues


### PR DESCRIPTION
Context:
Relate to PR https://github.com/messari/subgraphs/pull/1003 and https://github.com/messari/subgraphs/pull/1004

The protocol entity gets created at the beginning of indexing, and when you graft on top, even though you change the version, the protocol entity still displays the older version. This will happen unless the versions get reset in the protocol getters. This fix sets the version after each get.