### PR TITLE
[GIN] fix (#patch); maker Gov; fixed handling invalid spells v2

### DIFF
--- a/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
+++ b/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
@@ -121,7 +121,7 @@ export function handleEtch(event: Etch): void {
   if (to && to != event.address) {
     const fromAdmin = DelegateAdmin.load(sender);
     if (!fromAdmin) {
-      const toAdmin = DelegateAdmin.load(to!.toHexString());
+      const toAdmin = DelegateAdmin.load(to.toHexString());
       if (!toAdmin) {
         log.error("Etch not trigger by a delegate admin. TxnHash: {}", [
           event.transaction.hash.toHexString(),

--- a/subgraphs/maker-governance/src/helpers.ts
+++ b/subgraphs/maker-governance/src/helpers.ts
@@ -133,18 +133,16 @@ export function createSlate(slateID: Bytes, event: ethereum.Event): Slate {
       const expiration = dsSpell.try_expiration();
       if (!expiration.reverted) {
         spell.expiryTime = expiration.value;
-      } else {
-        spell.expiryTime = BIGINT_ZERO;
+        spell.governanceFramework = event.address.toHexString();
+        spell.totalVotes = BIGINT_ZERO;
+        spell.totalWeightedVotes = BIGINT_ZERO;
+        spell.save();
+
+        // Track this new spell
+        DSSpellTemplate.create(spellAddress);
+
+        newSpellCount = newSpellCount + 1;
       }
-      spell.governanceFramework = event.address.toHexString();
-      spell.totalVotes = BIGINT_ZERO;
-      spell.totalWeightedVotes = BIGINT_ZERO;
-      spell.save();
-
-      // Track this new spell
-      DSSpellTemplate.create(spellAddress);
-
-      newSpellCount = newSpellCount + 1;
     }
     slate.yays = slate.yays.concat([spellID]);
     // loop through slate indices until a revert breaks it


### PR DESCRIPTION
### Description

Alter the fix in #1554 to avoid saving invalid spell addresses instead of storing them