### PR TITLE
fix(): updated maple-finance dependencies to fix build

### DIFF
--- a/subgraphs/maple-finance/package.json
+++ b/subgraphs/maple-finance/package.json
@@ -8,8 +8,7 @@
         "build": "node ../../deployment/deployment.js --deploy=${npm_config_deploy} --token=${npm_config_token} --service=${npm_config_service} --id=${npm_config_id} --span=${npm_config_span} --target=${npm_config_target} --slug=${npm_config_slug} --printlogs=${npm_config_printlogs}"
     },
     "dependencies": {
-        "@graphprotocol/graph-cli": "^0.29.0",
-        "@graphprotocol/graph-ts": "^0.26.0"
-    },
-    "devDependencies": {}
+        "@graphprotocol/graph-cli": "^0.29.2",
+        "@graphprotocol/graph-ts": "^0.27.0"
+    }
 }

--- a/subgraphs/maple-finance/src/common/utils.ts
+++ b/subgraphs/maple-finance/src/common/utils.ts
@@ -137,7 +137,7 @@ export function readCallResult<T>(
  * @param call call to create the event from
  */
 export function createEventFromCall(call: ethereum.Call): ethereum.Event {
-    return new ethereum.Event(call.from, ZERO_BI, ZERO_BI, null, call.block, call.transaction, []);
+    return new ethereum.Event(call.from, ZERO_BI, ZERO_BI, null, call.block, call.transaction, [], null);
 }
 
 /**


### PR DESCRIPTION
Maple finance build seems to be broken because of some mismatch between the graph-ts versions during build and defined in the project itself. This should fix it for now