### PR TITLE
fix(): fixed radiant-capital deployment.json since it had the old structure

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2756,15 +2756,18 @@
           "subgraph": "1.0.1",
           "methodology": "1.0.0"
         },
-        "deployment-ids": {
-          "hosted-service": "radiant-capital-arbitrum"
-        },
         "files": {
           "template": "radiant.capital.template.yaml"
         },
         "options": {
           "prepare:yaml": true,
           "prepare:constants": false
+        },
+        "services": {
+          "hosted-service": {
+            "slug": "radiant-capital-arbitrum",
+            "query-id": "radiant-capital-arbitrum"
+          }
         }
       }
     }


### PR DESCRIPTION

The deployment.json structure was slightly changed during the time #976 was open, which broke the deployment scripts 😅 

<img width="909" alt="Screenshot 2022-09-30 at 00 27 50" src="https://user-images.githubusercontent.com/17258946/193153290-8922db15-0ea8-42cb-8fba-6537cb9ed1cc.png">
