### PR TITLE
fix(#patch): lido-ethereum; update snaphsots and tvl more often

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2075,7 +2075,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.0.1",
+          "subgraph": "1.0.2",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/lido/protocols/lido/config/templates/lido.template.yaml
+++ b/subgraphs/lido/protocols/lido/config/templates/lido.template.yaml
@@ -76,3 +76,75 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
       file: ./src/mappings/Lido.ts
+  - kind: ethereum
+    name: LidoOracle
+    network: mainnet
+    source:
+      address: "0x442af784a788a5bd6f42a01ebe9f287a871243fb"
+      abi: LidoOracle
+      startBlock: 11473216
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Token
+        - Pool
+        - PoolDailySnapshot
+        - PoolHourlySnapshot
+        - Protocol
+        - FinancialsDailySnapshot
+        - UsageMetricsDailySnapshot
+        - UsageMetricsHourlySnapshot
+      abis:
+        ###########################################
+        ########### Lido Generic ABIs #############
+        ###########################################
+        - name: Lido
+          file: ./abis/Lido.json
+        - name: NodeOperatorsRegistry
+          file: ./abis/NodeOperatorsRegistry.json
+        - name: LidoOracle
+          file: ./abis/LidoOracle.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+
+        ###########################################
+        ############## Price Oracle ###############
+        ###########################################
+        # ERC20
+        - name: _ERC20
+          file: ./abis/Prices/ERC20.json
+        # Curve Contracts
+        - name: CurveRegistry
+          file: ./abis/Prices/Curve/Registry.json
+        - name: CurvePoolRegistry
+          file: ./abis/Prices/Curve/PoolRegistry.json
+        - name: CalculationsCurve
+          file: ./abis/Prices/Calculations/Curve.json
+        # YearnLens Contracts
+        - name: YearnLensContract
+          file: ./abis/Prices/YearnLens.json
+        # ChainLink Contracts
+        - name: ChainLinkContract
+          file: ./abis/Prices/ChainLink.json
+        # Uniswap Contracts
+        - name: UniswapRouter
+          file: ./abis/Prices/Uniswap/Router.json
+        - name: UniswapFactory
+          file: ./abis/Prices/Uniswap/Factory.json
+        - name: UniswapPair
+          file: ./abis/Prices/Uniswap/Pair.json
+        # SushiSwap Contracts
+        - name: SushiSwapRouter
+          file: ./abis/Prices/SushiSwap/Router.json
+        - name: SushiSwapFactory
+          file: ./abis/Prices/SushiSwap/Factory.json
+        - name: SushiSwapPair
+          file: ./abis/Prices/SushiSwap/Pair.json
+        - name: CalculationsSushiSwap
+          file: ./abis/Prices/Calculations/SushiSwap.json
+      eventHandlers:
+        - event: PostTotalShares(uint256,uint256,uint256,uint256)
+          handler: handlePostTotalShares
+      file: ./src/mappings/Oracle.ts

--- a/subgraphs/lido/src/entities/token.ts
+++ b/subgraphs/lido/src/entities/token.ts
@@ -30,6 +30,10 @@ export function getOrCreateToken(
     }
   }
 
+  if (token.lastPriceBlockNumber && token.lastPriceBlockNumber == blockNumber) {
+    return token;
+  }
+
   // Optional lastPriceUSD and lastPriceBlockNumber, but used in financialMetrics
   const price = getUsdPricePerToken(tokenAddress);
   if (price.reverted) {

--- a/subgraphs/lido/src/entityUpdates/financialMetrics.ts
+++ b/subgraphs/lido/src/entityUpdates/financialMetrics.ts
@@ -33,6 +33,10 @@ export function updateProtocolAndPoolTvl(
     getOrCreateToken(Address.fromString(ETH_ADDRESS), block.number)
       .lastPriceUSD!
   );
+  pool.outputTokenPriceUSD = getOrCreateToken(
+    Address.fromString(PROTOCOL_ID),
+    block.number
+  ).lastPriceUSD;
   pool.save();
 
   // Protocol
@@ -52,6 +56,7 @@ export function updateSnapshotsTvl(block: ethereum.Block): void {
   poolMetricsDailySnapshot.totalValueLockedUSD = pool.totalValueLockedUSD;
   poolMetricsDailySnapshot.inputTokenBalances = pool.inputTokenBalances;
   poolMetricsDailySnapshot.outputTokenSupply = pool.outputTokenSupply;
+  poolMetricsDailySnapshot.outputTokenPriceUSD = pool.outputTokenPriceUSD;
   poolMetricsDailySnapshot.cumulativeProtocolSideRevenueUSD =
     pool.cumulativeProtocolSideRevenueUSD;
   poolMetricsDailySnapshot.cumulativeSupplySideRevenueUSD =
@@ -64,11 +69,12 @@ export function updateSnapshotsTvl(block: ethereum.Block): void {
   poolMetricsHourlySnapshot.totalValueLockedUSD = pool.totalValueLockedUSD;
   poolMetricsHourlySnapshot.inputTokenBalances = pool.inputTokenBalances;
   poolMetricsHourlySnapshot.outputTokenSupply = pool.outputTokenSupply;
-  poolMetricsDailySnapshot.cumulativeProtocolSideRevenueUSD =
+  poolMetricsHourlySnapshot.outputTokenPriceUSD = pool.outputTokenPriceUSD;
+  poolMetricsHourlySnapshot.cumulativeProtocolSideRevenueUSD =
     pool.cumulativeProtocolSideRevenueUSD;
-  poolMetricsDailySnapshot.cumulativeSupplySideRevenueUSD =
+  poolMetricsHourlySnapshot.cumulativeSupplySideRevenueUSD =
     pool.cumulativeSupplySideRevenueUSD;
-  poolMetricsDailySnapshot.cumulativeTotalRevenueUSD =
+  poolMetricsHourlySnapshot.cumulativeTotalRevenueUSD =
     pool.cumulativeTotalRevenueUSD;
   poolMetricsHourlySnapshot.save();
 
@@ -85,7 +91,7 @@ export function updateSnapshotsTvl(block: ethereum.Block): void {
 export function updateTotalRevenueMetrics(
   block: ethereum.Block,
   revenueETH: BigInt,
-  totalShares: BigInt
+  totalSupply: BigInt
 ): void {
   const pool = getOrCreatePool(block.number, block.timestamp);
   const protocol = getOrCreateProtocol();
@@ -103,7 +109,7 @@ export function updateTotalRevenueMetrics(
   // Pool
   pool.cumulativeTotalRevenueUSD =
     pool.cumulativeTotalRevenueUSD.plus(stakingRewardsUSD);
-  pool.outputTokenSupply = totalShares;
+  pool.outputTokenSupply = totalSupply;
   pool.outputTokenPriceUSD = getOrCreateToken(
     Address.fromString(PROTOCOL_ID),
     block.number

--- a/subgraphs/lido/src/entityUpdates/financialMetrics.ts
+++ b/subgraphs/lido/src/entityUpdates/financialMetrics.ts
@@ -35,77 +35,74 @@ export function updateProtocolAndPoolTvl(
   );
   pool.save();
 
-  // Pool Daily and Hourly
-  // updateSnapshotsTvl(event.block) is called separately when protocol and supply side revenue
-  // metrics are being calculated to consolidate respective revenue metrics into same snapshots
-
   // Protocol
   protocol.totalValueLockedUSD = pool.totalValueLockedUSD;
   protocol.save();
 
-  // Financials Daily
-  // updateSnapshotsTvl(event.block) is called separately when protocol and supply side revenue
-  // metrics are being calculated to consolidate respective revenue metrics into same snapshots
+  updateSnapshotsTvl(block);
 }
 
 export function updateSnapshotsTvl(block: ethereum.Block): void {
   const pool = getOrCreatePool(block.number, block.timestamp);
-  const poolMetricsDailySnapshot = getOrCreatePoolsDailySnapshot(
-    Address.fromString(PROTOCOL_ID),
-    block
-  );
-  const poolMetricsHourlySnapshot = getOrCreatePoolsHourlySnapshot(
-    Address.fromString(PROTOCOL_ID),
-    block
-  );
+  const poolMetricsDailySnapshot = getOrCreatePoolsDailySnapshot(block);
+  const poolMetricsHourlySnapshot = getOrCreatePoolsHourlySnapshot(block);
   const financialMetrics = getOrCreateFinancialDailyMetrics(block);
 
   // Pool Daily
   poolMetricsDailySnapshot.totalValueLockedUSD = pool.totalValueLockedUSD;
   poolMetricsDailySnapshot.inputTokenBalances = pool.inputTokenBalances;
+  poolMetricsDailySnapshot.outputTokenSupply = pool.outputTokenSupply;
+  poolMetricsDailySnapshot.cumulativeProtocolSideRevenueUSD =
+    pool.cumulativeProtocolSideRevenueUSD;
+  poolMetricsDailySnapshot.cumulativeSupplySideRevenueUSD =
+    pool.cumulativeSupplySideRevenueUSD;
+  poolMetricsDailySnapshot.cumulativeTotalRevenueUSD =
+    pool.cumulativeTotalRevenueUSD;
   poolMetricsDailySnapshot.save();
 
   // Pool Hourly
   poolMetricsHourlySnapshot.totalValueLockedUSD = pool.totalValueLockedUSD;
   poolMetricsHourlySnapshot.inputTokenBalances = pool.inputTokenBalances;
+  poolMetricsHourlySnapshot.outputTokenSupply = pool.outputTokenSupply;
+  poolMetricsDailySnapshot.cumulativeProtocolSideRevenueUSD =
+    pool.cumulativeProtocolSideRevenueUSD;
+  poolMetricsDailySnapshot.cumulativeSupplySideRevenueUSD =
+    pool.cumulativeSupplySideRevenueUSD;
+  poolMetricsDailySnapshot.cumulativeTotalRevenueUSD =
+    pool.cumulativeTotalRevenueUSD;
   poolMetricsHourlySnapshot.save();
 
   // Financials Daily
   financialMetrics.totalValueLockedUSD = pool.totalValueLockedUSD;
+  financialMetrics.cumulativeProtocolSideRevenueUSD =
+    pool.cumulativeProtocolSideRevenueUSD;
+  financialMetrics.cumulativeSupplySideRevenueUSD =
+    pool.cumulativeSupplySideRevenueUSD;
+  financialMetrics.cumulativeTotalRevenueUSD = pool.cumulativeTotalRevenueUSD;
   financialMetrics.save();
 }
 
 export function updateTotalRevenueMetrics(
   block: ethereum.Block,
-  preTotalPooledEther: BigInt,
-  postTotalPooledEther: BigInt,
+  revenueETH: BigInt,
   totalShares: BigInt
 ): void {
   const pool = getOrCreatePool(block.number, block.timestamp);
   const protocol = getOrCreateProtocol();
   const financialMetrics = getOrCreateFinancialDailyMetrics(block);
-  const poolMetricsDailySnapshot = getOrCreatePoolsDailySnapshot(
-    Address.fromString(PROTOCOL_ID),
-    block
-  );
-  const poolMetricsHourlySnapshot = getOrCreatePoolsHourlySnapshot(
-    Address.fromString(PROTOCOL_ID),
-    block
-  );
+  const poolMetricsDailySnapshot = getOrCreatePoolsDailySnapshot(block);
+  const poolMetricsHourlySnapshot = getOrCreatePoolsHourlySnapshot(block);
 
   // Staking Rewards
-  const stakingRewards = bigIntToBigDecimal(
-    postTotalPooledEther.minus(preTotalPooledEther)
-  );
+  const stakingRewards = bigIntToBigDecimal(revenueETH);
   const stakingRewardsUSD = stakingRewards.times(
     getOrCreateToken(Address.fromString(ETH_ADDRESS), block.number)
       .lastPriceUSD!
   );
 
   // Pool
-  pool.cumulativeTotalRevenueUSD = pool.cumulativeTotalRevenueUSD.plus(
-    stakingRewardsUSD
-  );
+  pool.cumulativeTotalRevenueUSD =
+    pool.cumulativeTotalRevenueUSD.plus(stakingRewardsUSD);
   pool.outputTokenSupply = totalShares;
   pool.outputTokenPriceUSD = getOrCreateToken(
     Address.fromString(PROTOCOL_ID),
@@ -116,9 +113,8 @@ export function updateTotalRevenueMetrics(
   // Pool Daily
   poolMetricsDailySnapshot.cumulativeTotalRevenueUSD =
     pool.cumulativeTotalRevenueUSD;
-  poolMetricsDailySnapshot.dailyTotalRevenueUSD = poolMetricsDailySnapshot.dailyTotalRevenueUSD.plus(
-    stakingRewardsUSD
-  );
+  poolMetricsDailySnapshot.dailyTotalRevenueUSD =
+    poolMetricsDailySnapshot.dailyTotalRevenueUSD.plus(stakingRewardsUSD);
   poolMetricsDailySnapshot.outputTokenSupply = pool.outputTokenSupply;
   poolMetricsDailySnapshot.outputTokenPriceUSD = pool.outputTokenPriceUSD;
   poolMetricsDailySnapshot.save();
@@ -126,9 +122,8 @@ export function updateTotalRevenueMetrics(
   // Pool Hourly
   poolMetricsHourlySnapshot.cumulativeTotalRevenueUSD =
     pool.cumulativeTotalRevenueUSD;
-  poolMetricsHourlySnapshot.hourlyTotalRevenueUSD = poolMetricsHourlySnapshot.hourlyTotalRevenueUSD.plus(
-    stakingRewardsUSD
-  );
+  poolMetricsHourlySnapshot.hourlyTotalRevenueUSD =
+    poolMetricsHourlySnapshot.hourlyTotalRevenueUSD.plus(stakingRewardsUSD);
   poolMetricsHourlySnapshot.outputTokenSupply = pool.outputTokenSupply;
   poolMetricsHourlySnapshot.outputTokenPriceUSD = pool.outputTokenPriceUSD;
   poolMetricsHourlySnapshot.save();
@@ -151,14 +146,8 @@ export function updateProtocolSideRevenueMetrics(
   const pool = getOrCreatePool(block.number, block.timestamp);
   const protocol = getOrCreateProtocol();
   const financialMetrics = getOrCreateFinancialDailyMetrics(block);
-  const poolMetricsDailySnapshot = getOrCreatePoolsDailySnapshot(
-    Address.fromString(PROTOCOL_ID),
-    block
-  );
-  const poolMetricsHourlySnapshot = getOrCreatePoolsHourlySnapshot(
-    Address.fromString(PROTOCOL_ID),
-    block
-  );
+  const poolMetricsDailySnapshot = getOrCreatePoolsDailySnapshot(block);
+  const poolMetricsHourlySnapshot = getOrCreatePoolsHourlySnapshot(block);
 
   // Staking rewards revenue is in ETH (rebased in stETH for user), price in ETH
   const amountUSD = bigIntToBigDecimal(amount).times(
@@ -167,25 +156,22 @@ export function updateProtocolSideRevenueMetrics(
   );
 
   // Pool
-  pool.cumulativeProtocolSideRevenueUSD = pool.cumulativeProtocolSideRevenueUSD.plus(
-    amountUSD
-  );
+  pool.cumulativeProtocolSideRevenueUSD =
+    pool.cumulativeProtocolSideRevenueUSD.plus(amountUSD);
   pool.save();
 
   // Pool Daily
   poolMetricsDailySnapshot.cumulativeProtocolSideRevenueUSD =
     pool.cumulativeProtocolSideRevenueUSD;
-  poolMetricsDailySnapshot.dailyProtocolSideRevenueUSD = poolMetricsDailySnapshot.dailyProtocolSideRevenueUSD.plus(
-    amountUSD
-  );
+  poolMetricsDailySnapshot.dailyProtocolSideRevenueUSD =
+    poolMetricsDailySnapshot.dailyProtocolSideRevenueUSD.plus(amountUSD);
   poolMetricsDailySnapshot.save();
 
   // Pool Hourly
   poolMetricsHourlySnapshot.cumulativeProtocolSideRevenueUSD =
     pool.cumulativeProtocolSideRevenueUSD;
-  poolMetricsHourlySnapshot.hourlyProtocolSideRevenueUSD = poolMetricsHourlySnapshot.hourlyProtocolSideRevenueUSD.plus(
-    amountUSD
-  );
+  poolMetricsHourlySnapshot.hourlyProtocolSideRevenueUSD =
+    poolMetricsHourlySnapshot.hourlyProtocolSideRevenueUSD.plus(amountUSD);
   poolMetricsHourlySnapshot.save();
 
   // Protocol
@@ -196,9 +182,8 @@ export function updateProtocolSideRevenueMetrics(
   // Financial Daily
   financialMetrics.cumulativeProtocolSideRevenueUSD =
     pool.cumulativeProtocolSideRevenueUSD;
-  financialMetrics.dailyProtocolSideRevenueUSD = financialMetrics.dailyProtocolSideRevenueUSD.plus(
-    amountUSD
-  );
+  financialMetrics.dailyProtocolSideRevenueUSD =
+    financialMetrics.dailyProtocolSideRevenueUSD.plus(amountUSD);
   financialMetrics.save();
 }
 
@@ -206,14 +191,8 @@ export function updateSupplySideRevenueMetrics(block: ethereum.Block): void {
   const pool = getOrCreatePool(block.number, block.timestamp);
   const protocol = getOrCreateProtocol();
   const financialMetrics = getOrCreateFinancialDailyMetrics(block);
-  const poolMetricsDailySnapshot = getOrCreatePoolsDailySnapshot(
-    Address.fromString(PROTOCOL_ID),
-    block
-  );
-  const poolMetricsHourlySnapshot = getOrCreatePoolsHourlySnapshot(
-    Address.fromString(PROTOCOL_ID),
-    block
-  );
+  const poolMetricsDailySnapshot = getOrCreatePoolsDailySnapshot(block);
+  const poolMetricsHourlySnapshot = getOrCreatePoolsHourlySnapshot(block);
 
   // Pool
   pool.cumulativeSupplySideRevenueUSD =
@@ -268,7 +247,7 @@ export function updateSupplySideRevenueMetrics(block: ethereum.Block): void {
 export function getOrCreateFinancialDailyMetrics(
   block: ethereum.Block
 ): FinancialsDailySnapshot {
-  let dayId: string = (block.timestamp.toI64() / SECONDS_PER_DAY).toString();
+  const dayId: string = (block.timestamp.toI64() / SECONDS_PER_DAY).toString();
   let financialMetrics = FinancialsDailySnapshot.load(dayId);
 
   if (!financialMetrics) {
@@ -294,10 +273,9 @@ export function getOrCreateFinancialDailyMetrics(
 }
 
 export function getOrCreatePoolsDailySnapshot(
-  poolAddress: Address,
   block: ethereum.Block
 ): PoolDailySnapshot {
-  let dayId: string = (block.timestamp.toI64() / SECONDS_PER_DAY).toString();
+  const dayId: string = (block.timestamp.toI64() / SECONDS_PER_DAY).toString();
   let poolMetrics = PoolDailySnapshot.load(dayId);
 
   if (!poolMetrics) {
@@ -328,10 +306,11 @@ export function getOrCreatePoolsDailySnapshot(
 }
 
 export function getOrCreatePoolsHourlySnapshot(
-  poolAddress: Address,
   block: ethereum.Block
 ): PoolHourlySnapshot {
-  let hourId: string = (block.timestamp.toI64() / SECONDS_PER_HOUR).toString();
+  const hourId: string = (
+    block.timestamp.toI64() / SECONDS_PER_HOUR
+  ).toString();
   let poolMetrics = PoolHourlySnapshot.load(hourId);
 
   if (!poolMetrics) {

--- a/subgraphs/lido/src/mappings/Lido.ts
+++ b/subgraphs/lido/src/mappings/Lido.ts
@@ -1,6 +1,5 @@
 import { Address, log } from "@graphprotocol/graph-ts";
-import { Lido, Submitted, Transfer } from "../../generated/Lido/Lido";
-import { LidoOracle } from "../../generated/Lido/LidoOracle";
+import { Submitted, Transfer } from "../../generated/Lido/Lido";
 import { NodeOperatorsRegistry } from "../../generated/Lido/NodeOperatorsRegistry";
 import { getOrCreateToken } from "../entities/token";
 import { updateUsageMetrics } from "../entityUpdates/usageMetrics";
@@ -8,11 +7,9 @@ import {
   updateProtocolAndPoolTvl,
   updateSupplySideRevenueMetrics,
   updateProtocolSideRevenueMetrics,
-  updateTotalRevenueMetrics,
 } from "../entityUpdates/financialMetrics";
 import {
   PROTOCOL_TREASURY_ID,
-  PROTOCOL_ORACLE_ID,
   PROTOCOL_NODE_OPERATORS_REGISTRY_ID,
   ZERO_ADDRESS,
   ETH_ADDRESS,
@@ -20,59 +17,45 @@ import {
   BIGINT_ZERO,
 } from "../utils/constants";
 import { getOrCreatePool } from "../entities/pool";
+import { Lido } from "../../generated/Lido/Lido";
 
 export function handleSubmit(event: Submitted): void {
   // update Token lastPrice and lastBlock
   getOrCreateToken(Address.fromString(ETH_ADDRESS), event.block.number);
   getOrCreateToken(Address.fromString(PROTOCOL_ID), event.block.number);
 
+  const lido = Lido.bind(event.address);
+  const supply = lido.totalSupply();
+  const pool = getOrCreatePool(event.block.number, event.block.timestamp);
+  pool.outputTokenSupply = supply;
+  pool.save();
+
   // update metrics
   updateUsageMetrics(event.block, event.params.sender);
   updateProtocolAndPoolTvl(event.block, event.params.amount);
 }
 
+// handleTransfer is used to track minting of new shares.
+// From here we calculate protocol side revenue.
 export function handleTransfer(event: Transfer): void {
+  const sender = event.params.from;
+  const recipient = event.params.to;
+  const value = event.params.value;
+  if (sender.toHexString() != ZERO_ADDRESS) {
+    return;
+  }
+
   // update Token lastPrice and lastBlock
   getOrCreateToken(Address.fromString(ETH_ADDRESS), event.block.number);
   getOrCreateToken(Address.fromString(PROTOCOL_ID), event.block.number);
 
-  // get pre and post pooled ether
-  let preTotalPooledEther = BIGINT_ZERO;
-  let postTotalPooledEther = BIGINT_ZERO;
-  const lidoOracle = LidoOracle.bind(Address.fromString(PROTOCOL_ORACLE_ID));
-  const lastCompletedReportDeltaCallResult = lidoOracle.try_getLastCompletedReportDelta();
-
-  if (lastCompletedReportDeltaCallResult.reverted) {
-    log.info("LidoOracle call reverted", []);
-  } else {
-    preTotalPooledEther = lastCompletedReportDeltaCallResult.value.getPreTotalPooledEther();
-    postTotalPooledEther = lastCompletedReportDeltaCallResult.value.getPostTotalPooledEther();
-  }
-
-  // get total shares
-  let totalShares = BIGINT_ZERO;
-  const lido = Lido.bind(Address.fromString(PROTOCOL_ID));
-  const getTotalSharesCallResult = lido.try_getTotalShares();
-
-  if (getTotalSharesCallResult.reverted) {
-    log.info("Lido call reverted", []);
-  } else {
-    totalShares = getTotalSharesCallResult.value;
-  }
-  const pool = getOrCreatePool(event.block.number, event.block.timestamp);
-  pool.outputTokenSupply = totalShares;
-  pool.save();
-
   // get node operators
-  const sender = event.params.from;
-  const recipient = event.params.to;
-  const value = event.params.value;
-
   let nodeOperators: Address[] = [];
   const nodeOperatorsRegistry = NodeOperatorsRegistry.bind(
     Address.fromString(PROTOCOL_NODE_OPERATORS_REGISTRY_ID)
   );
-  const getRewardsDistributionCallResult = nodeOperatorsRegistry.try_getRewardsDistribution(BIGINT_ZERO);
+  const getRewardsDistributionCallResult =
+    nodeOperatorsRegistry.try_getRewardsDistribution(BIGINT_ZERO);
   if (getRewardsDistributionCallResult.reverted) {
     log.info("NodeOperatorsRegistry call reverted", []);
   } else {
@@ -85,19 +68,9 @@ export function handleTransfer(event: Transfer): void {
   const isMintToNodeOperators = fromZeros && nodeOperators.includes(recipient);
 
   // update metrics
-  let protocolRevenue = BIGINT_ZERO;
   if (isMintToTreasury || isMintToNodeOperators) {
-    protocolRevenue = value;
-
-    if (pool.outputTokenSupply < totalShares) {
-      // only increase total revenue if this is a mint to protocol (implies a distribution)
-      // and if we haven't accounted for it yet (shares updated).
-      const totalRevenue = postTotalPooledEther.minus(preTotalPooledEther);
-      updateTotalRevenueMetrics(event.block, totalRevenue, totalShares);
-    }
+    updateProtocolSideRevenueMetrics(event.block, value);
+    updateSupplySideRevenueMetrics(event.block);
+    updateProtocolAndPoolTvl(event.block, BIGINT_ZERO);
   }
-
-  updateProtocolSideRevenueMetrics(event.block, protocolRevenue);
-  updateSupplySideRevenueMetrics(event.block); // last, since it is calculated from total&protocol
-  updateProtocolAndPoolTvl(event.block, BIGINT_ZERO);
 }

--- a/subgraphs/lido/src/mappings/Oracle.ts
+++ b/subgraphs/lido/src/mappings/Oracle.ts
@@ -1,0 +1,25 @@
+import { PostTotalShares } from "../../generated/Lido/LidoOracle";
+import {
+  updateProtocolAndPoolTvl,
+  updateSupplySideRevenueMetrics,
+  updateTotalRevenueMetrics,
+} from "../entityUpdates/financialMetrics";
+import { BIGINT_ZERO, PROTOCOL_ID } from "../utils/constants";
+import { Lido } from "../../generated/Lido/Lido";
+import { Address } from "@graphprotocol/graph-ts";
+
+export function handlePostTotalShares(event: PostTotalShares): void {
+  // PostTotalShares is emitted by the oracle once a day when
+  // eth rewards are updated and minted as shares on the Lido contract.
+  // We use this event to calculate total & supply side revenue.
+  // Protocol revenue is calulated in the Lido mapping, by listening to
+  // mint events to treasury and node operators.
+  const totalRevenue = event.params.postTotalPooledEther.minus(
+    event.params.preTotalPooledEther
+  );
+  const lido = Lido.bind(Address.fromString(PROTOCOL_ID));
+  const supply = lido.totalSupply();
+  updateTotalRevenueMetrics(event.block, totalRevenue, supply);
+  updateSupplySideRevenueMetrics(event.block);
+  updateProtocolAndPoolTvl(event.block, BIGINT_ZERO);
+}


### PR DESCRIPTION
We were only updating snapshots when there was a mint of stETH. This only happens once every 24 hours, so hourly snapshots were only being created once daily.

Had to make some readjustments to the way we take snapshots in this subgraph and the times we update TVL and revenues:
- TVL was not being updated when a deposit was made, only on daily revenue mint. **Fixed this.**
- Snaphots are not updated as a whole. Only certain parts of it at a time (tvl alone, supply side revenue alone, total revenue alone, protocol revenue alone). Since revenue only increases every 24h, taking a snapshot before then would make 0 cumulative values on revenue on the hourly snapshots. **Added all the copying cumulative values on all snapshot taking functions.**
- Total revenue was calculated by observing mint events, and then calling the oracle to fetch the last daily reward update. **I moved that to its own event handler emitted from the oracle.** Functionality is the same, but slightly more efficient and clearer to read and understand.
  - We still look for mint events to see which ones go to treasury and operators (protocol revenue).
- We were using Lido’s internal contract shares as `OutputTokenSupply`. The number of shares is not the supply of stETH. **Fixed that too.**

Solves this: #1453

Syncing here (name is saddle-finance because of reusing eth deployments): https://okgraph.xyz/?q=Qmd13EkC2ksj4ETcnSpJfncorf4ynfwyK7UUTkHrxiL4hY