### PR TITLE
fix (#patch); euler-finance; fix oneshot cancelled error

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1883,7 +1883,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.2",
+          "subgraph": "1.1.3",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/euler-finance/abis/Markets.json
+++ b/subgraphs/euler-finance/abis/Markets.json
@@ -1,0 +1,1359 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "moduleGitCommit_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalBalances",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalBorrows",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint96",
+        "name": "reserveBalance",
+        "type": "uint96"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "poolSize",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "interestAccumulator",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int96",
+        "name": "interestRate",
+        "type": "int96"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "AssetStatus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Borrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegate",
+        "type": "address"
+      }
+    ],
+    "name": "DelegateAverageLiquidity",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "EnterMarket",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "ExitMarket",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "Genesis",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "GovConvertReserves",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "eTokenAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "borrowIsolated",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint32",
+            "name": "collateralFactor",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "borrowFactor",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint24",
+            "name": "twapWindow",
+            "type": "uint24"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Storage.AssetConfig",
+        "name": "newConfig",
+        "type": "tuple"
+      }
+    ],
+    "name": "GovSetAssetConfig",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "chainlinkAggregator",
+        "type": "address"
+      }
+    ],
+    "name": "GovSetChainlinkPriceFeed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "interestRateModel",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "resetParams",
+        "type": "bytes"
+      }
+    ],
+    "name": "GovSetIRM",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "newPricingType",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newPricingParameter",
+        "type": "uint32"
+      }
+    ],
+    "name": "GovSetPricingConfig",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newReserveFee",
+        "type": "uint32"
+      }
+    ],
+    "name": "GovSetReserveFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "moduleId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "moduleImpl",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "moduleGitCommit",
+        "type": "bytes32"
+      }
+    ],
+    "name": "InstallerInstallModule",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newGovernorAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "InstallerSetGovernorAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newUpgradeAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "InstallerSetUpgradeAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "liquidator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "violator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "collateral",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "repay",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "Yield",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "healthScore",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "baseDiscount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "discount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Liquidation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "eToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "dToken",
+        "type": "address"
+      }
+    ],
+    "name": "MarketActivated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pToken",
+        "type": "address"
+      }
+    ],
+    "name": "PTokenActivated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "PTokenUnWrap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "PTokenWrap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "proxy",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "moduleId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ProxyCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Repay",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestBurn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestDeposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestDonate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "liquidator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "violator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "collateral",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "repay",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minYield",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestLiquidate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestMint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestRepay",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "accountIn",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "accountOut",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlyingIn",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "underlyingOut",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapType",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestSwap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestTransferDToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestTransferEToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestWithdraw",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "TrackAverageLiquidity",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "UnTrackAverageLiquidity",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "activateMarket",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "activatePToken",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dToken",
+        "type": "address"
+      }
+    ],
+    "name": "dTokenToUnderlying",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "eToken",
+        "type": "address"
+      }
+    ],
+    "name": "eTokenToDToken",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "dTokenAddr",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "eToken",
+        "type": "address"
+      }
+    ],
+    "name": "eTokenToUnderlying",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "subAccountId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "newMarket",
+        "type": "address"
+      }
+    ],
+    "name": "enterMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "subAccountId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "oldMarket",
+        "type": "address"
+      }
+    ],
+    "name": "exitMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "getChainlinkPriceFeedConfig",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "chainlinkAggregator",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getEnteredMarkets",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "getPricingConfig",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "pricingType",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint32",
+        "name": "pricingParameters",
+        "type": "uint32"
+      },
+      {
+        "internalType": "address",
+        "name": "pricingForwarded",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "interestAccumulator",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "interestRate",
+    "outputs": [
+      {
+        "internalType": "int96",
+        "name": "",
+        "type": "int96"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "interestRateModel",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "moduleGitCommit",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "moduleId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "reserveFee",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "underlyingToAssetConfig",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "eTokenAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "borrowIsolated",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint32",
+            "name": "collateralFactor",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "borrowFactor",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint24",
+            "name": "twapWindow",
+            "type": "uint24"
+          }
+        ],
+        "internalType": "struct Storage.AssetConfig",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "underlyingToAssetConfigUnresolved",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "eTokenAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "borrowIsolated",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint32",
+            "name": "collateralFactor",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "borrowFactor",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint24",
+            "name": "twapWindow",
+            "type": "uint24"
+          }
+        ],
+        "internalType": "struct Storage.AssetConfig",
+        "name": "config",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "underlyingToDToken",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "underlyingToEToken",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying",
+        "type": "address"
+      }
+    ],
+    "name": "underlyingToPToken",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/euler-finance/protocols/euler-finance/config/deployments/euler-finance-ethereum/configurations.json
+++ b/subgraphs/euler-finance/protocols/euler-finance/config/deployments/euler-finance-ethereum/configurations.json
@@ -1,7 +1,7 @@
 {
-    "factoryContract": "0x27182842E098f60e3D576794A5bFFb0777E025d3",
-    "startBlock": "13711759",
-    "graftEnabled": true,
-    "subgraphId": "QmVk2CdYHyfpQxwd4eVMSHz8GMD2R8g8xrJqWrYj6AcHdN",
-    "graftStartBlock": 15358325
+  "factoryContract": "0x27182842E098f60e3D576794A5bFFb0777E025d3",
+  "startBlock": "13711759",
+  "graftEnabled": true,
+  "subgraphId": "QmbRqZMNgzDy6jgfce13SW9gjBB8ZDujWQrUKL84F15uKT",
+  "graftStartBlock": 15700197
 }

--- a/subgraphs/euler-finance/protocols/euler-finance/config/deployments/euler-finance-ethereum/configurations.json
+++ b/subgraphs/euler-finance/protocols/euler-finance/config/deployments/euler-finance-ethereum/configurations.json
@@ -1,7 +1,7 @@
 {
   "factoryContract": "0x27182842E098f60e3D576794A5bFFb0777E025d3",
   "startBlock": "13711759",
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "QmbRqZMNgzDy6jgfce13SW9gjBB8ZDujWQrUKL84F15uKT",
   "graftStartBlock": 15700197
 }

--- a/subgraphs/euler-finance/protocols/euler-finance/config/templates/euler.template.yaml
+++ b/subgraphs/euler-finance/protocols/euler-finance/config/templates/euler.template.yaml
@@ -37,6 +37,8 @@ dataSources:
           file: ./abis/EulerGeneralView.json
         - name: Exec
           file: ./abis/Exec.json
+        - name: Markets
+          file: ./abis/Markets.json
         - name: ERC20
           file: ./abis/ERC20.json
         - name: ERC20SymbolBytes

--- a/subgraphs/euler-finance/schema.graphql
+++ b/subgraphs/euler-finance/schema.graphql
@@ -378,7 +378,7 @@ type FinancialsDailySnapshot @entity {
 
   " Protocol this snapshot is associated with "
   protocol: LendingProtocol!
-  
+
   " Block number of this snapshot "
   blockNumber: BigInt!
 
@@ -588,7 +588,7 @@ type MarketDailySnapshot @entity {
 
   " The pool this snapshot belongs to "
   market: Market!
-  
+
   " Block number of this snapshot "
   blockNumber: BigInt!
 
@@ -684,7 +684,7 @@ type MarketHourlySnapshot @entity {
 
   " The pool this snapshot belongs to "
   market: Market!
-  
+
   " Block number of this snapshot "
   blockNumber: BigInt!
 
@@ -1081,4 +1081,17 @@ type _ProtocolUtility @entity {
 
   " Active markets on the protocol. "
   markets: [Market!]!
+}
+
+type _AssetStatus @entity {
+  "address of underlying asset"
+  id: ID!
+  "last totalBorrows"
+  totalBorrows: BigInt!
+  "last reserveBalance"
+  reserveBalance: BigInt!
+  "interestAccumulator"
+  interestAccumulator: BigInt
+  "last timestamp"
+  timestamp: BigInt
 }

--- a/subgraphs/euler-finance/src/common/constants.ts
+++ b/subgraphs/euler-finance/src/common/constants.ts
@@ -7,7 +7,7 @@ import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
 export const PROTOCOL_NAME = "Euler";
 export const PROTOCOL_SLUG = "euler";
 export const PROTOCOL_SCHEMA_VERSION = "1.3.0";
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.2";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.3";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 
 ////////////////////////
@@ -176,3 +176,8 @@ export const EXEC_START_BLOCK_NUMBER = BigInt.fromI32(13711556);
 export const UNISWAP_Q192 = BigDecimal.fromString(BigInt.fromI32(2).pow(192).toString());
 export const DECIMAL_PRECISION = BIGINT_TEN_TO_EIGHTEENTH.toBigDecimal();
 export const INTEREST_RATE_PRECISION = BigDecimal.fromString("1e25");
+export const INTERNAL_DEBT_PRECISION = BigDecimal.fromString("1e9");
+export const MODULEID__EXEC = BigInt.fromI32(5);
+export const MODULEID__RISK_MANAGER = BigInt.fromI32(1000000);
+export const MODULEID__MARKETS = BigInt.fromI32(2);
+export const INITIAL_INTEREST_ACCUMULATOR = BigInt.fromI32(10).pow(27);

--- a/subgraphs/euler-finance/src/common/getters.ts
+++ b/subgraphs/euler-finance/src/common/getters.ts
@@ -297,9 +297,6 @@ export function getOrCreateLendingProtocol(): LendingProtocol {
     protocol = new LendingProtocol(EULER_ADDRESS);
     protocol.name = PROTOCOL_NAME;
     protocol.slug = PROTOCOL_SLUG;
-    protocol.schemaVersion = PROTOCOL_SCHEMA_VERSION;
-    protocol.subgraphVersion = PROTOCOL_SUBGRAPH_VERSION;
-    protocol.methodologyVersion = PROTOCOL_METHODOLOGY_VERSION;
     protocol.network = Network.MAINNET;
     protocol.type = ProtocolType.LENDING;
     protocol.lendingType = LendingType.POOLED;
@@ -317,8 +314,12 @@ export function getOrCreateLendingProtocol(): LendingProtocol {
     protocol.mintedTokens = [];
     protocol.mintedTokenSupplies = [];
     protocol.totalPoolCount = INT_ZERO;
-    protocol.save();
   }
+
+  protocol.schemaVersion = PROTOCOL_SCHEMA_VERSION;
+  protocol.subgraphVersion = PROTOCOL_SUBGRAPH_VERSION;
+  protocol.methodologyVersion = PROTOCOL_METHODOLOGY_VERSION;
+  protocol.save();
   return protocol as LendingProtocol;
 }
 

--- a/subgraphs/euler-finance/src/mappings/handlers.ts
+++ b/subgraphs/euler-finance/src/mappings/handlers.ts
@@ -16,7 +16,6 @@ import {
   EulerGeneralView__doQueryInputQStruct,
   EulerGeneralView__doQueryResultRStruct,
 } from "../../generated/euler/EulerGeneralView";
-import { RiskManager } from "../../generated/euler/RiskManager";
 import {
   getOrCreateLendingProtocol,
   getOrCreateMarket,
@@ -30,13 +29,9 @@ import {
   TransactionType,
   EULER_GENERAL_VIEW_V2_ADDRESS,
   VIEW_V2_START_BLOCK_NUMBER,
-  INTERNAL_DEBT_PRECISION,
-  MODULEID__EXEC,
-  MODULEID__RISK_MANAGER,
   BIGINT_ZERO,
   DECIMAL_PRECISION,
   INITIAL_INTEREST_ACCUMULATOR,
-  BIGDECIMAL_ONE,
   USDC_ERC20_ADDRESS,
   RESERVE_FEE_SCALE,
   MODULEID__MARKETS,
@@ -60,7 +55,6 @@ import {
   updateSnapshotRevenues,
 } from "./helpers";
 import { _AssetStatus } from "../../generated/schema";
-import { Exec } from "../../generated/euler/Exec";
 
 export function handleAssetStatus(event: AssetStatus): void {
   updateAsset(event);

--- a/subgraphs/euler-finance/src/mappings/handlers.ts
+++ b/subgraphs/euler-finance/src/mappings/handlers.ts
@@ -1,21 +1,27 @@
-import { Address, ethereum, BigInt } from "@graphprotocol/graph-ts";
+import { Address, ethereum, BigInt, BigDecimal, log } from "@graphprotocol/graph-ts";
 import {
   AssetStatus,
   Borrow,
   Deposit,
+  Euler,
   GovSetAssetConfig,
   Liquidation,
   MarketActivated,
   Repay,
-  Withdraw
-} from "../../generated/euler/Euler"
+  Withdraw,
+} from "../../generated/euler/Euler";
+import { Markets } from "../../generated/euler/Markets";
 import {
   EulerGeneralView,
   EulerGeneralView__doQueryInputQStruct,
-  EulerGeneralView__doQueryResultRStruct
+  EulerGeneralView__doQueryResultRStruct,
 } from "../../generated/euler/EulerGeneralView";
+import { RiskManager } from "../../generated/euler/RiskManager";
 import {
+  getOrCreateLendingProtocol,
+  getOrCreateMarket,
   getOrCreateProtocolUtility,
+  getOrCreateToken,
 } from "../common/getters";
 import {
   EULER_ADDRESS,
@@ -24,8 +30,23 @@ import {
   TransactionType,
   EULER_GENERAL_VIEW_V2_ADDRESS,
   VIEW_V2_START_BLOCK_NUMBER,
+  INTERNAL_DEBT_PRECISION,
+  MODULEID__EXEC,
+  MODULEID__RISK_MANAGER,
+  BIGINT_ZERO,
+  DECIMAL_PRECISION,
+  INITIAL_INTEREST_ACCUMULATOR,
+  BIGDECIMAL_ONE,
+  USDC_ERC20_ADDRESS,
+  RESERVE_FEE_SCALE,
+  MODULEID__MARKETS,
 } from "../common/constants";
-import { updateFinancials, updateMarketDailyMetrics, updateMarketHourlyMetrics, updateUsageMetrics } from "../common/metrics";
+import {
+  updateFinancials,
+  updateMarketDailyMetrics,
+  updateMarketHourlyMetrics,
+  updateUsageMetrics,
+} from "../common/metrics";
 import {
   createBorrow,
   createDeposit,
@@ -36,10 +57,133 @@ import {
   syncWithEulerGeneralView,
   updateAsset,
   updateLendingFactors,
+  updateSnapshotRevenues,
 } from "./helpers";
+import { _AssetStatus } from "../../generated/schema";
+import { Exec } from "../../generated/euler/Exec";
 
 export function handleAssetStatus(event: AssetStatus): void {
   updateAsset(event);
+
+  const underlying = event.params.underlying;
+  const marketId = underlying.toHexString();
+  const block = event.block;
+  const totalBorrows = event.params.totalBorrows;
+  const reserveBalance = event.params.reserveBalance;
+  const interestAccumulator = event.params.interestAccumulator;
+  const interstRate = event.params.interestRate;
+  const timestamp = event.params.timestamp;
+
+  const eulerContract = Euler.bind(Address.fromString(EULER_ADDRESS));
+  const marketsProxyAddress = eulerContract.moduleIdToProxy(MODULEID__MARKETS);
+  const marketsContract = Markets.bind(marketsProxyAddress);
+  const reserveFee = marketsContract.reserveFee(underlying);
+
+  // update price
+  const execProxyAddress = eulerContract.moduleIdToProxy(MODULEID__EXEC);
+  log.info("[handleAssetStatus]execProxyAddress={}", [execProxyAddress.toHexString()]);
+  const execProxyContract = Exec.bind(execProxyAddress);
+  let underlyingPriceUSD: BigDecimal;
+  if (marketId.toLowerCase() == USDC_ERC20_ADDRESS) {
+    underlyingPriceUSD = BIGDECIMAL_ONE;
+  } else {
+    // price in WETH
+    const underlyingPriceWETH = execProxyContract.getPriceFull(underlying).getCurrPrice();
+    // this is the inversion of WETH price in USD
+    const USDCPriceWETH = execProxyContract.getPriceFull(Address.fromString(USDC_ERC20_ADDRESS)).getCurrPrice();
+    underlyingPriceUSD = underlyingPriceWETH.divDecimal(DECIMAL_PRECISION).div(USDCPriceWETH.toBigDecimal());
+  }
+
+  const token = getOrCreateToken(underlying);
+  token.lastPriceUSD = underlyingPriceUSD;
+  token.lastPriceBlockNumber = event.block.number;
+  token.save();
+
+  log.info("[handleAssetStatus]tx={},token={},currPrice={}", [
+    event.transaction.hash.toHexString(),
+    token.name,
+    underlyingPriceUSD.toString(),
+  ]);
+
+  const assetStatus = getOrCreateAssetStatus(marketId);
+
+  assert(
+    !assetStatus.timestamp || timestamp.ge(assetStatus.timestamp!),
+    `event timestamp ${timestamp} < assetStatus.timestamp`,
+  );
+
+  assert(
+    !assetStatus.reserveBalance || reserveBalance.ge(assetStatus.reserveBalance),
+    `event reserveBalance ${reserveBalance} < assetStatus.reserveBalance`,
+  );
+
+  //const tokenPrecision = new BigDecimal(BigInt.fromI32(10).pow(<u8>token.decimals));
+  log.info("[handleAssetStatus]underlying={},blk={},tx={},token.id={},token.lastPriceUSD={}", [
+    marketId,
+    block.number.toString(),
+    event.transaction.hash.toHexString(),
+    token.id,
+    token.lastPriceUSD!.toString(),
+  ]);
+
+  const deltaProtocolSideRevenue = reserveBalance
+    .minus(assetStatus.reserveBalance)
+    .divDecimal(DECIMAL_PRECISION)
+    .times(token.lastPriceUSD!);
+  // because protocolSideRev = totalRev * reserveFee/RESERVE_FEE_SCALE
+  // ==> totalRev = protocolSideRev * RESERVE_FEE_SCALE / reserveFee
+  const deltaTotalRevenue = deltaProtocolSideRevenue.times(RESERVE_FEE_SCALE).div(reserveFee.toBigDecimal());
+  const deltaSupplySideRevenue = deltaTotalRevenue.minus(deltaProtocolSideRevenue);
+
+  log.info(
+    "[handleAssetStatus]totalBorrows={},prev totalBorrows={},totalRev={},reserveBalance={},prev reserveBal={},protocolSideRev={},price={}",
+    [
+      //block.number.toString(),
+      //event.transaction.hash.toHexString(),
+      totalBorrows.toString(),
+      assetStatus.totalBorrows.toString(),
+      deltaTotalRevenue.toString(),
+      reserveBalance.toString(),
+      assetStatus.reserveBalance.toString(),
+      deltaProtocolSideRevenue.toString(),
+      token.lastPriceUSD!.toString(),
+      //tokenPrecision.toString(),
+    ],
+  );
+
+  const protocol = getOrCreateLendingProtocol();
+  // update protocol revenue
+  protocol.cumulativeSupplySideRevenueUSD = protocol.cumulativeSupplySideRevenueUSD.plus(deltaSupplySideRevenue);
+  protocol.cumulativeProtocolSideRevenueUSD = protocol.cumulativeProtocolSideRevenueUSD.plus(deltaProtocolSideRevenue);
+  protocol.cumulativeTotalRevenueUSD = protocol.cumulativeTotalRevenueUSD.plus(deltaTotalRevenue);
+  protocol.save();
+
+  const market = getOrCreateMarket(marketId);
+  // update market's revenue
+  market.cumulativeSupplySideRevenueUSD = market.cumulativeSupplySideRevenueUSD.plus(deltaSupplySideRevenue);
+  market.cumulativeProtocolSideRevenueUSD = market.cumulativeProtocolSideRevenueUSD.plus(deltaProtocolSideRevenue);
+  market.cumulativeTotalRevenueUSD = market.cumulativeTotalRevenueUSD.plus(deltaTotalRevenue);
+  market.save();
+
+  updateSnapshotRevenues(marketId, block, deltaSupplySideRevenue, deltaProtocolSideRevenue, deltaTotalRevenue);
+
+  assetStatus.totalBorrows = totalBorrows;
+  assetStatus.reserveBalance = reserveBalance;
+  assetStatus.interestAccumulator = interestAccumulator;
+  assetStatus.timestamp = timestamp;
+  assetStatus.save();
+}
+
+function getOrCreateAssetStatus(id: string): _AssetStatus {
+  let assetStatus = _AssetStatus.load(id);
+  if (!assetStatus) {
+    assetStatus = new _AssetStatus(id);
+    assetStatus.totalBorrows = BIGINT_ZERO;
+    assetStatus.reserveBalance = BIGINT_ZERO;
+    assetStatus.interestAccumulator = INITIAL_INTEREST_ACCUMULATOR;
+    assetStatus.save();
+  }
+  return assetStatus;
 }
 
 export function handleBorrow(event: Borrow): void {
@@ -49,7 +193,7 @@ export function handleBorrow(event: Borrow): void {
   updateFinancials(event.block, borrowUSD, TransactionType.BORROW);
   updateMarketDailyMetrics(event.block, marketId, borrowUSD, TransactionType.BORROW);
   updateMarketHourlyMetrics(event.block, marketId, borrowUSD, TransactionType.BORROW);
-  updateProtocolAndMarkets(event.block);
+  updateProtocolAndMarkets(event, marketId);
 }
 
 export function handleDeposit(event: Deposit): void {
@@ -59,7 +203,7 @@ export function handleDeposit(event: Deposit): void {
   updateFinancials(event.block, depositUSD, TransactionType.DEPOSIT);
   updateMarketDailyMetrics(event.block, marketId, depositUSD, TransactionType.DEPOSIT);
   updateMarketHourlyMetrics(event.block, marketId, depositUSD, TransactionType.DEPOSIT);
-  updateProtocolAndMarkets(event.block);
+  updateProtocolAndMarkets(event, marketId);
 }
 
 export function handleRepay(event: Repay): void {
@@ -69,7 +213,7 @@ export function handleRepay(event: Repay): void {
   updateFinancials(event.block, repayUSD, TransactionType.REPAY);
   updateMarketDailyMetrics(event.block, marketId, repayUSD, TransactionType.REPAY);
   updateMarketHourlyMetrics(event.block, marketId, repayUSD, TransactionType.REPAY);
-  updateProtocolAndMarkets(event.block);
+  updateProtocolAndMarkets(event, marketId);
 }
 
 export function handleWithdraw(event: Withdraw): void {
@@ -79,7 +223,7 @@ export function handleWithdraw(event: Withdraw): void {
   updateFinancials(event.block, withdrawUSD, TransactionType.WITHDRAW);
   updateMarketDailyMetrics(event.block, marketId, withdrawUSD, TransactionType.WITHDRAW);
   updateMarketHourlyMetrics(event.block, marketId, withdrawUSD, TransactionType.WITHDRAW);
-  updateProtocolAndMarkets(event.block);
+  updateProtocolAndMarkets(event, marketId);
 }
 
 export function handleLiquidation(event: Liquidation): void {
@@ -89,11 +233,11 @@ export function handleLiquidation(event: Liquidation): void {
   updateFinancials(event.block, liquidateUSD, TransactionType.LIQUIDATE);
   updateMarketDailyMetrics(event.block, marketId, liquidateUSD, TransactionType.LIQUIDATE);
   updateMarketHourlyMetrics(event.block, marketId, liquidateUSD, TransactionType.LIQUIDATE);
-  updateProtocolAndMarkets(event.block);
+  updateProtocolAndMarkets(event, marketId);
 }
 
 export function handleGovSetAssetConfig(event: GovSetAssetConfig): void {
- updateLendingFactors(event);
+  updateLendingFactors(event);
 }
 
 export function handleMarketActivated(event: MarketActivated): void {
@@ -101,20 +245,23 @@ export function handleMarketActivated(event: MarketActivated): void {
 }
 
 function getEulerViewContract(block: ethereum.Block): EulerGeneralView {
- const viewAddress = block.number.gt(VIEW_V2_START_BLOCK_NUMBER)
-   ? EULER_GENERAL_VIEW_V2_ADDRESS
-   : EULER_GENERAL_VIEW_ADDRESS;
+  const viewAddress = block.number.gt(VIEW_V2_START_BLOCK_NUMBER)
+    ? EULER_GENERAL_VIEW_V2_ADDRESS
+    : EULER_GENERAL_VIEW_ADDRESS;
   return EulerGeneralView.bind(Address.fromString(viewAddress));
 }
 
 /**
  * Query Euler General View contract in order to get markets current status.
- * 
+ *
  * @param marketIds List of markets to query
  * @param block current block
  * @returns query resul or null if nothing could be queried.
  */
-function queryEulerGeneralView(marketIds: string[], block: ethereum.Block): EulerGeneralView__doQueryResultRStruct | null {
+function queryEulerGeneralView(
+  marketIds: string[],
+  block: ethereum.Block,
+): EulerGeneralView__doQueryResultRStruct | null {
   if (marketIds.length === 0) {
     return null; // No market is initialized, nothing to do.
   }
@@ -139,19 +286,24 @@ function queryEulerGeneralView(marketIds: string[], block: ethereum.Block): Eule
 }
 
 // initiates market / protocol updates in syncWithEulerGeneralView()
-function updateProtocolAndMarkets(block: ethereum.Block): void {
-  let blockNumber = block.number.toI32();
+function updateProtocolAndMarkets(event: ethereum.Event, marketId: string): void {
+  let blockNumber = event.block.number.toI32();
   let protocolUtility = getOrCreateProtocolUtility(blockNumber);
   let markets = protocolUtility.markets;
+  const marketIndex = markets.indexOf(marketId);
+  assert(marketIndex >= 0, `[updateProtocolAndMarkets]marketId=${marketId} not in protocolUtility.markets`);
+  markets = [marketId, USDC_ERC20_ADDRESS];
 
-  if (protocolUtility.lastBlockNumber >= blockNumber - 120 ) {
+  /* 
+  if (protocolUtility.lastBlockNumber >= blockNumber - 120) {
     // Do this update every 120 blocks
     // this equates to about 30 minutes on ethereum mainnet
     // this is done since the following logic slows down the indexer
     return;
   }
+  */
 
-  let eulerViewQueryResult = queryEulerGeneralView(markets, block);
+  let eulerViewQueryResult = queryEulerGeneralView(markets, event.block);
   if (!eulerViewQueryResult) {
     return;
   }
@@ -160,5 +312,5 @@ function updateProtocolAndMarkets(block: ethereum.Block): void {
   protocolUtility.lastBlockNumber = blockNumber;
   protocolUtility.save();
 
-  syncWithEulerGeneralView(eulerViewQueryResult, block);
+  syncWithEulerGeneralView(eulerViewQueryResult, event);
 }

--- a/subgraphs/euler-finance/src/mappings/helpers.ts
+++ b/subgraphs/euler-finance/src/mappings/helpers.ts
@@ -446,22 +446,6 @@ export function syncWithEulerGeneralView(
     */
 
     market.save();
-    log.info(
-      "[syncWithEulerGeneralView]blk={},market={},prev tvl={},tvl={},protocl tvl={},prev borrowBal={},borrowBal={},protocol borrowBal={},prev DepositBal={},DepositBal={},protocol DepositBal={}",
-      [
-        event.transaction.hash.toHexString(),
-        market.id,
-        prevMarketTotalValueLockedUSD.toString(),
-        market.totalValueLockedUSD.toString(),
-        protocol.totalValueLockedUSD.toString(),
-        prevMarketTotalBorrowBalanceUSD.toString(),
-        market.totalBorrowBalanceUSD.toString(),
-        protocol.totalBorrowBalanceUSD.toString(),
-        prevMarketTotalDepositBalanceUSD.toString(),
-        market.totalDepositBalanceUSD.toString(),
-        protocol.totalDepositBalanceUSD.toString(),
-      ],
-    );
 
     //update TVL, borrow balance, and deposit balance
     protocol.totalValueLockedUSD = protocol.totalValueLockedUSD


### PR DESCRIPTION
This is a quick fix for the error from euler finance subgraph deployment on recent blocks:

```
Subgraph failed with non-deterministic error: failed to process trigger: block #15700199 (0x1567…983b), transaction 102d9eb3d096d5cfc74ba56ea7c3b0ebfc30454d7f3d000fd42c1307f746c2cf: Mapping terminated before passing in trigger: send failed because receiver is gone, retry_delay_s: 1800, attempt: 95
```

and the underlying error msg

```
"message": "failed to process trigger: block #15700199 (0x1567…983b), transaction 102d9eb3d096d5cfc74ba56ea7c3b0ebfc30454d7f3d000fd42c1307f746c2cf: Mapping terminated before handling trigger: oneshot canceled"
```

Ready to review/merge if verified working https://thegraph.com/hosted-service/subgraph/tnkrxyz/euler?version=pending&selected=logs