### PR TITLE
fix(#patch); bastion; reward token reverting

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1021,7 +1021,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.5",
+          "subgraph": "1.1.6",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/compound-forks/protocols/bastion-protocol/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/bastion-protocol/src/mapping.ts
@@ -318,7 +318,7 @@ function getOrCreateProtocol(): LendingProtocol {
     "Bastion Protocol",
     "bastion-protocol",
     "2.0.1",
-    "1.1.5",
+    "1.1.6",
     "1.0.0",
     Network.AURORA,
     comptroller.try_liquidationIncentiveMantissa(),
@@ -369,14 +369,10 @@ function updateRewards(marketAddress: Address, blockNumber: BigInt): void {
     // load BSTN token
     token = Token.load(REWARD_TOKENS[INT_ZERO].toHexString());
     if (!token) {
-      const BSTNContract = ERC20.bind(REWARD_TOKENS[INT_ZERO]);
       token = new Token(REWARD_TOKENS[INT_ZERO].toHexString());
-      token.name = getOrElse<string>(
-        BSTNContract.try_name(),
-        "Bastion Protocol"
-      );
-      token.symbol = getOrElse<string>(BSTNContract.try_symbol(), "BSTN");
-      token.decimals = getOrElse<i32>(BSTNContract.try_decimals(), 18);
+      token.name = "Bastion Protocol";
+      token.symbol = "BSTN";
+      token.decimals = 18;
     }
     token.lastPriceUSD = getBastionPrice();
     token.lastPriceBlockNumber = blockNumber;
@@ -454,14 +450,10 @@ function updateRewards(marketAddress: Address, blockNumber: BigInt): void {
     // load BSTN token
     token = Token.load(REWARD_TOKENS[INT_ZERO].toHexString());
     if (!token) {
-      const BSTNContract = ERC20.bind(REWARD_TOKENS[INT_ZERO]);
       token = new Token(REWARD_TOKENS[INT_ZERO].toHexString());
-      token.name = getOrElse<string>(
-        BSTNContract.try_name(),
-        "Bastion Protocol"
-      );
-      token.symbol = getOrElse<string>(BSTNContract.try_symbol(), "BSTN");
-      token.decimals = getOrElse<i32>(BSTNContract.try_decimals(), 18);
+      token.name = "Bastion Protocol";
+      token.symbol = "BSTN";
+      token.decimals = 18;
     }
     token.lastPriceUSD = getBastionPrice();
     token.lastPriceBlockNumber = blockNumber;


### PR DESCRIPTION
Reward token reverting and causing incorrect output.

To override since we know the name and decimals of the token we hardcode it.

Testing: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/id/QmXoLTGo3w6f1EWShayjCka7aP8n6jV11jpBw2JHTrXJcA&tab=protocol