### PR TITLE
(#patch); Eslint; Added eslint ignore and updated eslintrc to apply tsconfig same directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier-check": "prettier --loglevel silent --write --check \"**/*.{md,jsx,tsx,ts,json,html,css,js}\"",
     "lint:fix": "npx eslint --fix --max-warnings 0",
     "lint": "npx eslint",
-    "lint:subgraphs": "npx eslint -c subgraphs/.eslintrc.json",
+    "lint:subgraphs": "npx eslint -c subgraphs/.eslintrc.js",
     "prepare": "husky install",
     "folderslint": "cd subgraphs && folderslint"
   }

--- a/subgraphs/.eslintignore
+++ b/subgraphs/.eslintignore
@@ -1,0 +1,2 @@
+**/build
+**/generated

--- a/subgraphs/.eslintrc.js
+++ b/subgraphs/.eslintrc.js
@@ -1,28 +1,28 @@
-{
-  "env": {
-    "browser": true,
-    "es2021": true
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
   },
-  "extends": [
+  extends: [
     // Using the recommended typescript configurations
     "plugin:@typescript-eslint/recommended",
 
     // Prettier - last to override all other formatting rules
-    "prettier"
+    "prettier",
   ],
-  "parser": "@typescript-eslint/parser",
-  "overrides": [
+  parser: "@typescript-eslint/parser",
+  overrides: [
     {
-      "files": ["*.ts", "*.tsx"]
-    }
+      files: ["*.ts", "*.tsx"],
+    },
   ],
-  "parserOptions": {
-    "ecmaVersion": "latest",
-    "project": "./tsconfig.json",
-    "tsconfigRootDir": "subgraphs"
+  parserOptions: {
+    ecmaVersion: "latest",
+    project: "./tsconfig.json",
+    tsconfigRootDir: __dirname,
   },
-  "plugins": ["@typescript-eslint"],
-  "rules": {
+  plugins: ["@typescript-eslint"],
+  rules: {
     // Give the power to the people! We decided to leave this decision up to the dev.
     "@typescript-eslint/no-inferrable-types": "off",
 
@@ -38,12 +38,12 @@
     "@typescript-eslint/ban-types": [
       "error",
       {
-        "types": {
+        types: {
           // un-ban BigInt - It must be getting confused with the native bigInt type
-          "BigInt": false
+          BigInt: false,
         },
-        "extendDefaults": true
-      }
-    ]
-  }
-}
+        extendDefaults: true,
+      },
+    ],
+  },
+};


### PR DESCRIPTION
**Context:**
Added a .eslintignore to the subgraphs linter so that the build and generated files do not get linted. Because they are types generated by the codegen and build commands, we do not want to lint them according to our standards. 

Additionally, eslint was not using the tsconfig file from the same location as the eslintrc. This does not make linting with our standards as flexible as we want it to be. Updated the `eslintrc.json` to `eslintrs.js` so that we could use `__dirname` within the configurations to always use the tsconfig withing the subgraphs/ folder. 