### PR TITLE
fix(#patch); dForce; reward array mismatch

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1373,7 +1373,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.4",
+          "subgraph": "1.2.5",
           "methodology": "1.0.0"
         },
         "files": {
@@ -1395,7 +1395,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.3",
+          "subgraph": "1.2.5",
           "methodology": "1.0.0"
         },
         "files": {
@@ -1417,7 +1417,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.3",
+          "subgraph": "1.2.5",
           "methodology": "1.0.0"
         },
         "files": {
@@ -1439,7 +1439,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.3",
+          "subgraph": "1.2.5",
           "methodology": "1.0.0"
         },
         "files": {
@@ -1465,7 +1465,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.3",
+          "subgraph": "1.2.5",
           "methodology": "1.0.0"
         },
         "files": {
@@ -1487,7 +1487,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.3",
+          "subgraph": "1.2.5",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/compound-forks/abis/dforce/Comptroller.json
+++ b/subgraphs/compound-forks/abis/dforce/Comptroller.json
@@ -357,7 +357,7 @@
       {
         "indexed": false,
         "internalType": "address",
-        "name": "_newRewardDistributor",
+        "name": "newRewardDistributor",
         "type": "address"
       }
     ],

--- a/subgraphs/compound-forks/abis/dforce/RewardDistributor.json
+++ b/subgraphs/compound-forks/abis/dforce/RewardDistributor.json
@@ -13,6 +13,19 @@
         "internalType": "uint256",
         "name": "borrowSpeed",
         "type": "uint256"
+      }
+    ],
+    "name": "DistributionBorrowSpeedUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "iToken",
+        "type": "address"
       },
       {
         "indexed": false,
@@ -21,7 +34,7 @@
         "type": "uint256"
       }
     ],
-    "name": "DistributionSpeedsUpdated",
+    "name": "DistributionSupplySpeedUpdated",
     "type": "event"
   },
   {
@@ -197,11 +210,7 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "_iToken",
-        "type": "address"
-      },
+      { "internalType": "address", "name": "_iToken", "type": "address" },
       {
         "internalType": "uint256",
         "name": "_distributionFactor",
@@ -222,18 +231,14 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "_iTokens",
-        "type": "address[]"
-      },
+      { "internalType": "address[]", "name": "_iTokens", "type": "address[]" },
       {
         "internalType": "uint256[]",
-        "name": "_distributionFactors",
+        "name": "_borrowSpeeds",
         "type": "uint256[]"
       }
     ],
-    "name": "_setDistributionFactors",
+    "name": "_setDistributionBorrowSpeeds",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -241,17 +246,41 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "_borrowSpeed",
-        "type": "uint256"
+        "internalType": "address[]",
+        "name": "_borrowiTokens",
+        "type": "address[]"
       },
       {
-        "internalType": "uint256",
-        "name": "_supplySpeed",
-        "type": "uint256"
+        "internalType": "uint256[]",
+        "name": "_borrowSpeeds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_supplyiTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_supplySpeeds",
+        "type": "uint256[]"
       }
     ],
-    "name": "_setGlobalDistributionSpeeds",
+    "name": "_setDistributionSpeeds",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address[]", "name": "_iTokens", "type": "address[]" },
+      {
+        "internalType": "uint256[]",
+        "name": "_supplySpeeds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "_setDistributionSupplySpeeds",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -285,14 +314,24 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "_borrowSpeed",
-        "type": "uint256"
+        "internalType": "address[]",
+        "name": "_borrowiTokens",
+        "type": "address[]"
       },
       {
-        "internalType": "uint256",
-        "name": "_supplySpeed",
-        "type": "uint256"
+        "internalType": "uint256[]",
+        "name": "_borrowSpeeds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_supplyiTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_supplySpeeds",
+        "type": "uint256[]"
       }
     ],
     "name": "_unpause",
@@ -302,11 +341,7 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "_holders",
-        "type": "address[]"
-      }
+      { "internalType": "address[]", "name": "_holders", "type": "address[]" }
     ],
     "name": "claimAllReward",
     "outputs": [],
@@ -315,18 +350,29 @@
   },
   {
     "inputs": [
+      { "internalType": "address[]", "name": "_holders", "type": "address[]" },
+      { "internalType": "address[]", "name": "_iTokens", "type": "address[]" }
+    ],
+    "name": "claimReward",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address[]", "name": "_holders", "type": "address[]" },
       {
         "internalType": "address[]",
-        "name": "_holders",
+        "name": "_suppliediTokens",
         "type": "address[]"
       },
       {
         "internalType": "address[]",
-        "name": "_iTokens",
+        "name": "_borrowediTokens",
         "type": "address[]"
       }
     ],
-    "name": "claimReward",
+    "name": "claimRewards",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -335,164 +381,68 @@
     "inputs": [],
     "name": "controller",
     "outputs": [
-      {
-        "internalType": "contract Controller",
-        "name": "",
-        "type": "address"
-      }
+      { "internalType": "contract Controller", "name": "", "type": "address" }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "name": "distributionBorrowState",
     "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "index",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "block",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "index", "type": "uint256" },
+      { "internalType": "uint256", "name": "block", "type": "uint256" }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
     ],
     "name": "distributionBorrowerIndex",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "name": "distributionFactorMantissa",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "name": "distributionSpeed",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
     ],
     "name": "distributionSupplierIndex",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "name": "distributionSupplySpeed",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "name": "distributionSupplyState",
     "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "index",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "block",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "index", "type": "uint256" },
+      { "internalType": "uint256", "name": "block", "type": "uint256" }
     ],
     "stateMutability": "view",
     "type": "function"
@@ -500,26 +450,14 @@
   {
     "inputs": [],
     "name": "globalDistributionSpeed",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "globalDistributionSupplySpeed",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
@@ -540,11 +478,7 @@
     "inputs": [],
     "name": "owner",
     "outputs": [
-      {
-        "internalType": "address payable",
-        "name": "",
-        "type": "address"
-      }
+      { "internalType": "address payable", "name": "", "type": "address" }
     ],
     "stateMutability": "view",
     "type": "function"
@@ -552,13 +486,7 @@
   {
     "inputs": [],
     "name": "paused",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
     "stateMutability": "view",
     "type": "function"
   },
@@ -566,66 +494,29 @@
     "inputs": [],
     "name": "pendingOwner",
     "outputs": [
-      {
-        "internalType": "address payable",
-        "name": "",
-        "type": "address"
-      }
+      { "internalType": "address payable", "name": "", "type": "address" }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "name": "reward",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "rewardToken",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "updateDistributionSpeed",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "_iToken",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_isBorrow",
-        "type": "bool"
-      }
+      { "internalType": "address", "name": "_iToken", "type": "address" },
+      { "internalType": "bool", "name": "_isBorrow", "type": "bool" }
     ],
     "name": "updateDistributionState",
     "outputs": [],
@@ -634,21 +525,9 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "_iToken",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_account",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_isBorrow",
-        "type": "bool"
-      }
+      { "internalType": "address", "name": "_iToken", "type": "address" },
+      { "internalType": "address", "name": "_account", "type": "address" },
+      { "internalType": "bool", "name": "_isBorrow", "type": "bool" }
     ],
     "name": "updateReward",
     "outputs": [],
@@ -657,16 +536,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "_holders",
-        "type": "address[]"
-      },
-      {
-        "internalType": "address[]",
-        "name": "_iTokens",
-        "type": "address[]"
-      }
+      { "internalType": "address[]", "name": "_holders", "type": "address[]" },
+      { "internalType": "address[]", "name": "_iTokens", "type": "address[]" }
     ],
     "name": "updateRewardBatch",
     "outputs": [],

--- a/subgraphs/compound-forks/protocols/bastion-protocol/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/bastion-protocol/src/mapping.ts
@@ -335,7 +335,6 @@ function getOrCreateProtocol(): LendingProtocol {
 //
 //
 // Update the rewards arrays in a given market
-// can be done for supply / borrow side triggered by Supply/BorrowSpeedUpdate events
 function updateRewards(marketAddress: Address, blockNumber: BigInt): void {
   const market = Market.load(marketAddress.toHexString());
   if (!market) {

--- a/subgraphs/compound-forks/protocols/dforce/README.md
+++ b/subgraphs/compound-forks/protocols/dforce/README.md
@@ -59,7 +59,7 @@ Not applicable.
 
 ## Notes
 
-- Avalanche is not supported on their frontend. We will keep the config for now, but it is not actively being used as far as we know.
+- Avalanche and Fantom is not supported on their frontend. We will keep the config for now, but it is not actively being used as far as we know.
 
 ## Smart Contracts Interactions
 

--- a/subgraphs/compound-forks/protocols/dforce/config/templates/dforce.template.yaml
+++ b/subgraphs/compound-forks/protocols/dforce/config/templates/dforce.template.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.2
+specVersion: 0.0.4
 schema:
   file: ./schema.graphql
 dataSources:
@@ -50,7 +50,6 @@ dataSources:
         - event: NewRewardDistributor(address,address)
           handler: handleNewRewardDistributor
       file: ./protocols/dforce/src/mapping.ts
-
   - kind: ethereum/contract
     name: USX
     network: {{ network }}
@@ -98,7 +97,6 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleStablecoinTransfer
       file: ./protocols/dforce/src/mapping.ts
-
 templates:
   - name: CToken
     kind: ethereum/contract
@@ -122,6 +120,8 @@ templates:
           file: ./abis/dforce/Comptroller.json
         - name: PriceOracle
           file: ./abis/dforce/PriceOracle.json
+        - name: RewardDistributor
+          file: ./abis/dforce/RewardDistributor.json
       eventHandlers:
         - event: Mint(address,address,uint256,uint256)
           handler: handleMint
@@ -142,9 +142,8 @@ templates:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
       file: ./protocols/dforce/src/mapping.ts
-
   - kind: ethereum/contract
-    name: Reward
+    name: RewardDistributor
     network: {{ network }}
     source:
       abi: RewardDistributor
@@ -166,8 +165,8 @@ templates:
         - name: RewardDistributor
           file: ./abis/dforce/RewardDistributor.json
       eventHandlers:
-        - event: RewardDistributed(address,address,uint256,uint256)
-          handler: handleRewardDistributed
-        - event: NewRewardToken(address,address)
-          handler: handleNewRewardToken
+        - event: DistributionBorrowSpeedUpdated(address,uint256)
+          handler: handleDistributionBorrowSpeedUpdated
+        - event: DistributionSupplySpeedUpdated(address,uint256)
+          handler: handleDistributionSupplySpeedUpdated
       file: ./protocols/dforce/src/mapping.ts

--- a/subgraphs/compound-forks/protocols/dforce/src/constants.ts
+++ b/subgraphs/compound-forks/protocols/dforce/src/constants.ts
@@ -30,24 +30,14 @@ const ARBITRUM_BLOCKS_PER_YEAR = ETHEREUM_BLOCKS_PER_YEAR;
 const ARBITRUM_BLOCKS_PER_DAY = ETHEREUM_BLOCKS_PER_DAY;
 
 export class NetworkSpecificConstant {
-  comptrollerAddr: Address;
-  network: string;
-  blocksPerDay: i32;
-  blocksPerYear: i32;
   constructor(
-    comptrollerAddr: Address,
-    network: string,
-    blocksPerDay: i32,
-    blocksPerYear: i32
-  ) {
-    this.comptrollerAddr = comptrollerAddr;
-    this.network = network;
-    this.blocksPerDay = blocksPerDay;
-    this.blocksPerYear = blocksPerYear;
-  }
+    public readonly comptrollerAddr: Address,
+    public readonly network: string,
+    public readonly blocksPerDay: i32,
+    public readonly blocksPerYear: i32,
+    public readonly rewardTokenAddress: Address
+  ) {}
 }
-const ARBITRUM_ONE = "ARBITRUM-ONE";
-
 export function getNetworkSpecificConstant(): NetworkSpecificConstant {
   const network = dataSource.network();
   if (equalsIgnoreCase(network, Network.MAINNET)) {
@@ -55,56 +45,63 @@ export function getNetworkSpecificConstant(): NetworkSpecificConstant {
       Address.fromString("0x8B53Ab2c0Df3230EA327017C91Eb909f815Ad113"),
       Network.MAINNET,
       ETHEREUM_BLOCKS_PER_DAY,
-      ETHEREUM_BLOCKS_PER_YEAR
+      ETHEREUM_BLOCKS_PER_YEAR,
+      Address.fromString("0x431ad2ff6a9C365805eBaD47Ee021148d6f7DBe0")
     );
   } else if (equalsIgnoreCase(network, Network.BSC)) {
     return new NetworkSpecificConstant(
       Address.fromString("0x0b53E608bD058Bb54748C35148484fD627E6dc0A"),
       Network.BSC,
       BSC_BLOCKS_PER_DAY,
-      BSC_BLOCKS_PER_YEAR
+      BSC_BLOCKS_PER_YEAR,
+      Address.fromString("0x4a9a2b2b04549c3927dd2c9668a5ef3fca473623")
     );
-  } else if (equalsIgnoreCase(network, ARBITRUM_ONE)) {
+  } else if (equalsIgnoreCase(network, Network.ARBITRUM_ONE)) {
     return new NetworkSpecificConstant(
       Address.fromString("0x8E7e9eA9023B81457Ae7E6D2a51b003D421E5408"),
       Network.ARBITRUM_ONE,
       ARBITRUM_BLOCKS_PER_DAY,
-      ARBITRUM_BLOCKS_PER_YEAR
+      ARBITRUM_BLOCKS_PER_YEAR,
+      Address.fromString("0xae6aab43c4f3e0cea4ab83752c278f8debaba689")
     );
   } else if (equalsIgnoreCase(network, Network.OPTIMISM)) {
     return new NetworkSpecificConstant(
       Address.fromString("0xA300A84D8970718Dac32f54F61Bd568142d8BCF4"),
       Network.OPTIMISM,
       OPTIMISM_BLOCKS_PER_DAY,
-      OPTIMISM_BLOCKS_PER_YEAR
+      OPTIMISM_BLOCKS_PER_YEAR,
+      Address.fromString("0x9e5aac1ba1a2e6aed6b32689dfcf62a509ca96f3")
     );
   } else if (equalsIgnoreCase(network, Network.MATIC)) {
     return new NetworkSpecificConstant(
       Address.fromString("0x52eacd19e38d501d006d2023c813d7e37f025f37"),
       Network.MATIC,
       MATIC_BLOCKS_PER_DAY,
-      MATIC_BLOCKS_PER_YEAR
+      MATIC_BLOCKS_PER_YEAR,
+      Address.fromString("0x08c15fa26e519a78a666d19ce5c646d55047e0a3")
     );
   } else if (equalsIgnoreCase(network, Network.AVALANCHE)) {
     return new NetworkSpecificConstant(
       Address.fromString("0x75b9a7b6f55754d4d0e952da4bdb55eaea7df38e"),
       Network.AVALANCHE,
       AVALANCHE_BLOCKS_PER_DAY,
-      AVALANCHE_BLOCKS_PER_YEAR
-    );
-  } else {
-    log.error("[getNetworkSpecificConstant] Unsupported network {}", [network]);
-    return new NetworkSpecificConstant(
-      Address.fromString("0x0000000000000000000000000000000000000000"),
-      "",
-      0,
-      0
+      AVALANCHE_BLOCKS_PER_YEAR,
+      Address.fromString(ZERO_ADDRESS)
     );
   }
+
+  log.error("[getNetworkSpecificConstant] Unsupported network {}", [network]);
+  return new NetworkSpecificConstant(
+    Address.fromString(ZERO_ADDRESS),
+    "",
+    0,
+    0,
+    Address.fromString(ZERO_ADDRESS)
+  );
 }
 
 function equalsIgnoreCase(a: string, b: string): boolean {
-  return a.toLowerCase() == b.toLowerCase();
+  return a.toLowerCase().replace("-", "_") == b.toLowerCase().replace("-", "_");
 }
 
 // whether any element of the input array is true
@@ -140,8 +137,9 @@ export function BigDecimalTruncateToBigInt(x: BigDecimal): BigInt {
 }
 
 export const iETH_ADDRESS = "0x5acd75f21659a59ffab9aebaf350351a8bfaabc0";
-export const DF_ADDRESS = "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0";
+export const DF_ADDRESS = Address.fromString(
+  "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0"
+);
 export const MKR_ADDRESS = "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2";
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-export const PRICE_BASE = 18;
-export const DISTRIBUTIONFACTOR_BASE = 18;
+export const DEFAULT_DECIMALS = 18;

--- a/subgraphs/compound-forks/protocols/dforce/src/constants.ts
+++ b/subgraphs/compound-forks/protocols/dforce/src/constants.ts
@@ -137,9 +137,7 @@ export function BigDecimalTruncateToBigInt(x: BigDecimal): BigInt {
 }
 
 export const iETH_ADDRESS = "0x5acd75f21659a59ffab9aebaf350351a8bfaabc0";
-export const DF_ADDRESS = Address.fromString(
-  "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0"
-);
+export const DF_ADDRESS = "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0";
 export const MKR_ADDRESS = "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2";
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 export const DEFAULT_DECIMALS = 18;

--- a/subgraphs/compound-forks/protocols/dforce/src/mapping.ts
+++ b/subgraphs/compound-forks/protocols/dforce/src/mapping.ts
@@ -46,24 +46,22 @@ import { CToken } from "../../../generated/Comptroller/CToken";
 import { PriceOracle } from "../../../generated/Comptroller/PriceOracle";
 import {
   CToken as CTokenTemplate,
-  Reward as RewardTemplate,
+  RewardDistributor as RewardDistributorTemplate,
 } from "../../../generated/templates";
 import {
   getNetworkSpecificConstant,
   ZERO_ADDRESS,
-  prefixID,
-  BigDecimalTruncateToBigInt,
   anyTrue,
-  PRICE_BASE,
-  DISTRIBUTIONFACTOR_BASE,
   DF_ADDRESS,
   MKR_ADDRESS,
+  DEFAULT_DECIMALS,
+  BigDecimalTruncateToBigInt,
 } from "./constants";
 import {
   RewardDistributor,
-  RewardDistributed,
-  NewRewardToken,
-} from "../../../generated/templates/Reward/RewardDistributor";
+  DistributionBorrowSpeedUpdated,
+  DistributionSupplySpeedUpdated,
+} from "../../../generated/templates/RewardDistributor/RewardDistributor";
 import {
   stablecoin,
   Transfer as StablecoinTransfer,
@@ -99,6 +97,7 @@ const comptrollerAddr = constant.comptrollerAddr;
 const network = constant.network;
 const blocksPerDay = new BigDecimal(BigInt.fromI32(constant.blocksPerDay));
 const blocksPerYear = constant.blocksPerYear;
+const rewardTokenAddr = constant.rewardTokenAddress;
 
 export function handleNewPriceOracle(event: NewPriceOracle): void {
   const protocol = getOrCreateProtocol();
@@ -152,7 +151,7 @@ export function handleMarketAdded(event: MarketAdded): void {
       underlyingName = "Maker";
       underlyingSymbol = "MKR";
       underlyingDecimals = 18;
-    } else if (underlyingTokenAddr.toHexString() == DF_ADDRESS) {
+    } else if (underlyingTokenAddr == DF_ADDRESS) {
       underlyingName = "dForce";
       underlyingSymbol = "DF";
       underlyingDecimals = 18;
@@ -209,6 +208,8 @@ export function handleMarketAdded(event: MarketAdded): void {
     ),
     event
   );
+
+  initRewards(cTokenAddr);
 }
 
 export function handleNewCollateralFactor(event: NewCollateralFactor): void {
@@ -432,162 +433,8 @@ export function handleUpdateInterest(event: AccrueInterest): void {
     network.toLowerCase() == Network.MAINNET.toLowerCase(),
     event
   );
-}
 
-export function handleNewRewardDistributor(event: NewRewardDistributor): void {
-  // trigger RewardDistributor template
-  RewardTemplate.create(event.params._newRewardDistributor);
-}
-
-function _getOrCreateRewardTokens(tokenAddr: string): string[] {
-  // add reward token to Token if not already there
-  let token = Token.load(tokenAddr);
-  if (token == null) {
-    token = new Token(tokenAddr);
-    // speciall handle for DF token since its name and symbol is byte32
-    if (tokenAddr == DF_ADDRESS) {
-      token.name = "dForce";
-      token.symbol = "DF";
-      token.decimals = 18;
-    } else {
-      const tokenContract = ERC20.bind(Address.fromString(tokenAddr));
-      token.name = getOrElse<string>(tokenContract.try_name(), "unknown");
-      token.symbol = getOrElse<string>(tokenContract.try_symbol(), "unknown");
-      token.decimals = getOrElse<i32>(tokenContract.try_decimals(), 18);
-    }
-    token.save();
-  }
-
-  const borrowRewardTokenId = prefixID(tokenAddr, RewardTokenType.BORROW);
-  let borrowRewardToken = RewardToken.load(borrowRewardTokenId);
-  if (borrowRewardToken == null) {
-    borrowRewardToken = new RewardToken(borrowRewardTokenId);
-    borrowRewardToken.token = tokenAddr;
-    borrowRewardToken.type = RewardTokenType.BORROW;
-    borrowRewardToken.save();
-  }
-
-  const depositRewardTokenId = prefixID(tokenAddr, RewardTokenType.DEPOSIT);
-  let depositRewardToken = RewardToken.load(depositRewardTokenId);
-  if (depositRewardToken == null) {
-    depositRewardToken = new RewardToken(depositRewardTokenId);
-    depositRewardToken.token = tokenAddr;
-    depositRewardToken.type = RewardTokenType.DEPOSIT;
-    depositRewardToken.save();
-  }
-
-  return [borrowRewardTokenId, depositRewardTokenId];
-}
-
-export function handleNewRewardToken(event: NewRewardToken): void {
-  // Add new reward token to the rewardToken entity
-  const tokenAddr = event.params.newRewardToken.toHexString();
-
-  const rewardTokenIds = _getOrCreateRewardTokens(tokenAddr);
-
-  const protocol = getOrCreateProtocol();
-  const markets = protocol._marketIDs;
-  for (let i = 0; i < markets.length; i++) {
-    const marketID = markets[i];
-    const market = Market.load(marketID);
-    if (market == null) {
-      log.warning("[handleNewRewardToken] Market not found: {}", [marketID]);
-      return;
-    }
-    market.rewardTokens = [rewardTokenIds[0], rewardTokenIds[1]];
-    market.save();
-  }
-}
-
-export function handleRewardDistributed(event: RewardDistributed): void {
-  // RewardDistributed event in dforce is emitted when rewards is distributed
-  // to individual account (borrower/depositor)
-  // Since there is no event for market level/protocol level reward emission
-  // we have to do the calculation by ourselves following the logic in
-  // function _updateDistributionState in RewardDistributor.sol
-  // It'd be more efficient to handle the DistributionSpeedsUpdated event
-  // instead, but it was never emitted for some reason
-  const distributorContract = RewardDistributor.bind(event.address);
-
-  const marketID = event.params.iToken.toHexString();
-  const market = Market.load(marketID);
-  if (market == null) {
-    log.warning("[handleRewardDistributed] Market not found: {}", [marketID]);
-    return;
-  }
-
-  const rewardTokens = market.rewardTokens;
-  if (rewardTokens == null || rewardTokens.length == 0) {
-    const rewardTokenAddr = distributorContract.rewardToken().toHexString();
-    market.rewardTokens = _getOrCreateRewardTokens(rewardTokenAddr);
-    market.save();
-  }
-
-  const rewardTokenId = RewardToken.load(market.rewardTokens![0])!.token;
-  const rewardToken = Token.load(rewardTokenId);
-  if (rewardToken == null) {
-    log.warning("[handleRewardDistributed] Token not found: {}", [
-      rewardTokenId,
-    ]);
-    return;
-  }
-
-  const decimals = rewardToken.decimals;
-  let rewardTokenPrice = rewardToken.lastPriceUSD;
-  if (!rewardTokenPrice) {
-    const protocol = getOrCreateProtocol();
-    const oracleContract = PriceOracle.bind(
-      Address.fromString(protocol._priceOracle)
-    );
-    rewardTokenPrice = oracleContract
-      .getAssetPrice(Address.fromString(rewardTokenId))
-      .toBigDecimal()
-      .div(exponentToBigDecimal(PRICE_BASE));
-  }
-
-  // initialized rewardTokenEmissionsAmount and rewardTokenEmissionsUSD
-  let rewardTokenEmissionsAmount = market.rewardTokenEmissionsAmount;
-  rewardTokenEmissionsAmount =
-    rewardTokenEmissionsAmount != null
-      ? rewardTokenEmissionsAmount
-      : [BIGINT_ZERO, BIGINT_ZERO];
-  let rewardTokenEmissionsUSD = market.rewardTokenEmissionsUSD;
-  rewardTokenEmissionsUSD =
-    rewardTokenEmissionsUSD != null
-      ? rewardTokenEmissionsUSD
-      : [BIGDECIMAL_ZERO, BIGDECIMAL_ZERO];
-
-  const marketAddr = Address.fromString(marketID);
-  const distributionFactor = distributorContract
-    .distributionFactorMantissa(marketAddr)
-    .toBigDecimal()
-    .div(exponentToBigDecimal(DISTRIBUTIONFACTOR_BASE));
-
-  // rewards is only affected by speed and deltaBlocks
-  const emissionSpeedBorrow = getOrElse<BigInt>(
-    distributorContract.try_distributionSpeed(marketAddr),
-    BIGINT_ZERO
-  );
-  const emissionSpeedSupply = getOrElse<BigInt>(
-    distributorContract.try_distributionSupplySpeed(marketAddr),
-    BIGINT_ZERO
-  );
-  const emissionBorrow = emissionSpeedBorrow.toBigDecimal().times(blocksPerDay);
-  rewardTokenEmissionsAmount[0] = BigDecimalTruncateToBigInt(emissionBorrow);
-  rewardTokenEmissionsUSD[0] = emissionBorrow
-    .div(exponentToBigDecimal(decimals))
-    .times(distributionFactor)
-    .times(rewardTokenPrice);
-  const emissionSupply = emissionSpeedSupply.toBigDecimal().times(blocksPerDay);
-  rewardTokenEmissionsAmount[1] = BigDecimalTruncateToBigInt(emissionSupply);
-  rewardTokenEmissionsUSD[1] = emissionSupply
-    .div(exponentToBigDecimal(decimals))
-    .times(distributionFactor)
-    .times(rewardTokenPrice);
-
-  market.rewardTokenEmissionsAmount = rewardTokenEmissionsAmount;
-  market.rewardTokenEmissionsUSD = rewardTokenEmissionsUSD;
-  market.save();
+  updateRewardPrices(marketAddress);
 }
 
 // update USX/EUX supply for
@@ -703,4 +550,167 @@ export function getOrCreateMarketStatus(marketId: string): _DforceMarketStatus {
     marketStatus.save();
   }
   return marketStatus;
+}
+
+////////////////////////////
+///// Reward Functions /////
+////////////////////////////
+
+export function handleNewRewardDistributor(event: NewRewardDistributor): void {
+  // trigger RewardDistributor template
+  RewardDistributorTemplate.create(event.params.newRewardDistributor);
+}
+
+export function handleDistributionBorrowSpeedUpdated(
+  event: DistributionBorrowSpeedUpdated
+): void {
+  const market = Market.load(event.params.iToken.toHexString());
+  if (!market) {
+    log.error("Market not found for address {}", [
+      event.params.iToken.toHexString(),
+    ]);
+    return;
+  }
+
+  const emissionsAmount = market.rewardTokenEmissionsAmount!;
+  emissionsAmount[0] = BigDecimalTruncateToBigInt(
+    event.params.borrowSpeed.toBigDecimal().times(blocksPerDay)
+  );
+  market.rewardTokenEmissionsAmount = emissionsAmount;
+  market.save();
+
+  updateRewardPrices(event.params.iToken);
+}
+
+export function handleDistributionSupplySpeedUpdated(
+  event: DistributionSupplySpeedUpdated
+): void {
+  const market = Market.load(event.params.iToken.toHexString());
+  if (!market) {
+    log.error("Market not found for address {}", [
+      event.params.iToken.toHexString(),
+    ]);
+    return;
+  }
+  const emissionsAmount = market.rewardTokenEmissionsAmount!;
+  emissionsAmount[1] = BigDecimalTruncateToBigInt(
+    event.params.supplySpeed.toBigDecimal().times(blocksPerDay)
+  );
+  market.rewardTokenEmissionsAmount = emissionsAmount;
+  market.save();
+
+  updateRewardPrices(event.params.iToken);
+}
+
+function initRewards(marketAddr: Address): void {
+  const market = Market.load(marketAddr.toHexString());
+  if (!market) {
+    log.error("Market not found for address {}", [marketAddr.toHexString()]);
+    return;
+  }
+
+  market.rewardTokens = getOrCreateRewardTokens();
+  market.rewardTokenEmissionsAmount = [BIGINT_ZERO, BIGINT_ZERO];
+  market.rewardTokenEmissionsUSD = [BIGDECIMAL_ZERO, BIGDECIMAL_ZERO];
+  market.save();
+}
+
+// initially create reward tokens
+// reward is always DForce token
+function getOrCreateRewardTokens(): string[] {
+  let token = Token.load(rewardTokenAddr.toHexString());
+  if (token == null) {
+    token = new Token(rewardTokenAddr.toHexString());
+    // special handle for DF token since its name and symbol is byte32
+    if (rewardTokenAddr == DF_ADDRESS) {
+      token.name = "dForce";
+      token.symbol = "DF";
+      token.decimals = 18;
+    } else {
+      const tokenContract = ERC20.bind(rewardTokenAddr);
+      token.name = getOrElse<string>(tokenContract.try_name(), "unknown");
+      token.symbol = getOrElse<string>(tokenContract.try_symbol(), "unknown");
+      token.decimals = getOrElse<i32>(tokenContract.try_decimals(), 18);
+    }
+    token.save();
+  }
+
+  const borrowRewardTokenId = RewardTokenType.BORROW.concat("-").concat(
+    token.id
+  );
+  let borrowRewardToken = RewardToken.load(borrowRewardTokenId);
+  if (borrowRewardToken == null) {
+    borrowRewardToken = new RewardToken(borrowRewardTokenId);
+    borrowRewardToken.token = token.id;
+    borrowRewardToken.type = RewardTokenType.BORROW;
+    borrowRewardToken.save();
+  }
+
+  const depositRewardTokenId = RewardTokenType.DEPOSIT.concat("-").concat(
+    token.id
+  );
+  let depositRewardToken = RewardToken.load(depositRewardTokenId);
+  if (depositRewardToken == null) {
+    depositRewardToken = new RewardToken(depositRewardTokenId);
+    depositRewardToken.token = token.id;
+    depositRewardToken.type = RewardTokenType.DEPOSIT;
+    depositRewardToken.save();
+  }
+
+  return [borrowRewardTokenId, depositRewardTokenId];
+}
+
+function updateRewardPrices(marketAddress: Address): void {
+  const market = Market.load(marketAddress.toHexString());
+  if (!market) {
+    log.error("Market not found for address {}", [marketAddress.toHexString()]);
+    return;
+  }
+  const rewardToken = RewardToken.load(market.rewardTokens![0]);
+  if (!rewardToken) {
+    log.error("Reward token not found for market", [market.id]);
+    return;
+  }
+
+  const comptroller = Comptroller.bind(comptrollerAddr);
+  const tryRewardDistributor = comptroller.try_rewardDistributor();
+  if (tryRewardDistributor.reverted) {
+    log.info("Reward distributor not found", []);
+    return;
+  }
+  const distributorContract = RewardDistributor.bind(
+    tryRewardDistributor.value
+  );
+  const tryDistributionFactor =
+    distributorContract.try_distributionFactorMantissa(marketAddress);
+  const distributionFactor = tryDistributionFactor.reverted
+    ? BIGDECIMAL_ZERO
+    : tryDistributionFactor.value
+        .toBigDecimal()
+        .div(exponentToBigDecimal(DEFAULT_DECIMALS));
+  const protocol = getOrCreateProtocol();
+  const oracleContract = PriceOracle.bind(
+    Address.fromString(protocol._priceOracle)
+  );
+  const priceRaw = getOrElse(
+    oracleContract.try_getAssetPrice(Address.fromString(rewardToken.token)),
+    BIGINT_ZERO
+  );
+  const priceUSD = priceRaw
+    .toBigDecimal()
+    .div(exponentToBigDecimal(DEFAULT_DECIMALS));
+
+  market.rewardTokenEmissionsUSD = [
+    market
+      .rewardTokenEmissionsAmount![0].toBigDecimal()
+      .div(exponentToBigDecimal(DEFAULT_DECIMALS))
+      .times(distributionFactor)
+      .times(priceUSD),
+    market
+      .rewardTokenEmissionsAmount![1].toBigDecimal()
+      .div(exponentToBigDecimal(DEFAULT_DECIMALS))
+      .times(distributionFactor)
+      .times(priceUSD),
+  ];
+  market.save();
 }


### PR DESCRIPTION
Reward arrays could be mismatched and were. We cannot allow this so this was updated.

Also refactored rewards to be more readable and update emissions with events.

Testing:
- arb: https://okgraph.xyz/?q=dmelotik%2Fdforce-arbitrum
- bsc: https://okgraph.xyz/?q=dmelotik%2Fdforce-bsc
- eth: https://okgraph.xyz/?q=dmelotik%2Fdforce-ethereum
- optimism: https://okgraph.xyz/?q=dmelotik%2Fdforce-optimism
- polygon: https://okgraph.xyz/?q=dmelotik%2Fdforce-polygon