### PR TITLE
fix(#minor); Uniswap V3; Updated to use Collect instead of burn. Also, configured to use deployment versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ Reference/
 .vscode/
 
 subgraph.yaml
-version.ts
+versions.ts
 deploymentJsonContext.json
 **/configurations/configure.ts
 generated/

--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2990,7 +2990,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3012,7 +3012,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3034,7 +3034,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3056,7 +3056,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3078,7 +3078,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-v3/configurations/configurations/interface.ts
+++ b/subgraphs/uniswap-v3/configurations/configurations/interface.ts
@@ -5,14 +5,11 @@ export interface Configurations {
   getNetwork(): string;
   getProtocolName(): string;
   getProtocolSlug(): string;
-  getSchemaVersion(): string;
-  getSubgraphVersion(): string;
-  getMethodologyVersion(): string;
   getFactoryAddress(): string;
   getFactoryContract(): Factory;
   getFeeOnOff(): string;
   getRewardIntervalType(): string;
-  getReferenceToken(): string
+  getReferenceToken(): string;
   getRewardToken(): string;
   getWhitelistTokens(): string[];
   getStableCoins(): string[];

--- a/subgraphs/uniswap-v3/package.json
+++ b/subgraphs/uniswap-v3/package.json
@@ -2,7 +2,8 @@
   "name": "uniswap-v3-alt",
   "license": "UNLICENSED",
   "scripts": {
-    "codegen": "graph codegen"
+    "codegen": "graph codegen",
+    "prepare:constants": "mustache protocols/${npm_config_protocol}/config/deployments/${npm_config_id}/configurations.json configurations/configure.mustache > configurations/configure.ts"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.27.0",

--- a/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.ts
+++ b/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.ts
@@ -3,30 +3,15 @@ import { Factory } from "../../../../../generated/Factory/Factory";
 import {
   FeeSwitch,
   Network,
-  PROTOCOL_SCHEMA_VERSION,
   RewardIntervalType,
 } from "../../../../../src/common/constants";
 import { Configurations } from "../../../../../configurations/configurations/interface";
-import {
-  PROTOCOL_SUBGRAPH_VERSION,
-  PROTOCOL_METHODOLOGY_VERSION,
-  PROTOCOL_NAME,
-  PROTOCOL_SLUG,
-} from "../../../src/common/constants";
+import { PROTOCOL_NAME, PROTOCOL_SLUG } from "../../../src/common/constants";
 import { toLowerCase } from "../../../../../src/common/utils/utils";
 
 export class UniswapV3ArbitrumConfigurations implements Configurations {
   getNetwork(): string {
     return Network.ARBITRUM_ONE;
-  }
-  getSchemaVersion(): string {
-    return PROTOCOL_SCHEMA_VERSION;
-  }
-  getSubgraphVersion(): string {
-    return PROTOCOL_SUBGRAPH_VERSION;
-  }
-  getMethodologyVersion(): string {
-    return PROTOCOL_METHODOLOGY_VERSION;
   }
   getProtocolName(): string {
     return PROTOCOL_NAME;

--- a/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-celo/configurations.ts
+++ b/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-celo/configurations.ts
@@ -3,29 +3,14 @@ import { Factory } from "../../../../../generated/Factory/Factory";
 import {
   FeeSwitch,
   Network,
-  PROTOCOL_SCHEMA_VERSION,
   RewardIntervalType,
 } from "../../../../../src/common/constants";
 import { Configurations } from "../../../../../configurations/configurations/interface";
-import {
-  PROTOCOL_SUBGRAPH_VERSION,
-  PROTOCOL_METHODOLOGY_VERSION,
-  PROTOCOL_NAME,
-  PROTOCOL_SLUG,
-} from "../../../src/common/constants";
+import { PROTOCOL_NAME, PROTOCOL_SLUG } from "../../../src/common/constants";
 
 export class UniswapV3CeloConfigurations implements Configurations {
   getNetwork(): string {
     return Network.CELO;
-  }
-  getSchemaVersion(): string {
-    return PROTOCOL_SCHEMA_VERSION;
-  }
-  getSubgraphVersion(): string {
-    return PROTOCOL_SUBGRAPH_VERSION;
-  }
-  getMethodologyVersion(): string {
-    return PROTOCOL_METHODOLOGY_VERSION;
   }
   getProtocolName(): string {
     return PROTOCOL_NAME;
@@ -61,7 +46,6 @@ export class UniswapV3CeloConfigurations implements Configurations {
       "0x02de4766c272abc10bc88c220d214a26960a7e92", // NCT
       "0x32a9fe697a32135bfd313a6ac28792dae4d9979d", // cMC02
       "0x66803fb87abd4aac3cbb3fad7c3aa01f6f3fb207", // wETH
-
     ];
   }
   getStableCoins(): string[] {

--- a/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-ethereum/configurations.ts
+++ b/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-ethereum/configurations.ts
@@ -3,30 +3,15 @@ import { Factory } from "../../../../../generated/Factory/Factory";
 import {
   FeeSwitch,
   Network,
-  PROTOCOL_SCHEMA_VERSION,
   RewardIntervalType,
 } from "../../../../../src/common/constants";
 import { Configurations } from "../../../../../configurations/configurations/interface";
-import {
-  PROTOCOL_SUBGRAPH_VERSION,
-  PROTOCOL_METHODOLOGY_VERSION,
-  PROTOCOL_NAME,
-  PROTOCOL_SLUG,
-} from "../../../src/common/constants";
+import { PROTOCOL_NAME, PROTOCOL_SLUG } from "../../../src/common/constants";
 import { toLowerCase } from "../../../../../src/common/utils/utils";
 
 export class UniswapV3MainnetConfigurations implements Configurations {
   getNetwork(): string {
     return Network.MAINNET;
-  }
-  getSchemaVersion(): string {
-    return PROTOCOL_SCHEMA_VERSION;
-  }
-  getSubgraphVersion(): string {
-    return PROTOCOL_SUBGRAPH_VERSION;
-  }
-  getMethodologyVersion(): string {
-    return PROTOCOL_METHODOLOGY_VERSION;
   }
   getProtocolName(): string {
     return PROTOCOL_NAME;

--- a/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-optimism/configurations.ts
+++ b/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-optimism/configurations.ts
@@ -3,30 +3,15 @@ import { Factory } from "../../../../../generated/Factory/Factory";
 import {
   FeeSwitch,
   Network,
-  PROTOCOL_SCHEMA_VERSION,
   RewardIntervalType,
 } from "../../../../../src/common/constants";
 import { Configurations } from "../../../../../configurations/configurations/interface";
-import {
-  PROTOCOL_SUBGRAPH_VERSION,
-  PROTOCOL_METHODOLOGY_VERSION,
-  PROTOCOL_NAME,
-  PROTOCOL_SLUG,
-} from "../../../src/common/constants";
+import { PROTOCOL_NAME, PROTOCOL_SLUG } from "../../../src/common/constants";
 import { toLowerCase } from "../../../../../src/common/utils/utils";
 
 export class UniswapV3OptimismConfigurations implements Configurations {
   getNetwork(): string {
     return Network.OPTIMISM;
-  }
-  getSchemaVersion(): string {
-    return PROTOCOL_SCHEMA_VERSION;
-  }
-  getSubgraphVersion(): string {
-    return PROTOCOL_SUBGRAPH_VERSION;
-  }
-  getMethodologyVersion(): string {
-    return PROTOCOL_METHODOLOGY_VERSION;
   }
   getProtocolName(): string {
     return PROTOCOL_NAME;

--- a/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-polygon/configurations.ts
+++ b/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-polygon/configurations.ts
@@ -3,30 +3,15 @@ import { Factory } from "../../../../../generated/Factory/Factory";
 import {
   FeeSwitch,
   Network,
-  PROTOCOL_SCHEMA_VERSION,
   RewardIntervalType,
 } from "../../../../../src/common/constants";
 import { Configurations } from "../../../../../configurations/configurations/interface";
-import {
-  PROTOCOL_SUBGRAPH_VERSION,
-  PROTOCOL_METHODOLOGY_VERSION,
-  PROTOCOL_NAME,
-  PROTOCOL_SLUG,
-} from "../../../src/common/constants";
+import { PROTOCOL_NAME, PROTOCOL_SLUG } from "../../../src/common/constants";
 import { toLowerCase } from "../../../../../src/common/utils/utils";
 
 export class UniswapV3MaticConfigurations implements Configurations {
   getNetwork(): string {
     return Network.MATIC;
-  }
-  getSchemaVersion(): string {
-    return PROTOCOL_SCHEMA_VERSION;
-  }
-  getSubgraphVersion(): string {
-    return PROTOCOL_SUBGRAPH_VERSION;
-  }
-  getMethodologyVersion(): string {
-    return PROTOCOL_METHODOLOGY_VERSION;
   }
   getProtocolName(): string {
     return PROTOCOL_NAME;

--- a/subgraphs/uniswap-v3/protocols/uniswap-v3/config/templates/uniswap.v3.template.yaml
+++ b/subgraphs/uniswap-v3/protocols/uniswap-v3/config/templates/uniswap.v3.template.yaml
@@ -89,7 +89,7 @@ templates:
           handler: handleSwap
         - event: Mint(address,indexed address,indexed int24,indexed int24,uint128,uint256,uint256)
           handler: handleMint
-        - event: Burn(indexed address,indexed int24,indexed int24,uint128,uint256,uint256)
-          handler: handleBurn
         - event: Collect(indexed address,address,indexed int24,indexed int24,uint128,uint128)
           handler: handleCollect
+        #- event: Burn(indexed address,indexed int24,indexed int24,uint128,uint256,uint256)
+          #handler: handleBurn

--- a/subgraphs/uniswap-v3/protocols/uniswap-v3/src/common/constants.ts
+++ b/subgraphs/uniswap-v3/protocols/uniswap-v3/src/common/constants.ts
@@ -2,7 +2,5 @@
 //////Versions//////
 ////////////////////
 
-export const PROTOCOL_SUBGRAPH_VERSION = "1.1.3";
-export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 export const PROTOCOL_NAME = "Uniswap V3";
 export const PROTOCOL_SLUG = "uniswap-v3";

--- a/subgraphs/uniswap-v3/schema.graphql
+++ b/subgraphs/uniswap-v3/schema.graphql
@@ -742,9 +742,6 @@ type Withdraw implements Event @entity {
 
   " The pool involving this transaction "
   pool: LiquidityPool!
-
-  " Specifies whether the withdrawal from a pool is trigger from a user collecting accrued swap fees "
-  isCollect: Boolean!
 }
 
 type Swap implements Event @entity {

--- a/subgraphs/uniswap-v3/src/common/constants.ts
+++ b/subgraphs/uniswap-v3/src/common/constants.ts
@@ -1,11 +1,5 @@
 import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
 
-////////////////////
-///// Versions /////
-////////////////////
-
-export const PROTOCOL_SCHEMA_VERSION = "1.3.0";
-
 ////////////////////////
 ///// Schema Enums /////
 ////////////////////////

--- a/subgraphs/uniswap-v3/src/common/creators.ts
+++ b/subgraphs/uniswap-v3/src/common/creators.ts
@@ -13,7 +13,7 @@ import { Pool as PoolTemplate } from "../../generated/templates";
 import {
   getLiquidityPool,
   getLiquidityPoolAmounts,
-  getOrCreateDex,
+  getOrCreateProtocol,
   getOrCreateToken,
 } from "./getters";
 import { NetworkConfigs } from "../../configurations/configure";
@@ -47,7 +47,7 @@ export function createLiquidityPool(
   token1Address: string,
   fees: i32
 ): void {
-  const protocol = getOrCreateDex();
+  const protocol = getOrCreateProtocol();
 
   // create the tokens and tokentracker
   const token0 = getOrCreateToken(token0Address);
@@ -159,7 +159,7 @@ export function createDeposit(
   const pool = getLiquidityPool(poolAddress);
   const poolAmounts = getLiquidityPoolAmounts(poolAddress);
 
-  const protocol = getOrCreateDex();
+  const protocol = getOrCreateProtocol();
 
   const token0 = getOrCreateToken(pool.inputTokens[0]);
   const token1 = getOrCreateToken(pool.inputTokens[1]);
@@ -230,18 +230,16 @@ export function createDeposit(
 // Also, updated token balances and total value locked.
 export function createWithdraw(
   event: ethereum.Event,
-  owner: Address,
   recipient: Address,
   amount0: BigInt,
-  amount1: BigInt,
-  isCollect: boolean
+  amount1: BigInt
 ): void {
   const poolAddress = event.address.toHexString();
 
   const pool = getLiquidityPool(poolAddress);
   const poolAmounts = getLiquidityPoolAmounts(poolAddress);
 
-  const protocol = getOrCreateDex();
+  const protocol = getOrCreateProtocol();
 
   const token0 = getOrCreateToken(pool.inputTokens[0]);
   const token1 = getOrCreateToken(pool.inputTokens[1]);
@@ -298,7 +296,6 @@ export function createWithdraw(
   withdrawal.inputTokenAmounts = [amount0, amount1];
   withdrawal.pool = pool.id;
   withdrawal.amountUSD = amountUSD;
-  withdrawal.isCollect = isCollect;
 
   withdrawal.save();
   pool.save();
@@ -317,7 +314,7 @@ export function createSwapHandleVolumeAndFees(
   sqrtPriceX96: BigInt
 ): void {
   const poolAddress = event.address.toHexString();
-  const protocol = getOrCreateDex();
+  const protocol = getOrCreateProtocol();
 
   const pool = getLiquidityPool(poolAddress);
   const poolAmounts = getLiquidityPoolAmounts(poolAddress);

--- a/subgraphs/uniswap-v3/src/common/getters.ts
+++ b/subgraphs/uniswap-v3/src/common/getters.ts
@@ -16,6 +16,7 @@ import {
   LiquidityPoolDailySnapshot,
   UsageMetricsHourlySnapshot,
 } from "../../generated/schema";
+import { Versions } from "../versions";
 import {
   INT_ZERO,
   BIGDECIMAL_ZERO,
@@ -28,16 +29,13 @@ import {
   Network,
 } from "./constants";
 
-export function getOrCreateDex(): DexAmmProtocol {
+export function getOrCreateProtocol(): DexAmmProtocol {
   let protocol = DexAmmProtocol.load(NetworkConfigs.getFactoryAddress());
 
   if (!protocol) {
     protocol = new DexAmmProtocol(NetworkConfigs.getFactoryAddress());
     protocol.name = NetworkConfigs.getProtocolName();
     protocol.slug = NetworkConfigs.getProtocolSlug();
-    protocol.schemaVersion = NetworkConfigs.getSchemaVersion();
-    protocol.subgraphVersion = NetworkConfigs.getSubgraphVersion();
-    protocol.methodologyVersion = NetworkConfigs.getMethodologyVersion();
     protocol.totalValueLockedUSD = BIGDECIMAL_ZERO;
     protocol.cumulativeVolumeUSD = BIGDECIMAL_ZERO;
     protocol.cumulativeSupplySideRevenueUSD = BIGDECIMAL_ZERO;
@@ -50,9 +48,9 @@ export function getOrCreateDex(): DexAmmProtocol {
     protocol._regenesis = false;
   }
 
-  protocol.schemaVersion = NetworkConfigs.getSchemaVersion();
-  protocol.subgraphVersion = NetworkConfigs.getSubgraphVersion();
-  protocol.methodologyVersion = NetworkConfigs.getMethodologyVersion();
+  protocol.schemaVersion = Versions.getSchemaVersion();
+  protocol.subgraphVersion = Versions.getSubgraphVersion();
+  protocol.methodologyVersion = Versions.getMethodologyVersion();
   protocol.save();
 
   return protocol;

--- a/subgraphs/uniswap-v3/src/common/updateMetrics.ts
+++ b/subgraphs/uniswap-v3/src/common/updateMetrics.ts
@@ -21,7 +21,7 @@ import {
   BIGINT_NEG_ONE,
 } from "./constants";
 import {
-  getOrCreateDex,
+  getOrCreateProtocol,
   getLiquidityPool,
   getLiquidityPoolFee,
   getLiquidityPoolAmounts,
@@ -44,7 +44,7 @@ import { percToDec } from "./utils/utils";
 export function updateFinancials(event: ethereum.Event): void {
   const financialMetricsDaily = getOrCreateFinancialsDailySnapshot(event);
 
-  const protocol = getOrCreateDex();
+  const protocol = getOrCreateProtocol();
 
   // Update the block number and timestamp to that of the last transaction of that day
   financialMetricsDaily.blockNumber = event.block.number;
@@ -66,7 +66,7 @@ export function updateUsageMetrics(
   const usageMetricsDaily = getOrCreateUsageMetricDailySnapshot(event);
   const usageMetricsHourly = getOrCreateUsageMetricHourlySnapshot(event);
 
-  const protocol = getOrCreateDex();
+  const protocol = getOrCreateProtocol();
 
   // Update the block number and timestamp to that of the last transaction of that day
   usageMetricsDaily.blockNumber = event.block.number;

--- a/subgraphs/uniswap-v3/src/common/utils/backfill.ts
+++ b/subgraphs/uniswap-v3/src/common/utils/backfill.ts
@@ -11,7 +11,11 @@ import {
   INT_ONE,
   INT_ZERO,
 } from "../constants";
-import { getOrCreateDex, getOrCreateToken, getTradingFee } from "../getters";
+import {
+  getOrCreateProtocol,
+  getOrCreateToken,
+  getTradingFee,
+} from "../getters";
 import { updateTokenWhitelists } from "../updateMetrics";
 import { Pool as PoolTemplate } from "../../../generated/templates";
 import { Pool } from "../../../generated/Factory/Pool";
@@ -25,7 +29,7 @@ import { POOL_MAPPINGS } from "./poolMappings";
  * before regenesis.
  */
 export function populateEmptyPools(event: ethereum.Event): void {
-  const protocol = getOrCreateDex();
+  const protocol = getOrCreateProtocol();
   const length = POOL_MAPPINGS.length;
 
   for (let i = 0; i < length; ++i) {

--- a/subgraphs/uniswap-v3/src/mappings/core.ts
+++ b/subgraphs/uniswap-v3/src/mappings/core.ts
@@ -1,6 +1,5 @@
 // import { log } from "@graphprotocol/graph-ts";
 import {
-  Burn as BurnEvent,
   Initialize,
   Mint as MintEvent,
   Swap as SwapEvent,

--- a/subgraphs/uniswap-v3/src/mappings/core.ts
+++ b/subgraphs/uniswap-v3/src/mappings/core.ts
@@ -45,21 +45,6 @@ export function handleMint(event: MintEvent): void {
   updatePoolMetrics(event);
 }
 
-// Handle a burn event emitted from a pool contract. Considered a withdraw into the given liquidity pool.
-export function handleBurn(event: BurnEvent): void {
-  createWithdraw(
-    event,
-    event.params.owner,
-    event.params.owner,
-    event.params.amount0,
-    event.params.amount1,
-    false
-  );
-  updateUsageMetrics(event, event.params.owner, UsageType.WITHDRAW);
-  updateFinancials(event);
-  updatePoolMetrics(event);
-}
-
 // Handle a swap event emitted from a pool contract.
 export function handleSwap(event: SwapEvent): void {
   createSwapHandleVolumeAndFees(
@@ -78,11 +63,9 @@ export function handleSwap(event: SwapEvent): void {
 export function handleCollect(event: CollectEvent): void {
   createWithdraw(
     event,
-    event.params.owner,
     event.params.recipient,
     event.params.amount0,
-    event.params.amount1,
-    true
+    event.params.amount1
   );
   updateFinancials(event);
   updatePoolMetrics(event);


### PR DESCRIPTION
**Context:**
We recently incorporated collect events into Uniswap V3 in attempt to fix TVL issues that were occurring in PR #1092. I made the change based on a PR the Uni team was using to address this issue.

After making these changes, however, we were getting negative token values. I have discovered that when incorporating both the `burn` and the `collect` events, tokens are being removed from liquidity pools, in a sense, twice. This is because the `amount0` and `amount1` emitted from the burn event do not refer to the actual amount of tokens leaving the liquidity pool, rather, it refers to an increasing balance of tokens owed to the user that can be collected.

`Burn` and `collect` are often emitted together, and with the same amounts, but this is not guaranteed, and the `burn` event does not account for tracking the token pair flows out of the pool that were earned from accrued fees while `collect` events do.

By removing the `burn` event and retaining tracking withdraws with the `collect` event, we can maintain a proper balance of the liquidity pools over time. I have tested this out with Uniswap V3 Celo, and it has remained accurate when compared with token balances against etherscan until fully synced. 

Changes
- [x] Removed the use of the Burn event and instead track withdraws from the liquidity pools using the collect event. 
- [x] Update the protocol getter to use the `versions.ts` generated from the deployment.json 