### PR TITLE
feat (#patch); goldfinch; added membership rewards

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2217,8 +2217,8 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.1",
-          "methodology": "1.0.0"
+          "subgraph": "1.1.2",
+          "methodology": "1.0.1"
         },
         "files": {
           "template": "goldfinch.template.yaml"

--- a/subgraphs/goldfinch/protocols/goldfinch/config/templates/goldfinch.template.yaml
+++ b/subgraphs/goldfinch/protocols/goldfinch/config/templates/goldfinch.template.yaml
@@ -440,8 +440,10 @@ dataSources:
       eventHandlers:
         - event: CapitalERC721Deposit(indexed address,indexed address,uint256,uint256,uint256)
           handler: handleCapitalErc721Deposit
+          receipt: true
         - event: CapitalERC721Withdrawal(indexed address,uint256,address,uint256)
           handler: handleCapitalErc721Withdrawal
+          receipt: true
       file: ./src/mappings/membership/capital_ledger.ts
 
   - kind: ethereum/contract

--- a/subgraphs/goldfinch/protocols/goldfinch/config/templates/goldfinch.template.yaml
+++ b/subgraphs/goldfinch/protocols/goldfinch/config/templates/goldfinch.template.yaml
@@ -393,6 +393,8 @@ dataSources:
       abis:
         - name: MembershipCollector
           file: ./abis/MembershipCollector.json
+        - name: MembershipVault
+          file: ./abis/MembershipVault.json
       eventHandlers:
         - event: EpochFinalized(indexed uint256,uint256)
           handler: handleEpochFinalized

--- a/subgraphs/goldfinch/schema.graphql
+++ b/subgraphs/goldfinch/schema.graphql
@@ -1351,7 +1351,6 @@ type SeniorPoolStatus @entity {
   """
   id: ID!
   rawBalance: BigInt!
-  compoundBalance: BigInt!
   balance: BigInt!
   """
   The actual amount of USDC associated with the Senior Pool contract, can also be thought of as the Senior Pool's liquidity in USDC

--- a/subgraphs/goldfinch/schema.graphql
+++ b/subgraphs/goldfinch/schema.graphql
@@ -669,11 +669,8 @@ type Market @entity {
   " senior pool interest received from Compound "
   _interestFromCompound: BigDecimal
 
-  " cumulative Reward Emission Amount "
-  _cumulativeRewardAmount: BigInt
-
-  " timestamp when reward emission started "
-  _rewardTimestamp: BigInt
+  " senior pool interest received from tranched pools "
+  _interestFromTranchedPool: BigDecimal
 
   " Is the market a migrated tranched pool "
   _isMigratedTranchedPool: Boolean

--- a/subgraphs/goldfinch/schema.graphql
+++ b/subgraphs/goldfinch/schema.graphql
@@ -666,6 +666,9 @@ type Market @entity {
   " timestamp when for interest accrual (used for interest rates calculation) "
   _interestTimestamp: BigInt
 
+  " senior pool interest received from Compound "
+  _interestFromCompound: BigDecimal
+
   " cumulative Reward Emission Amount "
   _cumulativeRewardAmount: BigInt
 

--- a/subgraphs/goldfinch/schema.graphql
+++ b/subgraphs/goldfinch/schema.graphql
@@ -1278,7 +1278,7 @@ type _PositionCounter @entity {
   nextCount: Int!
 }
 
-type _Membership @entity {
+type _MembershipDirector @entity {
   " owner address "
   id: ID!
   " MembershipScore returned from MembershipDirector.calculateMembershipScore "

--- a/subgraphs/goldfinch/schema.graphql
+++ b/subgraphs/goldfinch/schema.graphql
@@ -674,6 +674,12 @@ type Market @entity {
 
   " Is the market a migrated tranched pool "
   _isMigratedTranchedPool: Boolean
+
+  " eligibleAmount aggregated to the market "
+  _membershipRewardEligibleAmount: BigInt
+
+  " nextEpochAmount aggregated to the market "
+  _membershipRewardNextEpochAmount: BigInt
 }
 
 #################################
@@ -1270,6 +1276,42 @@ type _PositionCounter @entity {
   id: ID!
   " Next count "
   nextCount: Int!
+}
+
+type _Membership @entity {
+  " owner address "
+  id: ID!
+  " MembershipScore returned from MembershipDirector.calculateMembershipScore "
+  eligibleAmount: BigInt!
+  " MembershipScore for next epoch "
+  nextEpochAmount: BigInt!
+  " total staked USDC Equivalent by the owner "
+  totalCapitalStaked: BigInt!
+}
+
+type _MembershipCapitalStaked @entity {
+  " {owner address}-{market id} "
+  id: ID!
+  " market id (pool address) "
+  market: Market!
+  " total staked USDC Equivalent for the position "
+  CapitalStakedAmount: BigInt!
+}
+
+# Helper entity to avoid count staking transaction more than once
+type _MembershipStakingTx @entity {
+  " {tx hash}-{logIndex} "
+  id: ID!
+}
+
+# Helper entity to avoid count staking transaction more than once
+type _MembershipStakingPosition @entity {
+  " Position ID "
+  id: ID!
+  " market id (pool address) "
+  market: Market!
+  " usdcEquivalent of position "
+  usdcEquivalent: BigInt!
 }
 
 ### Entity below are from goldfinch's official subgraph ###

--- a/subgraphs/goldfinch/schema.graphql
+++ b/subgraphs/goldfinch/schema.graphql
@@ -663,14 +663,14 @@ type Market @entity {
   " Address of borrower (tranchedPool has one borrower per pool) "
   _borrower: String
 
-  " timestamp when for interest accrual (used for interest rates calculation) "
+  " timestamp when interest rates were last updated "
   _interestTimestamp: BigInt
 
-  " senior pool interest received from Compound "
-  _interestFromCompound: BigDecimal
+  " interest paid by borrowers, including reserve fee if applicable "
+  _borrowerInterestAmountUSD: BigDecimal
 
-  " senior pool interest received from tranched pools "
-  _interestFromTranchedPool: BigDecimal
+  " interest received by lenders "
+  _lenderInterestAmountUSD: BigDecimal
 
   " Is the market a migrated tranched pool "
   _isMigratedTranchedPool: Boolean

--- a/subgraphs/goldfinch/src/common/constants.ts
+++ b/subgraphs/goldfinch/src/common/constants.ts
@@ -108,6 +108,7 @@ export const DAYS_PER_YEAR = 365;
 export const SECONDS_PER_YEAR = 60 * 60 * 24 * DAYS_PER_YEAR;
 export const SECONDS_PER_DAY = 60 * 60 * 24; // 86400
 export const SECONDS_PER_HOUR = 60 * 60; // 3600
+export const DAYS_PER_EPOCH = 7;
 
 export const ETHEREUM_BLOCKS_PER_YEAR = SECONDS_PER_YEAR / 13; // 13 = seconds per block
 export const AVALANCHE_BLOCKS_PER_YEAR = SECONDS_PER_YEAR / 2; // 2 = seconds per block. This is NOT ideal since avalanche has variable block time.
@@ -172,6 +173,8 @@ export const USDC_ADDRESS = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 export const FIDU_ADDRESS = "0x6a445e9f40e0b97c92d0b8a3366cef1d67f700bf";
 export const GFI_ADDRESS = "0xdab396ccf3d84cf2d07c4454e10c8a6f5b008d2b";
 export const WETH_ADDRESS = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+export const MEMBERSHIP_VAULT_ADDRESS =
+  "0x375b906b25e00bdd43017400cd4cefb36fbf9c18";
 export const STAKING_REWARDS_ADDRESS =
   "0xfd6ff39da508d281c2d255e9bbbfab34b6be60c3";
 export const POOL_TOKENS_ADDRESS = "0x57686612c601cb5213b01aa8e80afeb24bbd01df";

--- a/subgraphs/goldfinch/src/common/getters.ts
+++ b/subgraphs/goldfinch/src/common/getters.ts
@@ -215,6 +215,8 @@ export function getOrCreateMarket(
 
     market._lenderInterestAmountUSD = BIGDECIMAL_ZERO;
     market._borrowerInterestAmountUSD = BIGDECIMAL_ZERO;
+    market._membershipRewardEligibleAmount = BIGINT_ZERO;
+    market._membershipRewardNextEpochAmount = BIGINT_ZERO;
 
     market.save();
 

--- a/subgraphs/goldfinch/src/common/getters.ts
+++ b/subgraphs/goldfinch/src/common/getters.ts
@@ -212,6 +212,10 @@ export function getOrCreateMarket(
 
     market.createdTimestamp = event.block.timestamp;
     market.createdBlockNumber = event.block.number;
+
+    market._lenderInterestAmountUSD = BIGDECIMAL_ZERO;
+    market._borrowerInterestAmountUSD = BIGDECIMAL_ZERO;
+
     market.save();
 
     let marketIDs = protocol._marketIDs!;

--- a/subgraphs/goldfinch/src/common/helpers.ts
+++ b/subgraphs/goldfinch/src/common/helpers.ts
@@ -505,8 +505,8 @@ export function updatePosition(
     account.openPositionCount += INT_ONE;
     market.positionCount += INT_ONE;
     market.openPositionCount += INT_ONE;
-    protocol.cumulativePositionCount += 1;
-    protocol.openPositionCount += 1;
+    protocol.cumulativePositionCount += INT_ONE;
+    protocol.openPositionCount += INT_ONE;
 
     if (transactionType == TransactionType.DEPOSIT) {
       market.lendingPositionCount += INT_ONE;
@@ -522,7 +522,10 @@ export function updatePosition(
     openPosition.blockNumberClosed = event.block.number;
 
     account.closedPositionCount += INT_ONE;
+    account.openPositionCount -= INT_ONE;
     market.closedPositionCount += INT_ONE;
+    market.openPositionCount -= INT_ONE;
+    protocol.openPositionCount -= INT_ONE;
   }
 
   if (transactionType == TransactionType.DEPOSIT) {

--- a/subgraphs/goldfinch/src/common/log.ts
+++ b/subgraphs/goldfinch/src/common/log.ts
@@ -1,0 +1,297 @@
+import {
+  Address,
+  ethereum,
+  BigInt,
+  ByteArray,
+  crypto,
+  log,
+} from "@graphprotocol/graph-ts";
+import {
+  _MembershipStakingPosition,
+  _MembershipStakingTx,
+  _MembershipCapitalStaked,
+  _PoolToken,
+} from "../../generated/schema";
+import {
+  BIGINT_ZERO,
+  POOL_TOKENS_ADDRESS,
+  SENIOR_POOL_ADDRESS,
+  STAKING_REWARDS_ADDRESS,
+} from "./constants";
+
+const AdjustedHoldingsSig = crypto.keccak256(
+  ByteArray.fromUTF8("AdjustedHoldings(address,uint256,uint256)")
+);
+
+export class AdjustedHoldingsLog {
+  owner: Address;
+  eligibleAmount: BigInt;
+  nextEpochAmount: BigInt;
+
+  private constructor(txLog: ethereum.Log) {
+    this.owner = txLog.address;
+    this.eligibleAmount = AdjustedHoldingsLog.getEligibleAmount(txLog);
+    this.nextEpochAmount = AdjustedHoldingsLog.getNextEpochAmount(txLog);
+  }
+
+  static parse(txLog: ethereum.Log): AdjustedHoldingsLog | null {
+    if (!AdjustedHoldingsLog.isAdjustedHoldingsLog(txLog)) {
+      return null;
+    }
+
+    return new AdjustedHoldingsLog(txLog);
+  }
+
+  static isAdjustedHoldingsLog(txLog: ethereum.Log): boolean {
+    return txLog.topics[0].equals(AdjustedHoldingsSig);
+  }
+
+  static getOwner(txLog: ethereum.Log): Address {
+    return ethereum.decode("address", txLog.topics[1])!.toAddress();
+  }
+
+  static getEligibleAmount(txLog: ethereum.Log): BigInt {
+    const decoded = ethereum.decode("(uint256,uint256)", txLog.data)!.toTuple();
+    return decoded[0].toBigInt();
+  }
+
+  static getNextEpochAmount(txLog: ethereum.Log): BigInt {
+    const decoded = ethereum.decode("(uint256,uint256)", txLog.data)!.toTuple();
+    return decoded[1].toBigInt();
+  }
+}
+
+const DepositSig = crypto.keccak256(
+  ByteArray.fromUTF8(
+    "CapitalERC721Deposit(address,address,uint256,uint256,uint256)"
+  )
+);
+
+export class CapitalERC721DepositLog {
+  owner: Address;
+  assetAddress: Address;
+  positionId: BigInt;
+  assetTokenId: BigInt;
+  usdcEquivalent: BigInt;
+  marketId: string;
+
+  private constructor(txLog: ethereum.Log) {
+    this.owner = CapitalERC721DepositLog.getOwner(txLog);
+    this.assetAddress = CapitalERC721DepositLog.getAssetAddress(txLog);
+    this.positionId = CapitalERC721DepositLog.getPositionID(txLog);
+    this.assetTokenId = CapitalERC721DepositLog.getAssetTokenId(txLog);
+    this.usdcEquivalent = CapitalERC721DepositLog.getusdcEquivalent(txLog);
+    this.marketId = "";
+  }
+
+  static parse(txLog: ethereum.Log): CapitalERC721DepositLog | null {
+    if (!CapitalERC721DepositLog.isAdjustedHoldingsLog(txLog)) {
+      return null;
+    }
+
+    return new CapitalERC721DepositLog(txLog);
+  }
+
+  static isAdjustedHoldingsLog(txLog: ethereum.Log): boolean {
+    return txLog.topics[0].equals(AdjustedHoldingsSig);
+  }
+
+  static getOwner(txLog: ethereum.Log): Address {
+    return ethereum.decode("address", txLog.topics[1])!.toAddress();
+  }
+
+  static getAssetAddress(txLog: ethereum.Log): Address {
+    return ethereum.decode("address", txLog.topics[2])!.toAddress();
+  }
+
+  static getPositionID(txLog: ethereum.Log): BigInt {
+    const decoded = ethereum
+      .decode("(uint256,uint256,uint256)", txLog.data)!
+      .toTuple();
+    return decoded[0].toBigInt();
+  }
+
+  static getAssetTokenId(txLog: ethereum.Log): BigInt {
+    const decoded = ethereum
+      .decode("(uint256,uint256,uint256)", txLog.data)!
+      .toTuple();
+    return decoded[1].toBigInt();
+  }
+
+  static getusdcEquivalent(txLog: ethereum.Log): BigInt {
+    const decoded = ethereum
+      .decode("(uint256,uint256,uint256)", txLog.data)!
+      .toTuple();
+    return decoded[2].toBigInt();
+  }
+
+  setmarketId(marketId: string): void {
+    this.marketId = marketId;
+  }
+
+  handleDeposit(txLog: ethereum.Log): void {
+    const currTxHash = txLog.transactionHash.toHexString();
+    const txLogID = `${currTxHash}-${txLog.logIndex.toString()}`;
+    const marketID = getMarketID(this.assetAddress, this.assetTokenId);
+    if (!marketID) {
+      log.error(
+        "[CapitalERC721DepositLog.handleDeposit]failed to look up market id for asset {} with tokenId {}",
+        [this.assetAddress.toHexString(), this.assetTokenId.toString()]
+      );
+      return;
+    }
+    this.setmarketId(marketID!);
+    const positionID = this.positionId.toString();
+    let position = _MembershipStakingPosition.load(positionID);
+    if (!position) {
+      position = new _MembershipStakingPosition(positionID);
+      position.market = marketID!;
+      position.usdcEquivalent = this.usdcEquivalent;
+      position.save();
+    }
+
+    let txLogEntity = _MembershipStakingTx.load(txLogID);
+    if (!txLogEntity) {
+      // a new tx that's not been processed
+      txLogEntity = new _MembershipStakingTx(txLogID);
+      txLogEntity.save();
+
+      const stakedID = `${currTxHash}-${marketID!}`;
+      let stakedEntity = _MembershipCapitalStaked.load(stakedID);
+      if (!stakedEntity) {
+        stakedEntity = new _MembershipCapitalStaked(stakedID);
+        stakedEntity.market = marketID!;
+        stakedEntity.CapitalStakedAmount = BIGINT_ZERO;
+      }
+      stakedEntity.CapitalStakedAmount = stakedEntity.CapitalStakedAmount.plus(
+        this.usdcEquivalent
+      );
+      stakedEntity.save();
+    }
+  }
+}
+
+const WithdrawSig = crypto.keccak256(
+  ByteArray.fromUTF8("CapitalERC721Withdrawal(address,uint256,address,uint256)")
+);
+
+export class CapitalERC721WithdrawalLog {
+  owner: Address;
+  positionId: BigInt;
+  assetAddress: Address;
+  depositTimestamp: BigInt;
+  marketId: string;
+  usdcEquivalent: BigInt;
+
+  private constructor(txLog: ethereum.Log) {
+    this.owner = CapitalERC721WithdrawalLog.getOwner(txLog);
+    this.positionId = CapitalERC721WithdrawalLog.getPositionID(txLog);
+    this.assetAddress = CapitalERC721WithdrawalLog.getAssetAddress(txLog);
+    this.depositTimestamp =
+      CapitalERC721WithdrawalLog.getDepositTimestamp(txLog);
+    this.marketId = "";
+    this.usdcEquivalent = BIGINT_ZERO;
+  }
+
+  static parse(txLog: ethereum.Log): CapitalERC721WithdrawalLog | null {
+    if (!CapitalERC721WithdrawalLog.isAdjustedHoldingsLog(txLog)) {
+      return null;
+    }
+
+    return new CapitalERC721WithdrawalLog(txLog);
+  }
+
+  static isAdjustedHoldingsLog(txLog: ethereum.Log): boolean {
+    return txLog.topics[0].equals(AdjustedHoldingsSig);
+  }
+
+  static getOwner(txLog: ethereum.Log): Address {
+    return ethereum.decode("address", txLog.topics[1])!.toAddress();
+  }
+
+  static getPositionID(txLog: ethereum.Log): BigInt {
+    const decoded = ethereum
+      .decode("(uint256,address,uint256)", txLog.data)!
+      .toTuple();
+    return decoded[0].toBigInt();
+  }
+
+  static getAssetAddress(txLog: ethereum.Log): Address {
+    const decoded = ethereum
+      .decode("(uint256,address,uint256)", txLog.data)!
+      .toTuple();
+    return decoded[1].toAddress();
+  }
+
+  static getDepositTimestamp(txLog: ethereum.Log): BigInt {
+    const decoded = ethereum
+      .decode("(uint256,address,uint256)", txLog.data)!
+      .toTuple();
+    return decoded[2].toBigInt();
+  }
+
+  setmarketId(marketId: string): void {
+    this.marketId = marketId;
+  }
+
+  setusdcEquivalent(usdcEquivalent: BigInt): void {
+    this.usdcEquivalent = usdcEquivalent;
+  }
+
+  handleWithdraw(txLog: ethereum.Log): void {
+    const positionID = this.positionId.toString();
+    let position = _MembershipStakingPosition.load(positionID);
+    if (!position) {
+      log.error(
+        "[processCapitalWithdraw]position {} not existing in _MembershipStakingPosition",
+        [positionID]
+      );
+      return;
+    }
+
+    this.setmarketId(position.market);
+    //this.setusdcEquivalent(position.usdcEquivalent);
+
+    const currTxHash = txLog.transactionHash.toHexString();
+    const txLogID = `${currTxHash}-${txLog.logIndex.toString()}`;
+    let txLogEntity = _MembershipStakingTx.load(txLogID);
+    if (!txLogEntity) {
+      // a new tx that's not been processed
+      txLogEntity = new _MembershipStakingTx(txLogID);
+      txLogEntity.save();
+
+      const stakedID = `${currTxHash}-${position.market}`;
+      let stakedEntity = _MembershipCapitalStaked.load(stakedID);
+      if (!stakedEntity) {
+        stakedEntity = new _MembershipCapitalStaked(stakedID);
+        stakedEntity.market = position.market;
+        stakedEntity.CapitalStakedAmount = BIGINT_ZERO;
+      }
+      stakedEntity.CapitalStakedAmount = stakedEntity.CapitalStakedAmount.minus(
+        position.usdcEquivalent
+      );
+      stakedEntity.save();
+    }
+  }
+}
+
+function getMarketID(assetAddress: Address, tokenID: BigInt): string | null {
+  if (assetAddress.equals(Address.fromString(STAKING_REWARDS_ADDRESS))) {
+    // staking of staked FIDU token, return senior pool id
+    return SENIOR_POOL_ADDRESS;
+  }
+
+  if (assetAddress.equals(Address.fromString(POOL_TOKENS_ADDRESS))) {
+    // staking ERC 721 tranched pool token, use tokenID to look up tranched pool address
+    const poolToken = _PoolToken.load(tokenID.toString());
+    if (!poolToken) {
+      log.error("[getMarketID]tokenID {} does not exist in _PoolToken", [
+        tokenID.toString(),
+      ]);
+      return null;
+    }
+    return poolToken.market;
+  }
+
+  return null;
+}

--- a/subgraphs/goldfinch/src/common/log.ts
+++ b/subgraphs/goldfinch/src/common/log.ts
@@ -80,7 +80,7 @@ export class CapitalERC721DepositLog {
     this.assetAddress = CapitalERC721DepositLog.getAssetAddress(txLog);
     this.positionId = CapitalERC721DepositLog.getPositionID(txLog);
     this.assetTokenId = CapitalERC721DepositLog.getAssetTokenId(txLog);
-    this.usdcEquivalent = CapitalERC721DepositLog.getusdcEquivalent(txLog);
+    this.usdcEquivalent = CapitalERC721DepositLog.getUsdcEquivalent(txLog);
     this.marketId = "";
   }
 
@@ -118,7 +118,7 @@ export class CapitalERC721DepositLog {
     return decoded[1].toBigInt();
   }
 
-  static getusdcEquivalent(txLog: ethereum.Log): BigInt {
+  static getUsdcEquivalent(txLog: ethereum.Log): BigInt {
     const decoded = ethereum
       .decode("(uint256,uint256,uint256)", txLog.data)!
       .toTuple();
@@ -234,7 +234,7 @@ export class CapitalERC721WithdrawalLog {
     this.marketId = marketId;
   }
 
-  setusdcEquivalent(usdcEquivalent: BigInt): void {
+  setUsdcEquivalent(usdcEquivalent: BigInt): void {
     this.usdcEquivalent = usdcEquivalent;
   }
 
@@ -250,7 +250,6 @@ export class CapitalERC721WithdrawalLog {
     }
 
     this.setmarketId(position.market);
-    //this.setusdcEquivalent(position.usdcEquivalent);
 
     const currTxHash = txLog.transactionHash.toHexString();
     const txLogID = `${currTxHash}-${txLog.logIndex.toString()}`;

--- a/subgraphs/goldfinch/src/common/log.ts
+++ b/subgraphs/goldfinch/src/common/log.ts
@@ -85,15 +85,15 @@ export class CapitalERC721DepositLog {
   }
 
   static parse(txLog: ethereum.Log): CapitalERC721DepositLog | null {
-    if (!CapitalERC721DepositLog.isAdjustedHoldingsLog(txLog)) {
+    if (!CapitalERC721DepositLog.isCapitalERC721DepositLog(txLog)) {
       return null;
     }
 
     return new CapitalERC721DepositLog(txLog);
   }
 
-  static isAdjustedHoldingsLog(txLog: ethereum.Log): boolean {
-    return txLog.topics[0].equals(AdjustedHoldingsSig);
+  static isCapitalERC721DepositLog(txLog: ethereum.Log): boolean {
+    return txLog.topics[0].equals(DepositSig);
   }
 
   static getOwner(txLog: ethereum.Log): Address {
@@ -194,15 +194,15 @@ export class CapitalERC721WithdrawalLog {
   }
 
   static parse(txLog: ethereum.Log): CapitalERC721WithdrawalLog | null {
-    if (!CapitalERC721WithdrawalLog.isAdjustedHoldingsLog(txLog)) {
+    if (!CapitalERC721WithdrawalLog.isCapitalERC721WithdrawalLog(txLog)) {
       return null;
     }
 
     return new CapitalERC721WithdrawalLog(txLog);
   }
 
-  static isAdjustedHoldingsLog(txLog: ethereum.Log): boolean {
-    return txLog.topics[0].equals(AdjustedHoldingsSig);
+  static isCapitalERC721WithdrawalLog(txLog: ethereum.Log): boolean {
+    return txLog.topics[0].equals(WithdrawSig);
   }
 
   static getOwner(txLog: ethereum.Log): Address {
@@ -240,7 +240,7 @@ export class CapitalERC721WithdrawalLog {
 
   handleWithdraw(txLog: ethereum.Log): void {
     const positionID = this.positionId.toString();
-    let position = _MembershipStakingPosition.load(positionID);
+    const position = _MembershipStakingPosition.load(positionID);
     if (!position) {
       log.error(
         "[processCapitalWithdraw]position {} not existing in _MembershipStakingPosition",

--- a/subgraphs/goldfinch/src/entities/market.ts
+++ b/subgraphs/goldfinch/src/entities/market.ts
@@ -23,6 +23,18 @@ export function updateInterestRates(
     return;
   }
 
+  log.info(
+    "[updateInterestRates]market {}/{} borrowerInterestAmountUSD={},lenderInterestAmountUSD={} block {} tx {}",
+    [
+      market.id,
+      market.name!,
+      borrowerInterestAmountUSD.toString(),
+      lenderInterestAmountUSD.toString(),
+      event.block.number.toString(),
+      event.transaction.hash.toHexString(),
+    ]
+  );
+
   const rates: string[] = [];
   // scale interest rate to APR
   // since interest is not compounding, apply a linear scaler based on time

--- a/subgraphs/goldfinch/src/entities/market.ts
+++ b/subgraphs/goldfinch/src/entities/market.ts
@@ -1,0 +1,86 @@
+import { BigDecimal, ethereum, log, BigInt } from "@graphprotocol/graph-ts";
+import { Market, InterestRate } from "../../generated/schema";
+import {
+  SECONDS_PER_YEAR,
+  InterestRateSide,
+  InterestRateType,
+  BIGDECIMAL_ZERO,
+  BIGDECIMAL_HUNDRED,
+} from "../common/constants";
+
+export function updateInterestRates(
+  market: Market,
+  borrowerInterestAmountUSD: BigDecimal,
+  lenderInterestAmountUSD: BigDecimal,
+  event: ethereum.Event
+): void {
+  const marketID = market.id;
+  if (!market._interestTimestamp) {
+    log.warning(
+      "[updateInterestRates]market._interestTimestamp for market {} not set for tx {}",
+      [marketID, event.transaction.hash.toHexString()]
+    );
+    market._interestTimestamp = event.block.timestamp;
+    market.save();
+    return;
+  }
+
+  const rates: string[] = [];
+  // scale interest rate to APR
+  // since interest is not compounding, apply a linear scaler based on time
+  const InterestRateScaler = BigInt.fromI32(SECONDS_PER_YEAR).divDecimal(
+    event.block.timestamp.minus(market._interestTimestamp!).toBigDecimal()
+  );
+  // even though borrow rates are supposed to be "STABLE", but there may be late payment, writedown
+  // the actual rate may not be stable
+  const borrowerInterestRateID = `${marketID}-${InterestRateSide.BORROWER}-${InterestRateType.STABLE}`;
+  const borrowerInterestRate = new InterestRate(borrowerInterestRateID);
+  if (market.totalBorrowBalanceUSD.gt(BIGDECIMAL_ZERO)) {
+    borrowerInterestRate.side = InterestRateSide.BORROWER;
+    borrowerInterestRate.type = InterestRateType.STABLE;
+    borrowerInterestRate.rate = borrowerInterestAmountUSD
+      .div(market.totalBorrowBalanceUSD)
+      .times(InterestRateScaler)
+      .times(BIGDECIMAL_HUNDRED);
+    borrowerInterestRate.save();
+
+    rates.push(borrowerInterestRate.id);
+  } else {
+    log.warning(
+      "[updateInterestRates]market.totalBorrowBalanceUSD={} for market {} at tx {}, skip updating borrower rates",
+      [
+        market.totalBorrowBalanceUSD.toString(),
+        marketID,
+        event.transaction.hash.toHexString(),
+      ]
+    );
+  }
+
+  // senior and junior rates are different, this is an average of them
+  const lenderInterestRateID = `${marketID}-${InterestRateSide.LENDER}-${InterestRateType.STABLE}`;
+  const lenderInterestRate = new InterestRate(lenderInterestRateID);
+  if (market.totalDepositBalanceUSD.gt(BIGDECIMAL_ZERO)) {
+    lenderInterestRate.side = InterestRateSide.LENDER;
+    lenderInterestRate.type = InterestRateType.STABLE;
+    lenderInterestRate.rate = lenderInterestAmountUSD
+      .div(market.totalDepositBalanceUSD)
+      .times(InterestRateScaler)
+      .times(BIGDECIMAL_HUNDRED);
+    lenderInterestRate.save();
+
+    rates.push(lenderInterestRate.id);
+  } else {
+    log.warning(
+      "[updateInterestRates]market.totalDepositBalanceUSD={} for market {} at tx {}, skip updating lender rates",
+      [
+        market.totalDepositBalanceUSD.toString(),
+        marketID,
+        event.transaction.hash.toHexString(),
+      ]
+    );
+  }
+
+  market.rates = rates;
+  market._interestTimestamp = event.block.timestamp;
+  market.save();
+}

--- a/subgraphs/goldfinch/src/mappings/membership/capital_ledger.ts
+++ b/subgraphs/goldfinch/src/mappings/membership/capital_ledger.ts
@@ -1,4 +1,12 @@
-import { store } from "@graphprotocol/graph-ts";
+import {
+  ByteArray,
+  store,
+  crypto,
+  ethereum,
+  log,
+  BigInt,
+  Address,
+} from "@graphprotocol/graph-ts";
 
 import {
   CapitalERC721Deposit,
@@ -8,12 +16,25 @@ import {
   VaultedStakedPosition,
   VaultedPoolToken,
   TranchedPoolToken,
+  _Membership,
+  _PoolToken,
+  _MembershipCapitalStaked,
+  _MembershipStakingTx,
+  _MembershipStakingPosition,
 } from "../../../generated/schema";
 
 import {
   STAKING_REWARDS_ADDRESS,
   POOL_TOKENS_ADDRESS,
+  BIGINT_ZERO,
+  SENIOR_POOL_ADDRESS,
 } from "../../common/constants";
+import { getOrCreateMarket } from "../../common/getters";
+import {
+  AdjustedHoldingsLog,
+  CapitalERC721DepositLog,
+  CapitalERC721WithdrawalLog,
+} from "../../common/log";
 import { createTransactionFromEvent } from "../../entities/helpers";
 
 export function handleCapitalErc721Deposit(event: CapitalERC721Deposit): void {
@@ -60,6 +81,18 @@ export function handleCapitalErc721Deposit(event: CapitalERC721Deposit): void {
     transaction.sentNftType = "POOL_TOKEN";
     transaction.save();
   }
+  //Original official goldfinch subgraph code above
+
+  const logs = event.receipt!.logs;
+  if (!logs) {
+    log.warning(
+      "[handleCapitalErc721Deposit]no logs for tx {}, skip reward emissions calculation",
+      [event.transaction.hash.toHexString()]
+    );
+    return;
+  }
+
+  _handleERC721DepositWithdrawal(event.params.owner, logs, event);
 }
 
 export function handleCapitalErc721Withdrawal(
@@ -88,5 +121,210 @@ export function handleCapitalErc721Withdrawal(
     transaction.receivedNftType = "POOL_TOKEN";
     transaction.save();
     store.remove("VaultedPoolToken", id);
+  }
+  //Original official goldfinch subgraph code above
+
+  const logs = event.receipt!.logs;
+  if (!logs) {
+    log.warning(
+      "[handleCapitalErc721Withdrawal]no logs for tx {}, skip reward emissions calculation",
+      [event.transaction.hash.toHexString()]
+    );
+    return;
+  }
+
+  _handleERC721DepositWithdrawal(event.params.owner, logs, event);
+}
+
+function _handleERC721DepositWithdrawal(
+  owner: Address,
+  logs: ethereum.Log[],
+  event: ethereum.Event
+): void {
+  const ownerAddress = owner.toHexString();
+  let membership = _Membership.load(ownerAddress);
+  if (!membership) {
+    membership = new _Membership(ownerAddress);
+    membership.eligibleAmount = BIGINT_ZERO;
+    membership.nextEpochAmount = BIGINT_ZERO;
+    membership.totalCapitalStaked = BIGINT_ZERO;
+    membership.save();
+  }
+
+  const touchedMarketIDs: string[] = [];
+  let eligibleAmount = BIGINT_ZERO;
+  let nextEpochAmount = BIGINT_ZERO;
+  let deltaTotalCapitalStaked = BIGINT_ZERO;
+  for (let i = 0; i < logs.length; i++) {
+    const currLog = logs.at(i);
+    const deposit = CapitalERC721DepositLog.parse(currLog);
+    if (deposit && deposit.owner.equals(owner)) {
+      deposit.handleDeposit(currLog);
+      // marketId is set if handleDeposit() is successful
+      if (deposit.marketId) {
+        deltaTotalCapitalStaked = deltaTotalCapitalStaked.plus(
+          deposit.usdcEquivalent
+        );
+        if (touchedMarketIDs.indexOf(deposit.marketId) < 0) {
+          touchedMarketIDs.push(deposit.marketId);
+        }
+      }
+    }
+
+    const withdraw = CapitalERC721WithdrawalLog.parse(currLog);
+    if (withdraw && withdraw.owner.equals(owner)) {
+      withdraw.handleWithdraw(currLog);
+      // marketId is set if handleWithdraw() is successful
+      if (withdraw.marketId) {
+        deltaTotalCapitalStaked = deltaTotalCapitalStaked.minus(
+          withdraw.usdcEquivalent
+        );
+        if (touchedMarketIDs.indexOf(withdraw.marketId) < 0) {
+          touchedMarketIDs.push(withdraw.marketId);
+        }
+      }
+    }
+
+    const holdings = AdjustedHoldingsLog.parse(currLog);
+    if (holdings && holdings.owner.equals(owner)) {
+      eligibleAmount = eligibleAmount.plus(holdings.eligibleAmount);
+      nextEpochAmount = nextEpochAmount.plus(holdings.nextEpochAmount);
+    }
+  }
+
+  const deltaEligibleAmount = eligibleAmount.minus(membership.eligibleAmount);
+  const deltaNextEpochAmount = nextEpochAmount.minus(
+    membership.nextEpochAmount
+  );
+
+  if (deltaTotalCapitalStaked.le(BIGINT_ZERO)) {
+    log.error("deltaTotalCapitalStaked={} <=0", [
+      deltaTotalCapitalStaked.toString(),
+    ]);
+    return;
+  }
+
+  membership.eligibleAmount = eligibleAmount;
+  membership.nextEpochAmount = nextEpochAmount;
+  membership.save();
+
+  allocateAmountToMarket(
+    touchedMarketIDs,
+    deltaEligibleAmount,
+    deltaNextEpochAmount,
+    deltaTotalCapitalStaked,
+    event
+  );
+}
+
+// TODO:DELETE
+function processCapitalDeposit(
+  deposit: CapitalERC721DepositLog,
+  currLog: ethereum.Log,
+  marketID: string,
+  usdcEquivalent: BigInt
+): void {
+  const currTxHash = currLog.transactionHash.toHexString();
+  const txLogID = `${currTxHash}-${currLog.logIndex.toString()}`;
+  const positionID = deposit.positionId.toString();
+  let position = _MembershipStakingPosition.load(positionID);
+  if (!position) {
+    position = new _MembershipStakingPosition(positionID);
+    position.market = marketID;
+    position.usdcEquivalent = usdcEquivalent;
+    position.save();
+  }
+
+  let txLogEntity = _MembershipStakingTx.load(txLogID);
+  if (!txLogEntity) {
+    // a new tx that's not been processed
+    txLogEntity = new _MembershipStakingTx(txLogID);
+    txLogEntity.save();
+
+    const stakedID = `${currTxHash}-${marketID}`;
+    let stakedEntity = _MembershipCapitalStaked.load(stakedID);
+    if (!stakedEntity) {
+      stakedEntity = new _MembershipCapitalStaked(stakedID);
+      stakedEntity.market = marketID;
+      stakedEntity.CapitalStakedAmount = BIGINT_ZERO;
+    }
+    stakedEntity.CapitalStakedAmount =
+      stakedEntity.CapitalStakedAmount!.plus(usdcEquivalent);
+    stakedEntity.save();
+  }
+}
+
+function processCapitalWithdraw(
+  withdraw: CapitalERC721WithdrawalLog,
+  currLog: ethereum.Log
+  //marketID: string,
+  //usdcEquivalent: BigInt
+): void {
+  const positionID = withdraw.positionId.toString();
+  let position = _MembershipStakingPosition.load(positionID);
+  if (!position) {
+    log.error(
+      "[processCapitalWithdraw]position {} not existing in _MembershipStakingPosition",
+      [positionID]
+    );
+    return;
+  }
+
+  withdraw.setmarketId(position.market);
+  withdraw.setusdcEquivalent(position.usdcEquivalent);
+
+  const currTxHash = currLog.transactionHash.toHexString();
+  const txLogID = `${currTxHash}-${currLog.logIndex.toString()}`;
+  let txLogEntity = _MembershipStakingTx.load(txLogID);
+  if (!txLogEntity) {
+    // a new tx that's not been processed
+    txLogEntity = new _MembershipStakingTx(txLogID);
+    txLogEntity.save();
+
+    const stakedID = `${currTxHash}-${position.market}`;
+    let stakedEntity = _MembershipCapitalStaked.load(stakedID);
+    if (!stakedEntity) {
+      stakedEntity = new _MembershipCapitalStaked(stakedID);
+      stakedEntity.market = position.market;
+      stakedEntity.CapitalStakedAmount = BIGINT_ZERO;
+    }
+    stakedEntity.CapitalStakedAmount =
+      stakedEntity.CapitalStakedAmount!.minus(usdcEquivalent);
+    stakedEntity.save();
+  }
+}
+
+function allocateAmountToMarket(
+  marketIDs: string[],
+  deltaEligibleAmount: BigInt,
+  deltaNextEpochAmount: BigInt,
+  deltaTotalCapitalStaked: BigInt,
+  event: ethereum.Event
+): void {
+  const txHash = event.transaction.hash.toHexString();
+  for (let i = 0; i < marketIDs.length; i++) {
+    const mktID = marketIDs[i];
+    const stkID = `${txHash}-${mktID}`;
+    const stkEntity = _MembershipCapitalStaked.load(stkID);
+    if (!stkEntity) {
+      log.error("_MembershipCapitalStaked {} does not exist tx {}", [
+        stkID,
+        txHash,
+      ]);
+      continue;
+    }
+    const mktDeltaEligibleAmount = deltaEligibleAmount
+      .times(stkEntity.CapitalStakedAmount)
+      .div(deltaTotalCapitalStaked);
+    const mktDeltaNextEpochAmount = deltaNextEpochAmount
+      .times(stkEntity.CapitalStakedAmount)
+      .div(deltaTotalCapitalStaked);
+
+    const mkt = getOrCreateMarket(mktID, event);
+    mkt._membershipRewardEligibleAmount =
+      mkt._membershipRewardEligibleAmount!.plus(mktDeltaEligibleAmount);
+    mkt._membershipRewardNextEpochAmount =
+      mkt._membershipRewardNextEpochAmount!.plus(mktDeltaNextEpochAmount);
+    mkt.save();
   }
 }

--- a/subgraphs/goldfinch/src/mappings/senior_pool.ts
+++ b/subgraphs/goldfinch/src/mappings/senior_pool.ts
@@ -14,7 +14,6 @@ import { Fidu as FiduContract } from "../../generated/SeniorPool/Fidu";
 import {
   BIGDECIMAL_ONE,
   BIGDECIMAL_ZERO,
-  BIGINT_ZERO,
   CONFIG_KEYS_ADDRESSES,
   FIDU_ADDRESS,
   GFI_ADDRESS,

--- a/subgraphs/goldfinch/src/mappings/tranched_pool.ts
+++ b/subgraphs/goldfinch/src/mappings/tranched_pool.ts
@@ -1,4 +1,4 @@
-import { InterestRate, TranchedPool } from "../../generated/schema";
+import { TranchedPool } from "../../generated/schema";
 import { GoldfinchConfig as GoldfinchConfigContract } from "../../generated/templates/TranchedPool/GoldfinchConfig";
 import { CreditLine as CreditLineContract } from "../../generated/templates/TranchedPool/CreditLine";
 import {
@@ -18,14 +18,10 @@ import {
 } from "../../generated/templates/TranchedPool/TranchedPool";
 import { PoolTokens as PoolTokensContract } from "../../generated/templates/TranchedPool/PoolTokens";
 import {
-  BIGDECIMAL_HUNDRED,
   BIGDECIMAL_ZERO,
   BIGINT_ZERO,
   CONFIG_KEYS_ADDRESSES,
-  InterestRateSide,
-  InterestRateType,
   PositionSide,
-  SECONDS_PER_YEAR,
   TransactionType,
   USDC_DECIMALS,
 } from "../common/constants";

--- a/subgraphs/goldfinch/src/mappings/tranched_pool.ts
+++ b/subgraphs/goldfinch/src/mappings/tranched_pool.ts
@@ -96,6 +96,14 @@ export function handleDepositMade(event: DepositMade): void {
       .toHexString();
   }
 
+  if (!market._interestTimestamp) {
+    market._interestTimestamp = event.block.timestamp;
+    log.debug(
+      "[handleDepositMade]market._interestTimestamp for market {} set to {}",
+      [marketID, event.block.timestamp.toString()]
+    );
+  }
+
   const creditLineAddress = tranchedPoolContract.creditLine();
   const creditLineContract = CreditLineContract.bind(creditLineAddress);
   if (!market._creditLine) {

--- a/subgraphs/goldfinch/src/mappings/tranched_pool.ts
+++ b/subgraphs/goldfinch/src/mappings/tranched_pool.ts
@@ -113,11 +113,6 @@ export function handleDepositMade(event: DepositMade): void {
   market.totalDepositBalanceUSD =
     market.inputTokenBalance.divDecimal(USDC_DECIMALS);
   market.totalValueLockedUSD = market.totalDepositBalanceUSD;
-  // calculate average daily emission since first deposit
-  if (!market._rewardTimestamp) {
-    market._rewardTimestamp = event.block.timestamp;
-    market._cumulativeRewardAmount = BIGINT_ZERO;
-  }
   market.save();
 
   const protocol = getOrCreateProtocol();
@@ -630,11 +625,6 @@ export function handleSharePriceUpdated(event: SharePriceUpdated): void {
   const totalBorrowBalance = creditLineContract.balance();
   market.totalBorrowBalanceUSD = totalBorrowBalance.divDecimal(USDC_DECIMALS);
 
-  // calculate average daily emission since first deposit
-  if (!market._rewardTimestamp) {
-    market._rewardTimestamp = event.block.timestamp;
-    market._cumulativeRewardAmount = BIGINT_ZERO;
-  }
   // set _isMigratedTranchedPool to false, so we only process the migration once
   market._isMigratedTranchedPool = false;
   market.save();


### PR DESCRIPTION
Added goldfinch membership rewards (staking of output ERC 720 tokens) #1499

- test deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/goldfinch-ethereum
- validation dashboard: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/name/tnkrxyz/goldfinch-ethereum

### Tasks
- [X] Membership vault / rewards
- [X] senior pool rates
- [ ] ~~[Add onto an existing position](https://github.com/messari/subgraphs/pull/1298#discussion_r1018210259)~~ (Dylan doesn't recall the exact concern here)
- [X] openPositionCount = cumulativePositionCount
- [ ] ~~additional identifier/names to add to Market names (tranched pool)~~ (confirmed with goldfinch folk, no tranched pool identifier available on chain)
- [x] remove compoundBalance field/code