### PR TITLE
fix (#patch); bridge sdk; fixed argument type for token

### DIFF
--- a/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
@@ -278,7 +278,9 @@ export class Account {
     updateMetrics: boolean = true
   ): LiquidityDeposit {
     const _pool = pool.pool;
-    const token = this.tokens.getOrCreateToken(_pool.inputToken);
+    const token = this.tokens.getOrCreateToken(
+      Address.fromBytes(_pool.inputToken)
+    );
 
     const deposit = new LiquidityDeposit(idFromEvent(this.event));
     deposit.hash = this.event.transaction.hash;
@@ -319,7 +321,9 @@ export class Account {
     updateMetrics: boolean = true
   ): LiquidityWithdraw {
     const _pool = pool.pool;
-    const token = this.tokens.getOrCreateToken(_pool.inputToken);
+    const token = this.tokens.getOrCreateToken(
+      Address.fromBytes(_pool.inputToken)
+    );
 
     const withdraw = new LiquidityWithdraw(idFromEvent(this.event));
     withdraw.hash = this.event.transaction.hash;

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/pool.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/pool.ts
@@ -464,7 +464,9 @@ export class Pool {
     if (!this.pool.outputToken) {
       return;
     }
-    const token = this.tokens.getOrCreateToken(this.pool.outputToken);
+    const token = this.tokens.getOrCreateToken(
+      Address.fromBytes(this.pool.outputToken)
+    );
     const price = this.protocol.pricer.getTokenPrice(token);
 
     this.pool.outputTokenPriceUSD = price;

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/tokens.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/tokens.ts
@@ -10,7 +10,7 @@ import { Bridge } from "./protocol";
 import { RewardTokenType } from "../../util/constants";
 
 export interface TokenInitializer {
-  getTokenParams(address: Bytes): TokenParams;
+  getTokenParams(address: Address): TokenParams;
 }
 
 export class TokenParams {
@@ -28,7 +28,7 @@ export class TokenManager {
     this.initializer = init;
   }
 
-  getOrCreateToken(address: Bytes): Token {
+  getOrCreateToken(address: Address): Token {
     let token = Token.load(address);
     if (token) {
       return token;

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/tokens.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/tokens.ts
@@ -10,7 +10,7 @@ import { Bridge } from "./protocol";
 import { RewardTokenType } from "../../util/constants";
 
 export interface TokenInitializer {
-  getTokenParams(address: Address): TokenParams;
+  getTokenParams(address: Bytes): TokenParams;
 }
 
 export class TokenParams {
@@ -28,7 +28,7 @@ export class TokenManager {
     this.initializer = init;
   }
 
-  getOrCreateToken(address: Address): Token {
+  getOrCreateToken(address: Bytes): Token {
     let token = Token.load(address);
     if (token) {
       return token;


### PR DESCRIPTION
In tokens.ts, the argument for `getOrCreateToken` and `getTokenParams` is specified as type `Address`, but Token.id is specified as `Bytes` in the schema. This PR changes the argument type to `Bytes`.