### PR TITLE
fix(#patch); Spookyswap Fantom; Fixed references to masterchefV2 handlers in template

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3557,7 +3557,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.4",
+          "subgraph": "1.1.5",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-forks/protocols/spookyswap/config/templates/spookyswap.template.yaml
+++ b/subgraphs/uniswap-forks/protocols/spookyswap/config/templates/spookyswap.template.yaml
@@ -79,11 +79,11 @@ dataSources:
           file: ./abis/spookyswap/IERC20.json
       eventHandlers:
         - event: Deposit(indexed address,indexed uint256,uint256,indexed address)
-          handler: handleDepositV2
+          handler: handleDeposit
         - event: Withdraw(indexed address,indexed uint256,uint256,indexed address)
-          handler: handleWithdrawV2
+          handler: handleWithdraw
         - event: EmergencyWithdraw(indexed address,indexed uint256,uint256,indexed address)
-          handler: handleEmergencyWithdrawV2
+          handler: handleEmergencyWithdraw
       file: ./protocols/spookyswap/src/mappings/masterchef/rewardV2.ts
  
 templates:

--- a/subgraphs/uniswap-forks/protocols/spookyswap/src/common/handlers/handleRewardV2.ts
+++ b/subgraphs/uniswap-forks/protocols/spookyswap/src/common/handlers/handleRewardV2.ts
@@ -3,7 +3,6 @@ import { NetworkConfigs } from "../../../../../configurations/configure";
 import { MasterChefV2Spookyswap } from "../../../../../generated/MasterChefV2/MasterChefV2Spookyswap";
 import {
   LiquidityPool,
-  _MasterChef,
   _MasterChefStakingPool,
 } from "../../../../../generated/schema";
 import { INT_ZERO, MasterChef } from "../../../../../src/common/constants";

--- a/subgraphs/uniswap-forks/protocols/spookyswap/src/common/handlers/handleRewardV2.ts
+++ b/subgraphs/uniswap-forks/protocols/spookyswap/src/common/handlers/handleRewardV2.ts
@@ -33,6 +33,7 @@ export function updateMasterChef(
   const masterchefV2Contract = MasterChefV2Spookyswap.bind(event.address);
   const masterChefV2 = getOrCreateMasterChef(event, MasterChef.MASTERCHEFV2);
 
+  // Sometimes the pool addition event is not emitted before the deposit/withdraw event. In this case, we need to add the pool and allocation to the masterchef entity.
   if (!masterChefV2Pool.poolAddress) {
     const poolAddress = poolContract.try_lpToken(pid);
     const poolInfo = poolContract.try_poolInfo(pid);


### PR DESCRIPTION
**Context:**
The references to the MasterChefV2 handlers needed to be updated. Just removed `V2` from the end since this caused the subgraphs to halt. The fix is currently being grafted at the Messari Spookyswap Fantom Hosted Service. 

Additionally, the pool addition events were not being emitted for some staking pools in MasterChefV2 before they were being deposited into. This caused issues, so I added some handling to getOrCreateMasterChefStakingPool. 