### PR TITLE
patch(): sdk; Fixed bridge sdk bug from schema change

### DIFF
--- a/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
@@ -35,7 +35,8 @@ export class AccountManager {
     acc.transferInCount = 0;
     acc.depositCount = 0;
     acc.withdrawCount = 0;
-    acc.messageCount = 0;
+    acc.messageSentCount = 0;
+    acc.messageReceivedCount = 0;
     acc.save();
 
     this.protocol.addUser();


### PR DESCRIPTION
We broke down that field in the schema into two other fields and didn’t get updated in the SDK.