### PR TITLE
Updates to maple finance readme.md, correct total value locked calculation

### DIFF
--- a/subgraphs/maple-finance/README.md
+++ b/subgraphs/maple-finance/README.md
@@ -14,7 +14,7 @@ Total amount on the supply side that is earning interest
 
 Sum across all Markets:
 
-`Total Deposit Balance USD + Total Stake Balance USD + Total Unclaimed Supplier Interest USD`
+`Total Deposit Balance USD`
 
 This does not include accrued staking rewards.
 


### PR DESCRIPTION
Removed staking from `Total value locked` to just `Total Deposit Balance USD`. This is to make it more consistent with other lending protocols.  