### PR TITLE
fix(#patch); CI Linter; Fix changed files action 

### DIFF
--- a/.github/workflows/build-checker.yaml
+++ b/.github/workflows/build-checker.yaml
@@ -39,21 +39,19 @@ jobs:
       
       - name: Get changed files in the subgraphs folder
         id: changed-files-specific
-        uses: tj-actions/changed-files@v31
+        uses: Ana06/get-changed-files@v2.1.0
         with:
-          files: |
-            subgraphs/**/*.ts
-            subgraphs/**/*.tsx
+          filter: 'subgraphs/**/*.ts'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
       - name: Echo file changes
         run: |
-          echo Changed files: "${{ steps.changed-files-specific.outputs.all_changed_files }}"
+          echo Changed files: "${{ steps.changed-files-specific.outputs.all }}"
       
       - name: Lint staged files
-        run: npm run lint:subgraphs ${{ steps.changed-files-specific.outputs.all_changed_files }}
+        run: npm run lint:subgraphs ${{ steps.changed-files-specific.outputs.all }}
 
   Build:
     runs-on: macos-latest


### PR DESCRIPTION
Context:
Sometime the linter was not able to fetch the commit prior to the PR causing it to fail. This PR updates the changed file action to one that has worked better in the past.

![Screen Shot 2022-10-23 at 3 56 06 PM](https://user-images.githubusercontent.com/56660047/197417908-898b743d-1036-4941-8d35-7a0e664447f1.png)
