### PR TITLE
(#patch); CLI; Move the creation of the deployment.json context class to inside src.

### DIFF
--- a/messari-cli/src/command-helpers/build/scriptGenerator.ts
+++ b/messari-cli/src/command-helpers/build/scriptGenerator.ts
@@ -187,7 +187,7 @@ export class ScriptGenerator {
       `mustache protocols/${deploymentData.protocol}/config/deployments/${deploymentData.deployment}/configurations.json protocols/${deploymentData.protocol}/config/templates/${deploymentData.files.template} > subgraph.yaml`
     )
     scripts.push(
-      `mustache protocols/${deploymentData.protocol}/config/deployments/${deploymentData.deployment}/deploymentJsonContext.json ../../deployment/context/template.mustache > deploymentJsonContext.ts`
+      `mustache protocols/${deploymentData.protocol}/config/deployments/${deploymentData.deployment}/deploymentJsonContext.json ../../deployment/context/template.mustache > src/deploymentJsonContext.ts`
     )
 
     if (deploymentData.options['prepare:constants'] === true) {


### PR DESCRIPTION
**Context:**
I think it fits better to put in the src folder, also, having it out causes linting errors, because I am putting a typescript file in the main body of the project. 