### PR TITLE
fix (#patch); euler-finance; fix for euler oneshot cancelled error

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1883,7 +1883,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.2",
+          "subgraph": "1.1.3",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/euler-finance/protocols/euler-finance/config/deployments/euler-finance-ethereum/configurations.json
+++ b/subgraphs/euler-finance/protocols/euler-finance/config/deployments/euler-finance-ethereum/configurations.json
@@ -1,7 +1,7 @@
 {
-    "factoryContract": "0x27182842E098f60e3D576794A5bFFb0777E025d3",
-    "startBlock": "13711759",
-    "graftEnabled": true,
-    "subgraphId": "QmVk2CdYHyfpQxwd4eVMSHz8GMD2R8g8xrJqWrYj6AcHdN",
-    "graftStartBlock": 15358325
+  "factoryContract": "0x27182842E098f60e3D576794A5bFFb0777E025d3",
+  "startBlock": "13711759",
+  "graftEnabled": true,
+  "subgraphId": "QmbRqZMNgzDy6jgfce13SW9gjBB8ZDujWQrUKL84F15uKT",
+  "graftStartBlock": 15700197
 }

--- a/subgraphs/euler-finance/src/common/constants.ts
+++ b/subgraphs/euler-finance/src/common/constants.ts
@@ -7,7 +7,7 @@ import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
 export const PROTOCOL_NAME = "Euler";
 export const PROTOCOL_SLUG = "euler";
 export const PROTOCOL_SCHEMA_VERSION = "1.3.0";
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.2";
+export const PROTOCOL_SUBGRAPH_VERSION = "1.1.3";
 export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 
 ////////////////////////

--- a/subgraphs/euler-finance/src/common/getters.ts
+++ b/subgraphs/euler-finance/src/common/getters.ts
@@ -297,9 +297,6 @@ export function getOrCreateLendingProtocol(): LendingProtocol {
     protocol = new LendingProtocol(EULER_ADDRESS);
     protocol.name = PROTOCOL_NAME;
     protocol.slug = PROTOCOL_SLUG;
-    protocol.schemaVersion = PROTOCOL_SCHEMA_VERSION;
-    protocol.subgraphVersion = PROTOCOL_SUBGRAPH_VERSION;
-    protocol.methodologyVersion = PROTOCOL_METHODOLOGY_VERSION;
     protocol.network = Network.MAINNET;
     protocol.type = ProtocolType.LENDING;
     protocol.lendingType = LendingType.POOLED;
@@ -317,8 +314,12 @@ export function getOrCreateLendingProtocol(): LendingProtocol {
     protocol.mintedTokens = [];
     protocol.mintedTokenSupplies = [];
     protocol.totalPoolCount = INT_ZERO;
-    protocol.save();
   }
+  // ensure to update versions with grafting
+  protocol.schemaVersion = PROTOCOL_SCHEMA_VERSION;
+  protocol.subgraphVersion = PROTOCOL_SUBGRAPH_VERSION;
+  protocol.methodologyVersion = PROTOCOL_METHODOLOGY_VERSION;
+  protocol.save();
   return protocol as LendingProtocol;
 }
 

--- a/subgraphs/euler-finance/src/mappings/handlers.ts
+++ b/subgraphs/euler-finance/src/mappings/handlers.ts
@@ -49,50 +49,50 @@ export function handleBorrow(event: Borrow): void {
   const borrowUSD = createBorrow(event);
   const marketId = event.params.underlying.toHexString();
   updateUsageMetrics(event, event.params.account, TransactionType.BORROW);
+  updateProtocolAndMarkets(event.block);
   updateFinancials(event.block, borrowUSD, TransactionType.BORROW);
   updateMarketDailyMetrics(event.block, marketId, borrowUSD, TransactionType.BORROW);
   updateMarketHourlyMetrics(event.block, marketId, borrowUSD, TransactionType.BORROW);
-  updateProtocolAndMarkets(event.block);
 }
 
 export function handleDeposit(event: Deposit): void {
   const depositUSD = createDeposit(event);
   const marketId = event.params.underlying.toHexString();
   updateUsageMetrics(event, event.params.account, TransactionType.DEPOSIT);
+  updateProtocolAndMarkets(event.block);
   updateFinancials(event.block, depositUSD, TransactionType.DEPOSIT);
   updateMarketDailyMetrics(event.block, marketId, depositUSD, TransactionType.DEPOSIT);
   updateMarketHourlyMetrics(event.block, marketId, depositUSD, TransactionType.DEPOSIT);
-  updateProtocolAndMarkets(event.block);
 }
 
 export function handleRepay(event: Repay): void {
   const repayUSD = createRepay(event);
   const marketId = event.params.underlying.toHexString();
   updateUsageMetrics(event, event.params.account, TransactionType.REPAY);
+  updateProtocolAndMarkets(event.block);
   updateFinancials(event.block, repayUSD, TransactionType.REPAY);
   updateMarketDailyMetrics(event.block, marketId, repayUSD, TransactionType.REPAY);
   updateMarketHourlyMetrics(event.block, marketId, repayUSD, TransactionType.REPAY);
-  updateProtocolAndMarkets(event.block);
 }
 
 export function handleWithdraw(event: Withdraw): void {
   const withdrawUSD = createWithdraw(event);
   const marketId = event.params.underlying.toHexString();
   updateUsageMetrics(event, event.params.account, TransactionType.WITHDRAW);
+  updateProtocolAndMarkets(event.block);
   updateFinancials(event.block, withdrawUSD, TransactionType.WITHDRAW);
   updateMarketDailyMetrics(event.block, marketId, withdrawUSD, TransactionType.WITHDRAW);
   updateMarketHourlyMetrics(event.block, marketId, withdrawUSD, TransactionType.WITHDRAW);
-  updateProtocolAndMarkets(event.block);
 }
 
 export function handleLiquidation(event: Liquidation): void {
   const liquidateUSD = createLiquidation(event);
   const marketId = event.params.underlying.toHexString();
   updateUsageMetrics(event, event.params.liquidator, TransactionType.LIQUIDATE);
+  updateProtocolAndMarkets(event.block);
   updateFinancials(event.block, liquidateUSD, TransactionType.LIQUIDATE);
   updateMarketDailyMetrics(event.block, marketId, liquidateUSD, TransactionType.LIQUIDATE);
   updateMarketHourlyMetrics(event.block, marketId, liquidateUSD, TransactionType.LIQUIDATE);
-  updateProtocolAndMarkets(event.block);
 }
 
 export function handleGovSetAssetConfig(event: GovSetAssetConfig): void {

--- a/subgraphs/euler-finance/src/mappings/helpers.ts
+++ b/subgraphs/euler-finance/src/mappings/helpers.ts
@@ -43,7 +43,6 @@ import {
 } from "../common/constants";
 import { getEthPriceUsd, getUnderlyingPrice } from "../common/pricing";
 import { amountToUsd } from "../common/conversions";
-import { updateMarketDailyMetrics, updateMarketHourlyMetrics } from "../common/metrics";
 import { getAssetTotalSupply } from "../common/tokens";
 
 export function updateAsset(event: AssetStatus): void {

--- a/subgraphs/euler-finance/src/mappings/helpers.ts
+++ b/subgraphs/euler-finance/src/mappings/helpers.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, ethereum, BigInt } from "@graphprotocol/graph-ts";
+import { Address, BigDecimal, ethereum, BigInt, log } from "@graphprotocol/graph-ts";
 import {
   AssetStatus,
   Borrow,
@@ -309,9 +309,11 @@ export function syncWithEulerGeneralView(
 
   // Using an indexed for loop because AssemblyScript does not support closures.
   // AS100: Not implemented: Closures
-  for (let i = 0; i < eulerViewMarkets.length; i += 1) {
+  const marketsCount = eulerViewMarkets.length;
+  for (let i = 0; i < marketsCount; i += 1) {
     const eulerViewMarket = eulerViewMarkets[i];
     const market = getOrCreateMarket(eulerViewMarket.underlying.toHexString());
+    log.info("[syncWithEulerGeneralView]{}/{},market={}", [i.toString(), marketsCount.toString(), market.id]);
     const marketUtility = getOrCreateMarketUtility(market.id);
     const lendingRate = getOrCreateInterestRate(InterestRateSide.LENDER, InterestRateType.VARIABLE, market.id);
     const borrowRate = getOrCreateInterestRate(InterestRateSide.BORROWER, InterestRateType.VARIABLE, market.id);
@@ -434,8 +436,7 @@ export function syncWithEulerGeneralView(
     marketUtility.twapPeriod = eulerViewMarket.twapPeriod;
     marketUtility.save();
 
-    updateMarketDailyMetrics(block, market.id, BIGDECIMAL_ZERO);
-    updateMarketHourlyMetrics(block, market.id, BIGDECIMAL_ZERO);
+    //market daily/hourly snapshots are updated in the handler function after updateProtocolAndMarkets() call
   }
   protocol.save();
 }


### PR DESCRIPTION
Fix for euler "oneshot cancelled error" with minimal changes to current implementation.

The loop ` for (let i = 0; i < eulerViewMarkets.length; i += 1)` in `syncWithEulerGeneralView()` of src/mappings/helper.ts is where the error occurs, and my tests found that [these two lines](https://github.com/messari/subgraphs/blob/fe78e431045dd61c4524fc308b80864f0786852c/subgraphs/euler-finance/src/mappings/helpers.ts#L440-L441) are the last straw 
```
    updateMarketDailyMetrics(block, market.id, BIGDECIMAL_ZERO);
    updateMarketHourlyMetrics(block, market.id, BIGDECIMAL_ZERO);
```

I removed these two lines in the function by swtiching the order of function calls in handler functions. My test deployment of the fix is working: https://thegraph.com/hosted-service/subgraph/tnkrxyz/euler?version=pending&selected=logs and a new test deployment with code in this PR is at: https://thegraph.com/hosted-service/subgraph/tnkrxyz/test-subgraph?version=pending

It'd be a good idea to merge #1212 first & rebase this PR before merging.