### PR TITLE
fix(#patch); makerdao; fixed a bug when liquidationPenalty is set to 0

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2850,7 +2850,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "2.0.0",
+          "subgraph": "2.0.1",
           "methodology": "1.1.0"
         },
         "files": {

--- a/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
+++ b/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
@@ -1,5 +1,5 @@
 {
   "graftEnabled": true,
-  "subgraphId": "QmTguv4qxrEnpT1e8aCbzaTVrLgeJvhq37Z5bp1pz9qny5",
-  "graftStartBlock": 8928152
+  "subgraphId": "Qmb5N7F76ARWsfRVrR7iT96v5aCcLYRcNyBXxkKP4t1iYy",
+  "graftStartBlock": 16126312
 }

--- a/subgraphs/makerdao/src/mapping.ts
+++ b/subgraphs/makerdao/src/mapping.ts
@@ -416,7 +416,7 @@ export function handleCatFile(event: CatNoteEvent): void {
       log.warning("[handleFileDog]Failed to get Market for ilk {}/{}", [ilk.toString(), ilk.toHexString()]);
       return;
     }
-    const liquidationPenalty = bigIntToBDUseDecimals(chop, RAY).minus(BIGDECIMAL_ONE).times(BIGDECIMAL_ONE_HUNDRED);
+    const liquidationPenalty = bigIntToBDUseDecimals(chop, WAD).minus(BIGDECIMAL_ONE).times(BIGDECIMAL_ONE_HUNDRED);
     if (liquidationPenalty.gt(BIGDECIMAL_ZERO)) {
       market.liquidationPenalty = liquidationPenalty;
       market.save();
@@ -499,15 +499,16 @@ export function handleDogFile(event: DogFileChopEvent): void {
       return;
     }
     const chop = event.params.data;
-    const liquidationPenalty = bigIntToBDUseDecimals(chop, RAY).minus(BIGDECIMAL_ONE).times(BIGDECIMAL_ONE_HUNDRED);
+    const liquidationPenalty = bigIntToBDUseDecimals(chop, WAD).minus(BIGDECIMAL_ONE).times(BIGDECIMAL_ONE_HUNDRED);
     if (liquidationPenalty.ge(BIGDECIMAL_ZERO)) {
       market.liquidationPenalty = liquidationPenalty;
       market.save();
     }
 
-    log.info("[handleCatFile]ilk={}, chop={}, liquidationPenalty={}", [
+    log.info("[handleDogFile]ilk={}, chop={}, liquidationPenalty={}, market.liquidationPenalty={}", [
       ilk.toString(),
       chop.toString(),
+      liquidationPenalty.toString(),
       market.liquidationPenalty.toString(),
     ]);
   }

--- a/subgraphs/makerdao/src/mapping.ts
+++ b/subgraphs/makerdao/src/mapping.ts
@@ -500,7 +500,7 @@ export function handleDogFile(event: DogFileChopEvent): void {
     }
     const chop = event.params.data;
     const liquidationPenalty = bigIntToBDUseDecimals(chop, RAY).minus(BIGDECIMAL_ONE).times(BIGDECIMAL_ONE_HUNDRED);
-    if (liquidationPenalty.gt(BIGDECIMAL_ZERO)) {
+    if (liquidationPenalty.ge(BIGDECIMAL_ZERO)) {
       market.liquidationPenalty = liquidationPenalty;
       market.save();
     }


### PR DESCRIPTION
This fixes the unreasonable protocol side revenue for USDC-A liquidation reported by @bye43  in #1502

- Test deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/makerdao-ethereum?version=pending&selected=logs
- validation dashboard: https://api.thegraph.com/subgraphs/name/tnkrxyz/makerdao-ethereum/graphql?query=%7B%0A++marketDailySnapshots+%28orderBy%3A+dailyLiquidateUSD%2C+orderDirection%3Adesc%2C+where%3A+%7Btimestamp_gte%3A+1670284800%2C+timestamp_lte%3A+1670371199%7D%29+%7B%0A++++timestamp%0A++++market+%7B%0A++++++name%0A++++++id%0A++++%7D%0A++++dailyLiquidateUSD+%0A++++dailyProtocolSideRevenueUSD%0A++%7D++%0A%7D
