### PR TITLE
[GOV] Add gov subgraphs to public deployments json

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -4122,7 +4122,7 @@
       }
     }
   },
-  "ens-governance-governance": {
+  "ens-governance": {
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "ens-governance",
@@ -4146,6 +4146,10 @@
           "hosted-service": {
             "slug": "ens-governance",
             "query-id": "ens-governance"
+          },
+          "decentralized-network": {
+            "slug": "ens-governance",
+            "query-id": "F7MznC87sv5y5jNUaBSrKFgCqTqP9Vgc11xcreZQpX7e"
           }
         }
       }
@@ -4175,6 +4179,10 @@
           "hosted-service": {
             "slug": "euler-governance",
             "query-id": "euler-governance"
+          },
+          "decentralized-network": {
+            "slug": "euler-governance",
+            "query-id": "4xyasjQeREe7PxnF6wVdobZvCw5mhoHZq3T7guRpuNPf"
           }
         }
       }
@@ -4233,6 +4241,10 @@
           "hosted-service": {
             "slug": "hop-governance",
             "query-id": "hop-governance"
+          },
+          "decentralized-network": {
+            "slug": "hop-governance",
+            "query-id": "zGuPrsVqtY5ehJDCmweb9ZnBrae3tSQWRux8Mz1M4Gn"
           }
         }
       }
@@ -4262,6 +4274,10 @@
           "hosted-service": {
             "slug": "silo-governance",
             "query-id": "silo-governance"
+          },
+          "decentralized-network": {
+            "slug": "silo-governance",
+            "query-id": "HnV3fhwsWfmQGdD2AeGzqvRVTDBqnMH74jCsDVq1DXYP"
           }
         }
       }
@@ -4291,6 +4307,10 @@
           "hosted-service": {
             "slug": "truefi-governance",
             "query-id": "truefi-governance"
+          },
+          "decentralized-network": {
+            "slug": "truefi-governance",
+            "query-id": "H36tAWQeYVioE4hHtaKJEMJMxwzVJWjfg2mimva2wcUj"
           }
         }
       }
@@ -4320,6 +4340,10 @@
           "hosted-service": {
             "slug": "unlock-governance",
             "query-id": "unlock-governance"
+          },
+          "decentralized-network": {
+            "slug": "unlock-governance",
+            "query-id": "Dpk4Gen22wxQ3Laojf7DR2me8wGzjaHwjsKAsLf2rCFV"
           }
         }
       }


### PR DESCRIPTION
## Description

~As part of our governance subgraph ingestion we want to pull subgraph subgraph deployment info from a central location instead of hardcoding it. Adding a new section to the `dashboard/public/deployments.json` enables that.~

@this-username-is-taken does the additional section to this json break anything on subgraphs.messari.io? As far as I can tell it will just be ignored. I could also move it into a separate json if it make more sense

EDIT: After discussion with @this-username-is-taken and @steegecs, standardising reading of data from `https://github.com/messari/subgraphs/blob/master/deployment/deployment.json` instead.