### PR TITLE
fix(#patch): alpaca-finance-lending; add markets field into LendingProtocol schema

### DIFF
--- a/subgraphs/alpaca-finance-lending/schema.graphql
+++ b/subgraphs/alpaca-finance-lending/schema.graphql
@@ -318,6 +318,11 @@ type LendingProtocol implements Protocol @entity {
 
   " Daily financial metrics for this protocol "
   financialMetrics: [FinancialsDailySnapshot!]! @derivedFrom(field: "protocol")
+
+  ##### Markets #####
+
+  " All markets that belong to this protocol "
+  markets: [Market!]! @derivedFrom(field: "protocol")
 }
 
 ###############################


### PR DESCRIPTION
Add markets field into LendingProtocol schema to fix subgraph bot monitor error at  https://discord.com/channels/953684103012683796/1027699754437726321/1046985971071205427