### PR TITLE
fix (#minor); subgraphs eslint; Turn off non-null assertion rule.

### DIFF
--- a/subgraphs/.eslintrc.json
+++ b/subgraphs/.eslintrc.json
@@ -30,7 +30,7 @@
     "@typescript-eslint/no-namespace": "off",
 
     // We want to make sure to correct for this. It can be difficult to debug when errors arise from this assertion.
-    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-non-null-assertion": "off",
 
     // Enforce for cleanliness
     "@typescript-eslint/no-unused-vars": "error",


### PR DESCRIPTION
**Context:**
Handling potentially null variables without assertions proved to be more difficult than expected for cases where the fields are optional. Requires the creation of another variable to bypass the assertion as seen below - otherwise it will still recognize the data type as { some-type | null}. While this is a rule we would ideally keep, @jaimehgb, @nemani, and I decided it's better to remove this rule and handle as we have been. There has been some discussion on improving the assertion functionality in this issue --> https://github.com/graphprotocol/graph-ts/pull/248

<img width="456" alt="Screen Shot 2022-10-07 at 1 38 27 AM" src="https://user-images.githubusercontent.com/56660047/194483621-751b7adf-80f8-407c-9cae-f02f051e69ab.png">