### PR TITLE
Venus rewards

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1695,7 +1695,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.9",
+          "subgraph": "1.2.0",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/compound-forks/abis/venus/Comptroller.json
+++ b/subgraphs/compound-forks/abis/venus/Comptroller.json
@@ -1,0 +1,1819 @@
+[
+  {
+    "inputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "enum ComptrollerV9Storage.Action",
+        "name": "action",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "pauseState",
+        "type": "bool"
+      }
+    ],
+    "name": "ActionPausedMarket",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "state",
+        "type": "bool"
+      }
+    ],
+    "name": "ActionProtocolPaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "venusDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "venusBorrowIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "DistributedBorrowerVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "supplier",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "venusDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "venusSupplyIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "DistributedSupplierVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DistributedVAIVaultVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "error",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "info",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "detail",
+        "type": "uint256"
+      }
+    ],
+    "name": "Failure",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "MarketEntered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "MarketExited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      }
+    ],
+    "name": "MarketListed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldAccessControlAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAccessControlAddress",
+        "type": "address"
+      }
+    ],
+    "name": "NewAccessControl",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newBorrowCap",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewBorrowCap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldCloseFactorMantissa",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newCloseFactorMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewCloseFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldCollateralFactorMantissa",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newCollateralFactorMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewCollateralFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldComptrollerLens",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newComptrollerLens",
+        "type": "address"
+      }
+    ],
+    "name": "NewComptrollerLens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldLiquidationIncentiveMantissa",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newLiquidationIncentiveMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewLiquidationIncentive",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldLiquidatorContract",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newLiquidatorContract",
+        "type": "address"
+      }
+    ],
+    "name": "NewLiquidatorContract",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldPauseGuardian",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newPauseGuardian",
+        "type": "address"
+      }
+    ],
+    "name": "NewPauseGuardian",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract PriceOracle",
+        "name": "oldPriceOracle",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract PriceOracle",
+        "name": "newPriceOracle",
+        "type": "address"
+      }
+    ],
+    "name": "NewPriceOracle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newSupplyCap",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewSupplyCap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldTreasuryAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newTreasuryAddress",
+        "type": "address"
+      }
+    ],
+    "name": "NewTreasuryAddress",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldTreasuryGuardian",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newTreasuryGuardian",
+        "type": "address"
+      }
+    ],
+    "name": "NewTreasuryGuardian",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldTreasuryPercent",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newTreasuryPercent",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewTreasuryPercent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract VAIControllerInterface",
+        "name": "oldVAIController",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract VAIControllerInterface",
+        "name": "newVAIController",
+        "type": "address"
+      }
+    ],
+    "name": "NewVAIController",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldVAIMintRate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newVAIMintRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewVAIMintRate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "vault_",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "releaseStartBlock_",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "releaseInterval_",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewVAIVaultInfo",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldVenusVAIVaultRate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newVenusVAIVaultRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewVenusVAIVaultRate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "VenusGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newSpeed",
+        "type": "uint256"
+      }
+    ],
+    "name": "VenusSpeedUpdated",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract Unitroller",
+        "name": "unitroller",
+        "type": "address"
+      }
+    ],
+    "name": "_become",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "_grantXVS",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newAccessControlAddress",
+        "type": "address"
+      }
+    ],
+    "name": "_setAccessControl",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "markets", "type": "address[]" },
+      {
+        "internalType": "enum ComptrollerV9Storage.Action[]",
+        "name": "actions",
+        "type": "uint8[]"
+      },
+      { "internalType": "bool", "name": "paused", "type": "bool" }
+    ],
+    "name": "_setActionsPaused",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newCloseFactorMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "_setCloseFactor",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newCollateralFactorMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "_setCollateralFactor",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract ComptrollerLensInterface",
+        "name": "comptrollerLens_",
+        "type": "address"
+      }
+    ],
+    "name": "_setComptrollerLens",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newLiquidationIncentiveMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "_setLiquidationIncentive",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newLiquidatorContract_",
+        "type": "address"
+      }
+    ],
+    "name": "_setLiquidatorContract",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract VToken[]",
+        "name": "vTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "newBorrowCaps",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "_setMarketBorrowCaps",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract VToken[]",
+        "name": "vTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "newSupplyCaps",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "_setMarketSupplyCaps",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newPauseGuardian",
+        "type": "address"
+      }
+    ],
+    "name": "_setPauseGuardian",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract PriceOracle",
+        "name": "newOracle",
+        "type": "address"
+      }
+    ],
+    "name": "_setPriceOracle",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "bool", "name": "state", "type": "bool" }],
+    "name": "_setProtocolPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newTreasuryGuardian",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "newTreasuryAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newTreasuryPercent",
+        "type": "uint256"
+      }
+    ],
+    "name": "_setTreasuryData",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract VAIControllerInterface",
+        "name": "vaiController_",
+        "type": "address"
+      }
+    ],
+    "name": "_setVAIController",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "uint256", "name": "newVAIMintRate", "type": "uint256" }
+    ],
+    "name": "_setVAIMintRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vault_", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "releaseStartBlock_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minReleaseAmount_",
+        "type": "uint256"
+      }
+    ],
+    "name": "_setVAIVaultInfo",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      { "internalType": "uint256", "name": "venusSpeed", "type": "uint256" }
+    ],
+    "name": "_setVenusSpeed",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "venusVAIVaultRate_",
+        "type": "uint256"
+      }
+    ],
+    "name": "_setVenusVAIVaultRate",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract VToken", "name": "vToken", "type": "address" }
+    ],
+    "name": "_supportMarket",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "name": "accountAssets",
+    "outputs": [
+      { "internalType": "contract VToken", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "market", "type": "address" },
+      {
+        "internalType": "enum ComptrollerV9Storage.Action",
+        "name": "action",
+        "type": "uint8"
+      }
+    ],
+    "name": "actionPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "admin",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "allMarkets",
+    "outputs": [
+      { "internalType": "contract VToken", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "borrowCapGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "borrowCaps",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "contract VToken", "name": "vToken", "type": "address" }
+    ],
+    "name": "checkMembership",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "holders", "type": "address[]" },
+      {
+        "internalType": "contract VToken[]",
+        "name": "vTokens",
+        "type": "address[]"
+      },
+      { "internalType": "bool", "name": "borrowers", "type": "bool" },
+      { "internalType": "bool", "name": "suppliers", "type": "bool" },
+      { "internalType": "bool", "name": "collateral", "type": "bool" }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "holder", "type": "address" },
+      {
+        "internalType": "contract VToken[]",
+        "name": "vTokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "holder", "type": "address" }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "holders", "type": "address[]" },
+      {
+        "internalType": "contract VToken[]",
+        "name": "vTokens",
+        "type": "address[]"
+      },
+      { "internalType": "bool", "name": "borrowers", "type": "bool" },
+      { "internalType": "bool", "name": "suppliers", "type": "bool" }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "holder", "type": "address" }
+    ],
+    "name": "claimVenusAsCollateral",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "closeFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptrollerImplementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptrollerLens",
+    "outputs": [
+      {
+        "internalType": "contract ComptrollerLensInterface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "vTokens", "type": "address[]" }
+    ],
+    "name": "enterMarkets",
+    "outputs": [
+      { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenAddress", "type": "address" }
+    ],
+    "name": "exitMarket",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "getAccountLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getAllMarkets",
+    "outputs": [
+      { "internalType": "contract VToken[]", "name": "", "type": "address[]" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "getAssetsIn",
+    "outputs": [
+      { "internalType": "contract VToken[]", "name": "", "type": "address[]" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "address", "name": "vTokenModify", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "getHypotheticalAccountLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getXVSAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getXVSVTokenAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isComptroller",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vTokenBorrowed",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "vTokenCollateral",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "liquidateBorrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vTokenBorrowed",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "vTokenCollateral",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "actualRepayAmount",
+        "type": "uint256"
+      },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "liquidateBorrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vTokenBorrowed",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "vTokenCollateral",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actualRepayAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "liquidateCalculateSeizeTokens",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vTokenCollateral",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actualRepayAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "liquidateVAICalculateSeizeTokens",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "liquidationIncentiveMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "liquidatorContract",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "markets",
+    "outputs": [
+      { "internalType": "bool", "name": "isListed", "type": "bool" },
+      {
+        "internalType": "uint256",
+        "name": "collateralFactorMantissa",
+        "type": "uint256"
+      },
+      { "internalType": "bool", "name": "isVenus", "type": "bool" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "maxAssets",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "minReleaseAmount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "minter", "type": "address" },
+      { "internalType": "uint256", "name": "mintAmount", "type": "uint256" }
+    ],
+    "name": "mintAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "mintVAIGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "minter", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "actualMintAmount",
+        "type": "uint256"
+      },
+      { "internalType": "uint256", "name": "mintTokens", "type": "uint256" }
+    ],
+    "name": "mintVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "mintedVAIs",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [
+      { "internalType": "contract PriceOracle", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pauseGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingComptrollerImplementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "protocolPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "releaseStartBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "releaseToVault",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "actualRepayAmount",
+        "type": "uint256"
+      },
+      { "internalType": "uint256", "name": "borrowerIndex", "type": "uint256" }
+    ],
+    "name": "repayBorrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "repayVAIGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vTokenCollateral",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "vTokenBorrowed",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seizeAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vTokenCollateral",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "vTokenBorrowed",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seizeVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "setMintedVAIOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "supplyCaps",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "transferTokens", "type": "uint256" }
+    ],
+    "name": "transferAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "transferTokens", "type": "uint256" }
+    ],
+    "name": "transferVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryPercent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiController",
+    "outputs": [
+      {
+        "internalType": "contract VAIControllerInterface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiMintRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiVaultAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusAccrued",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusBorrowState",
+    "outputs": [
+      { "internalType": "uint224", "name": "index", "type": "uint224" },
+      { "internalType": "uint32", "name": "block", "type": "uint32" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "venusBorrowerIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusInitialIndex",
+    "outputs": [{ "internalType": "uint224", "name": "", "type": "uint224" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusSpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "venusSupplierIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusSupplyState",
+    "outputs": [
+      { "internalType": "uint224", "name": "index", "type": "uint224" },
+      { "internalType": "uint32", "name": "block", "type": "uint32" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusVAIVaultRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/compound-forks/protocols/venus/config/deployments/venus-protocol-bsc/configurations.json
+++ b/subgraphs/compound-forks/protocols/venus/config/deployments/venus-protocol-bsc/configurations.json
@@ -2,7 +2,7 @@
   "network": "bsc",
   "factoryAddress": "0xfD36E2c2a6789Db23113685031d7F16329158384",
   "startBlock": "2471512",
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "QmVziuhA3ZU1pFFbQivSUMtiksKTY6bNNi93oNXKHUHGT2",
   "graftStartBlock": 17803400
 }

--- a/subgraphs/compound-forks/protocols/venus/config/templates/venus.template.yaml
+++ b/subgraphs/compound-forks/protocols/venus/config/templates/venus.template.yaml
@@ -32,6 +32,8 @@ dataSources:
           file: ./abis/CToken.json
         - name: ERC20
           file: ./abis/ERC20.json
+        - name: PriceOracle
+          file: ./abis/PriceOracle.json
       eventHandlers:
         - event: MarketListed(address)
           handler: handleMarketListed
@@ -47,6 +49,9 @@ dataSources:
           handler: handleNewLiquidationIncentive
         - event: ActionPausedMarket(indexed address,indexed uint8,bool)
           handler: handleActionPaused
+          # venus rewards emissions changes are conveniently emitted :)
+        - event: VenusSpeedUpdated(indexed address,uint256)
+          handler: handleVenusSpeedUpdated
       file: ./protocols/venus/src/mapping.ts
 templates:
   - name: CToken

--- a/subgraphs/compound-forks/protocols/venus/config/templates/venus.template.yaml
+++ b/subgraphs/compound-forks/protocols/venus/config/templates/venus.template.yaml
@@ -27,7 +27,7 @@ dataSources:
         - Token
       abis:
         - name: Comptroller
-          file: ./abis/Comptroller.json
+          file: ./abis/venus/Comptroller.json
         - name: CToken
           file: ./abis/CToken.json
         - name: ERC20
@@ -45,7 +45,7 @@ dataSources:
           handler: handleNewCollateralFactor
         - event: NewLiquidationIncentive(uint256,uint256)
           handler: handleNewLiquidationIncentive
-        - event: ActionPaused(address,string,bool)
+        - event: ActionPausedMarket(indexed address,indexed uint8,bool)
           handler: handleActionPaused
       file: ./protocols/venus/src/mapping.ts
 templates:

--- a/subgraphs/compound-forks/protocols/venus/src/constants.ts
+++ b/subgraphs/compound-forks/protocols/venus/src/constants.ts
@@ -23,3 +23,20 @@ export const nativeCToken = new TokenData(
 export const VDAI_MARKET_ADDRESS = Address.fromString(
   "0x334b3ecb4dca3593bccc3c7ebd1a1c1d1780fbf1"
 );
+
+export const vXVS = new TokenData(
+  Address.fromString("0x151b1e2635a717bcdc836ecd6fbb62b674fe3e1d"),
+  "Venus XVS",
+  "vXVS",
+  cTokenDecimals
+);
+
+export const XVS = new TokenData(
+  Address.fromString("0xcf6bb5389c92bdda8a3747ddb454cb7a64626c63"),
+  "Venus",
+  "XVS",
+  18
+);
+
+// number of decimals the oracle results are scaled by.
+export const ORACLE_PRECISION = 18;

--- a/subgraphs/compound-forks/protocols/venus/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/venus/src/mapping.ts
@@ -1,10 +1,4 @@
-import {
-  Address,
-  BigInt,
-  BigDecimal,
-  ethereum,
-  log,
-} from "@graphprotocol/graph-ts";
+import { Address, BigInt, ethereum, log } from "@graphprotocol/graph-ts";
 // import from the generated at root in order to reuse methods from root
 import {
   NewPriceOracle,
@@ -34,12 +28,11 @@ import {
 } from "../../../generated/schema";
 import {
   cTokenDecimals,
+  exponentToBigDecimal,
   Network,
   BIGINT_ZERO,
   BSC_BLOCKS_PER_YEAR,
-  DAYS_PER_YEAR,
   RewardTokenType,
-  BIGINT_TEN,
   BIGDECIMAL_ZERO,
 } from "../../../src/constants";
 import {
@@ -372,7 +365,7 @@ export function handleVenusSpeedUpdated(event: VenusSpeedUpdated): void {
     event.block.number,
     speed.toBigDecimal(),
     RewardIntervalType.BLOCK
-  ).times(BigDecimal.fromString(DAYS_PER_YEAR.toString()));
+  );
 
   const rewardAmount = BigInt.fromString(rewards.truncate(0).toString());
   const borrowRewardToken = getOrCreateRewardToken(RewardTokenType.BORROW);
@@ -424,8 +417,8 @@ function updateRewardValueUSD(market: Market): void {
   const rewardAmount = market.rewardTokenEmissionsAmount![0];
   const rewardAmountUSD = rewardAmount
     .times(priceCall.value)
-    .divDecimal(BIGINT_TEN.pow(ORACLE_PRECISION as u8).toBigDecimal())
-    .div(BIGINT_TEN.pow(XVS.decimals as u8).toBigDecimal());
+    .divDecimal(exponentToBigDecimal(ORACLE_PRECISION))
+    .div(exponentToBigDecimal(XVS.decimals));
   market.rewardTokenEmissionsUSD = [rewardAmountUSD, rewardAmountUSD];
   market.save();
 }

--- a/subgraphs/compound-forks/protocols/venus/src/rewards.ts
+++ b/subgraphs/compound-forks/protocols/venus/src/rewards.ts
@@ -1,0 +1,261 @@
+/////////////////////
+// VERSION 1.0.1 ////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// The purpose of this program is to dynamically estimate the blocks generated for the 24 HR period following the most recent update. //
+// It does so by calculating the moving average block rate for an arbitrary length of time preceding the current block.               //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+import { BigDecimal, BigInt, dataSource, log } from "@graphprotocol/graph-ts";
+import { _CircularBuffer } from "../../../generated/schema";
+import {
+  BIGDECIMAL_ZERO,
+  INT_FOUR,
+  INT_NEGATIVE_ONE,
+  INT_ONE,
+  INT_TWO,
+  INT_ZERO,
+} from "../../../src/constants";
+import { Network } from "../../../src/constants";
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// WINDOW_SIZE_SECONDS, TIMESTAMP_STORAGE_INTERVALS, and BUFFER_SIZE can be modified. These are just recommended values - 'somewhat' arbitrary. //
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// The storage interval tells you to only store blocks where the timestamps are separated by at least this amount.
+// Increasing this value will mean less blocks stored and less frequently computes blocksSpeed.
+export const TIMESTAMP_STORAGE_INTERVAL = 600;
+
+// The window size determines the range of blocks that you track from the current block minus the window size.
+// Window of block time used to calculate the moving average.
+// Increasing means less deviation but also less sensitivity to changing block speeds.
+export const WINDOW_SIZE_SECONDS = 86400;
+
+// BUFFER_SIZE determined the size of the array
+// Makes the buffer the maximum amount of blocks that can be stored given the block rate and storage interval
+// Recommended value is (RATE_IN_SECODNDS / TIMESTAMP_STORAGE_INTERVAL) - > Round up to nearest even integer
+export const BUFFER_SIZE = 144;
+
+// Add this entity to the schema.
+
+// type _CircularBuffer @entity {
+//     id: ID!
+//     blocks: [Int!]!
+//     windowStartIndex: Int!
+//     nextIndex: Int!
+//     bufferSize: Int!
+//     blocksPerDay: BigDecimal!
+// }
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const CIRCULAR_BUFFER = "CIRCULAR_BUFFER";
+
+// Describes whether the interval for which rewards are emitted is done by block or timestamp
+export namespace RewardIntervalType {
+  export const BLOCK = "BLOCK";
+  export const TIMESTAMP = "TIMESTAMP";
+}
+
+// Forecast period. This gives you the time period that you want to estimate count of blocks per interval, based on moving average block speed.
+// 86400 = 1 Day
+export const RATE_IN_SECONDS = 86400;
+export const RATE_IN_SECONDS_BD = BigDecimal.fromString(
+  RATE_IN_SECONDS.toString()
+);
+
+// Estimated seconds per block of the protocol
+export const STARTING_BLOCKS_PER_DAY = RATE_IN_SECONDS_BD.div(
+  getStartingBlockRate()
+);
+
+export const WINDOW_SIZE_SECONDS_BD = BigDecimal.fromString(
+  WINDOW_SIZE_SECONDS.toString()
+);
+
+// Call this function in event handlers frequently enough so that it calls on blocks frequently enough
+/**
+ * @param {BigInt} currentTimestamp    - Timestamp for current event
+ * @param {BigInt} currentBlockNumber  - Block nunmber of current event
+ * @param {BigInt} rewardRate          - Rate of reward emissions per reward interval
+ * @param {BigInt} rewardType          - Describes whether rewards are given per block or timestamp
+ * @returns {BigDecimal}               - Returns estimated rewards for specified rate, per day.
+ */
+export function getRewardsPerDay(
+  currentTimestamp: BigInt,
+  currentBlockNumber: BigInt,
+  rewardRate: BigDecimal,
+  rewardType: string
+): BigDecimal {
+  const circularBuffer = getOrCreateCircularBuffer();
+
+  // Create entity for the current block
+  const currentTimestampI32 = currentTimestamp.toI32();
+  const currentBlockNumberI32 = currentBlockNumber.toI32();
+
+  const blocks = circularBuffer.blocks;
+
+  // Interval between index and the index of the start of the window block
+  const windowWidth = abs(
+    circularBuffer.windowStartIndex - circularBuffer.nextIndex
+  );
+  if (windowWidth == INT_ZERO) {
+    if (circularBuffer.nextIndex >= circularBuffer.bufferSize) {
+      blocks[INT_ZERO] = currentTimestampI32;
+      blocks[INT_ONE] = currentBlockNumberI32;
+      circularBuffer.nextIndex = INT_TWO;
+    } else {
+      blocks[circularBuffer.nextIndex] = currentTimestampI32;
+      blocks[circularBuffer.nextIndex + INT_ONE] = currentBlockNumberI32;
+      circularBuffer.nextIndex += INT_TWO;
+    }
+
+    circularBuffer.save();
+
+    // return because there is only 1 reference point.
+    if (rewardType == RewardIntervalType.TIMESTAMP) {
+      return rewardRate.times(RATE_IN_SECONDS_BD);
+    } else {
+      return circularBuffer.blocksPerDay.times(rewardRate);
+    }
+  }
+
+  // Add current timestamp and block numnber to array if new block is at least X blocks later than previously stored.
+  // Used to save memory and efficiency on array resizing.
+  let recentSavedTimestamp: i32;
+  if (circularBuffer.nextIndex == INT_ZERO) {
+    recentSavedTimestamp = blocks[circularBuffer.bufferSize - INT_TWO];
+  } else {
+    recentSavedTimestamp = blocks[circularBuffer.nextIndex - INT_TWO];
+  }
+
+  if (
+    currentTimestampI32 - recentSavedTimestamp <=
+    TIMESTAMP_STORAGE_INTERVAL
+  ) {
+    if (rewardType == RewardIntervalType.TIMESTAMP) {
+      return rewardRate.times(RATE_IN_SECONDS_BD);
+    } else {
+      return circularBuffer.blocksPerDay.times(rewardRate);
+    }
+  }
+
+  blocks[circularBuffer.nextIndex] = currentTimestampI32;
+  blocks[circularBuffer.nextIndex + INT_ONE] = currentBlockNumberI32;
+  if (circularBuffer.nextIndex >= BUFFER_SIZE - INT_TWO) {
+    circularBuffer.nextIndex = INT_ZERO;
+  } else {
+    circularBuffer.nextIndex += INT_TWO;
+  }
+  // The timestamp at the start of the window (default 24 hours in seconds).
+  const startTimestamp = currentTimestampI32 - WINDOW_SIZE_SECONDS;
+
+  // Make sure to still have 2 blocks to calculate rate (This shouldn't happen past the beginning).
+  while (
+    abs(circularBuffer.nextIndex - circularBuffer.windowStartIndex) > INT_FOUR
+  ) {
+    const windowIndexBlockTimestamp = blocks[circularBuffer.windowStartIndex];
+
+    // Shift the start of the window if the current timestamp moves out of desired rate window
+    if (windowIndexBlockTimestamp < startTimestamp) {
+      circularBuffer.windowStartIndex =
+        circularBuffer.windowStartIndex + INT_TWO;
+      if (circularBuffer.windowStartIndex >= circularBuffer.bufferSize) {
+        circularBuffer.windowStartIndex = INT_ZERO;
+      }
+    } else {
+      break;
+    }
+  }
+
+  // Wideness of the window in seconds.
+  const windowSecondsCount = BigDecimal.fromString(
+    (currentTimestampI32 - blocks[circularBuffer.windowStartIndex]).toString()
+  );
+
+  // Wideness of the window in blocks.
+  const windowBlocksCount = BigDecimal.fromString(
+    (
+      currentBlockNumberI32 - blocks[circularBuffer.windowStartIndex + INT_ONE]
+    ).toString()
+  );
+
+  // Estimate block speed for the window in seconds.
+  const unnormalizedBlockSpeed =
+    WINDOW_SIZE_SECONDS_BD.div(windowSecondsCount).times(windowBlocksCount);
+
+  // block speed converted to specified rate.
+  const normalizedBlockSpeed = RATE_IN_SECONDS_BD.div(
+    WINDOW_SIZE_SECONDS_BD
+  ).times(unnormalizedBlockSpeed);
+
+  // Update BlockTracker with new values.
+  circularBuffer.blocksPerDay = normalizedBlockSpeed;
+  circularBuffer.blocks = blocks;
+
+  circularBuffer.save();
+
+  if (rewardType == RewardIntervalType.TIMESTAMP) {
+    return rewardRate.times(RATE_IN_SECONDS_BD);
+  } else {
+    return rewardRate.times(circularBuffer.blocksPerDay);
+  }
+}
+
+export function getOrCreateCircularBuffer(): _CircularBuffer {
+  let circularBuffer = _CircularBuffer.load(CIRCULAR_BUFFER);
+
+  if (!circularBuffer) {
+    circularBuffer = new _CircularBuffer(CIRCULAR_BUFFER);
+
+    const blocks = new Array<i32>(BUFFER_SIZE);
+    for (let i = INT_ZERO; i < BUFFER_SIZE; i += INT_TWO) {
+      blocks[i] = INT_NEGATIVE_ONE;
+      blocks[i + INT_ONE] = INT_NEGATIVE_ONE;
+    }
+
+    circularBuffer.blocks = blocks;
+    circularBuffer.windowStartIndex = INT_ZERO;
+    circularBuffer.nextIndex = INT_ZERO;
+    circularBuffer.bufferSize = BUFFER_SIZE;
+    circularBuffer.blocksPerDay = STARTING_BLOCKS_PER_DAY;
+
+    circularBuffer.save();
+  }
+
+  return circularBuffer;
+}
+
+function getStartingBlockRate(): BigDecimal {
+  // Block rates pulled from google searches - rough estimates
+
+  const network = dataSource.network().toUpperCase();
+  if (network == Network.MAINNET) {
+    return BigDecimal.fromString("13.39");
+  } else if (network == Network.ARBITRUM_ONE) {
+    return BigDecimal.fromString("15");
+  } else if (network == Network.AURORA) {
+    return BigDecimal.fromString("1.03");
+  } else if (network == Network.BSC) {
+    return BigDecimal.fromString("5");
+  } else if (network == Network.CELO) {
+    return BigDecimal.fromString("5");
+  } else if (network == Network.FANTOM) {
+    return BigDecimal.fromString("1");
+  } else if (network == Network.OPTIMISM) {
+    return BigDecimal.fromString("12.5");
+  } else if (network == Network.MATIC) {
+    return BigDecimal.fromString("2");
+  } else if (network == Network.XDAI) {
+    return BigDecimal.fromString("5");
+  }
+  // Blocks are mined as needed
+  // else if (network == SubgraphNetwork.AVALANCHE) return BigDecimal.fromString("2.5")
+  // else if (dataSource.network() == "cronos") return BigDecimal.fromString("13.39")
+  // else if (dataSource.network() == "harmony") return BigDecimal.fromString("13.39")
+  // else if (dataSource.network() == SubgraphNetwork.MOONBEAM) return BigDecimal.fromString("13.39")
+  // else if (dataSource.network() == SubgraphNetwork.MOONRIVER) return BigDecimal.fromString("13.39")
+  else {
+    log.warning("getStartingBlockRate(): Network not found", []);
+    return BIGDECIMAL_ZERO;
+  }
+}

--- a/subgraphs/compound-forks/src/constants.ts
+++ b/subgraphs/compound-forks/src/constants.ts
@@ -89,6 +89,7 @@ export const INT_FOUR = 4 as i32;
 export const BIGINT_ZERO = BigInt.fromI32(0);
 export const BIGINT_ONE = BigInt.fromI32(1);
 export const BIGINT_TEN_TO_EIGHTEENTH = BigInt.fromString("10").pow(18);
+export const BIGINT_TEN = BigInt.fromI32(10);
 
 export const BIGDECIMAL_ZERO = new BigDecimal(BIGINT_ZERO);
 export const BIGDECIMAL_ONE = new BigDecimal(BIGINT_ONE);


### PR DESCRIPTION
This PR has 2 purposes (they are split on separate commits):
- Fixes an issue with `ActionPaused` events:
  - I had to change the Comptroller ABI to be able to use part of Venus specific functionality, and the project stopped building. It was because the ActionPaused event name differs in Venus from the original Compound contract.
- Adds XVS rewards.
  - Each market is given a `reward speed`, that every time it changes emits an event. This determines the `market.rewardTokenEmissionsAmount` values.
  - Every time that event or `AccrueInterest` are emitted, we'll recalculate the USD value of that `rewardTokenAmount`.
  - To translate `reward speed` to yearly rewards I'm using the code in `rewards.ts` which was copied as is [from here](https://github.com/messari/subgraphs/blob/master/subgraphs/compound-forks/protocols/compound-v2/src/rewards.ts). Let me know if that is accurate or there is a more recent method (@dmelotik )


Syncing here: https://okgraph.xyz/?q=QmUC7vLhpuwP82tAdgp6v9GTdYX5DCaG3dSuQDouVgcP7u