### PR TITLE
feat (); euler-finance; used event.receipt

### DIFF
--- a/subgraphs/euler-finance/protocols/euler-finance/config/templates/euler.template.yaml
+++ b/subgraphs/euler-finance/protocols/euler-finance/config/templates/euler.template.yaml
@@ -19,7 +19,7 @@ dataSources:
       startBlock: {{ startBlock }} # this is when the first market was deployed
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - AssetStatus
@@ -46,6 +46,7 @@ dataSources:
       eventHandlers:
         - event: AssetStatus(indexed address,uint256,uint256,uint96,uint256,uint256,int96,uint256)
           handler: handleAssetStatus
+          receipt: true
         - event: Borrow(indexed address,indexed address,uint256)
           handler: handleBorrow
         - event: Deposit(indexed address,indexed address,uint256)

--- a/subgraphs/euler-finance/src/mappings/handlers.ts
+++ b/subgraphs/euler-finance/src/mappings/handlers.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, log } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 import {
   AssetStatus,
   Borrow,

--- a/subgraphs/euler-finance/src/mappings/handlers.ts
+++ b/subgraphs/euler-finance/src/mappings/handlers.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { Address, BigInt, log } from "@graphprotocol/graph-ts";
 import {
   AssetStatus,
   Borrow,
@@ -216,8 +216,13 @@ export function handleLiquidation(event: Liquidation): void {
   snapshotMarket(event.block, marketId, liquidateUSD, TransactionType.LIQUIDATE);
   snapshotFinancials(event.block, liquidateUSD, TransactionType.LIQUIDATE);
 
+  log.debug("[handleLiquidation]tx={} is a liquidation, repay={}", [
+    event.transaction.hash.toHexString(),
+    event.params.repay.toString(),
+  ]);
+
   // Roll back supply side & total revenue calculated from liquidation fee
-  rollbackRevenue(marketId, event, assetStatus);
+  // rollbackRevenue(marketId, event, assetStatus);
 }
 
 export function handleGovSetAssetConfig(event: GovSetAssetConfig): void {

--- a/subgraphs/euler-finance/src/mappings/handlers.ts
+++ b/subgraphs/euler-finance/src/mappings/handlers.ts
@@ -26,7 +26,7 @@ import {
   DEFAULT_DECIMALS,
   BIGINT_SEVENTY_FIVE,
 } from "../common/constants";
-import { rollbackRevenue, snapshotFinancials, snapshotMarket, updateUsageMetrics } from "./helpers";
+import { snapshotFinancials, snapshotMarket, updateUsageMetrics } from "./helpers";
 import {
   createBorrow,
   createDeposit,
@@ -215,14 +215,6 @@ export function handleLiquidation(event: Liquidation): void {
   updateUsageMetrics(event, event.params.liquidator, TransactionType.LIQUIDATE);
   snapshotMarket(event.block, marketId, liquidateUSD, TransactionType.LIQUIDATE);
   snapshotFinancials(event.block, liquidateUSD, TransactionType.LIQUIDATE);
-
-  log.debug("[handleLiquidation]tx={} is a liquidation, repay={}", [
-    event.transaction.hash.toHexString(),
-    event.params.repay.toString(),
-  ]);
-
-  // Roll back supply side & total revenue calculated from liquidation fee
-  // rollbackRevenue(marketId, event, assetStatus);
 }
 
 export function handleGovSetAssetConfig(event: GovSetAssetConfig): void {


### PR DESCRIPTION
This PR uses event.receipt to avoid having to roll back revenues for liquidations.

The diff is bit messed up. `getRepayForLiquidation` is not revised from `rollbackRevenue`, but a different function that gets ride of the need of rolling back.

Test deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/benqi?version=pending&selected=logs
https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/name/tnkrxyz/benqi&tab=protocol