### PR TITLE
fix(): temporarily whitelisted non-standard subgraph dir structures

### DIFF
--- a/subgraphs/.folderslintrc
+++ b/subgraphs/.folderslintrc
@@ -23,6 +23,11 @@
     "beefy-finance/setup/**",
     "compound-forks/queries/**",
     "erc20/data/**",
-    "erc20/configurations/*"
+    "erc20/configurations/*",
+    "cryptopunk/**",
+    "looksrare/**",
+    "opensea/**",
+    "x2y2/**",
+    "seaport/**"
    ]
 }


### PR DESCRIPTION

A few subgraphs have been added since I opened #1035 which didn't follow the directory structure enforced by folderslint. I didn't rebase to last master before merge so I didn't catch it. This is currently making all CI to fail on all new branches.

To make the CI pipelines to pass while the issue at hand is resolved I've temporarily whitelisted these new dir structures. As soon as they are fixed I'll revert this change :) 