### PR TITLE
fix (#minor); Deployment Json; Fix venus query ID

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1546,7 +1546,7 @@
         "services": {
           "hosted-service": {
             "slug": "venus-protocol-bsc",
-            "query-id": "venus--protocol-bsc"
+            "query-id": "venus-protocol-bsc"
           }
         }
       }


### PR DESCRIPTION
**Context:**
Venus Protocol's query-id had 2 dashes when it should have had 1 between `venus` and `protocol`. This PR fixes that. 