### PR TITLE
fix(#patch); truefi; decimals for input token balance

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1678,7 +1678,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.0.1",
+          "subgraph": "1.0.2",
           "methodology": "1.0.0"
         },
         "deployment-ids": {

--- a/subgraphs/truefi/src/utils/constants.ts
+++ b/subgraphs/truefi/src/utils/constants.ts
@@ -13,7 +13,7 @@ export const PROTOCOL_ID = "TrueFi";
 export const PROTOCOL_NAME = "TrueFi";
 export const PROTOCOL_SLUG = "truefi";
 export const PROTOCOL_SCHEMA_VERSION = "2.0.1";
-export const PROTOCOL_SUBGRAPH_VERSION = "1.0.1";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.0.2";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 
 ////////////////////////


### PR DESCRIPTION
- Fixed inputTokenBalance to just use the value from `value()` contract call
- used the new value and outputTokenSupply to get exchangeRate "properly"
- used tvl for totalDepositBalanceUSD
- updated to 1.0.2


testing: https://okgraph.xyz/?q=dmelotik%2Ftruefi-ethereum