### PR TITLE
[GIN] Fix reflexer governance proposal with empty values and signatures

### DIFF
--- a/subgraphs/governor-alpha-bravo/protocols/reflexer-governance/src/GovernorBravo.ts
+++ b/subgraphs/governor-alpha-bravo/protocols/reflexer-governance/src/GovernorBravo.ts
@@ -39,8 +39,8 @@ export function handleProposalCreated(event: ProposalCreated): void {
 
   // HACK: Reflexer is setting undefined for values and signatures instead of correct values
   // this results in diff array lengths so we have to add dummy values
-  const values: BigInt[] = new Array();
-  const signatures: string[] = new Array();
+  const values: BigInt[] = [];
+  const signatures: string[] = [];
   for (let i = 0; i < event.params.targets.length; i++) {
     values[i] = BIGINT_ZERO;
     signatures[i] = "";

--- a/subgraphs/governor-alpha-bravo/protocols/reflexer-governance/src/GovernorBravo.ts
+++ b/subgraphs/governor-alpha-bravo/protocols/reflexer-governance/src/GovernorBravo.ts
@@ -22,6 +22,7 @@ import { GovernorBravo } from "../../../generated/GovernorBravo/GovernorBravo";
 import { GovernanceFramework, Proposal } from "../../../generated/schema";
 import {
   BIGINT_ONE,
+  BIGINT_ZERO,
   GovernanceFrameworkType,
   NA,
   ProposalState,
@@ -36,6 +37,14 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 export function handleProposalCreated(event: ProposalCreated): void {
   const quorumVotes = getQuorumFromContract(event.address);
 
+  // HACK: Reflexer is setting undefined for values and signatures instead of correct values
+  // this results in diff array lengths so we have to add dummy values
+  const values: BigInt[] = new Array();
+  const signatures: string[] = new Array();
+  for (let i = 0; i < event.params.targets.length; i++) {
+    values[i] = BIGINT_ZERO;
+    signatures[i] = "";
+  }
   // FIXME: Prefer to use a single object arg for params
   // e.g.  { proposalId: event.params.proposalId, proposer: event.params.proposer, ...}
   // but graph wasm compilation breaks for unknown reasons
@@ -43,8 +52,8 @@ export function handleProposalCreated(event: ProposalCreated): void {
     event.params.id.toString(),
     event.params.proposer.toHexString(),
     event.params.targets,
-    event.params.values,
-    event.params.signatures,
+    values,
+    signatures,
     event.params.calldatas,
     event.params.startBlock,
     event.params.endBlock,


### PR DESCRIPTION
## Description

Reflexer governance proposal are created undefined values for `signatures` and `values`. This causes issues further down the pipeline as the target, calldata and signature lengths don't match. This PR adds a simple workaround to replace the undefined with empty values.

<img width="839" alt="image" src="https://user-images.githubusercontent.com/4507317/201949453-60ad0bac-0176-47e6-8348-3a4b53e0033d.png">
