### PR TITLE
feat (); bridge sdk; Added account methods messageOut and messageIn

### DIFF
--- a/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
@@ -285,7 +285,7 @@ export class Account {
       srcChainId,
       this.protocol.getCurrentChainID(),
       source,
-      this.account.id,
+      Address.fromBytes(this.account.id),
       false,
       data
     );
@@ -310,7 +310,7 @@ export class Account {
     return this.message(
       this.protocol.getCurrentChainID(),
       dstChainId,
-      this.account.id,
+      Address.fromBytes(this.account.id),
       destination,
       true,
       data

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
@@ -7,6 +7,7 @@ import {
   LiquidityWithdraw,
   PoolRoute,
   ActiveAccount,
+  BridgeMessage,
 } from "../../../../generated/schema";
 import { Pool } from "./pool";
 import { Bridge } from "./protocol";
@@ -268,6 +269,83 @@ export class Account {
   }
 
   /**
+   * Creates a BridgeMessage entity for a message arriving to this chain
+   *
+   * @param srcChainId the source chain id
+   * @param source The account sending the message.
+   * @param data Contents of the message
+   * @param transactionID Optional transaction ID on the source chain.
+   * @returns BridgeMessage
+   */
+  messageIn(srcChainId: BigInt, source: Address, data: Bytes): BridgeMessage {
+    this.countMessageIn();
+    this.protocol.addTransaction(TransactionType.MESSAGE_RECEIVED);
+
+    return this.message(
+      srcChainId,
+      this.protocol.getCurrentChainID(),
+      source,
+      this.account.id,
+      false,
+      data
+    );
+  }
+
+  /**
+   * Creates a BridgeMessage entity for a message away from this chain
+   *
+   * @param dstChainId the destination chain id
+   * @param destination The account receiving the message.
+   * @param data Contents of the message
+   * @returns BridgeMessage
+   */
+  messageOut(
+    dstChainId: BigInt,
+    destination: Address,
+    data: Bytes
+  ): BridgeMessage {
+    this.countMessageOut();
+    this.protocol.addTransaction(TransactionType.MESSAGE_SENT);
+
+    return this.message(
+      this.protocol.getCurrentChainID(),
+      dstChainId,
+      this.account.id,
+      destination,
+      true,
+      data
+    );
+  }
+
+  private message(
+    srcChainId: BigInt,
+    dstChainId: BigInt,
+    sender: Address,
+    receiver: Address,
+    isOutgoing: boolean,
+    data: Bytes
+  ): BridgeMessage {
+    const id = idFromEvent(this.event);
+    const message = new BridgeMessage(id);
+    message.hash = this.event.transaction.hash;
+    message.logIndex = this.event.logIndex.toI32();
+    message.blockNumber = this.event.block.number;
+    message.timestamp = this.event.block.timestamp;
+
+    message.protocol = this.protocol.getBytesID();
+    message.account = this.account.id;
+    message.from = sender;
+    message.to = receiver;
+    message.isOutgoing = isOutgoing;
+    message.data = data;
+    message.fromChainID = srcChainId;
+    message.toChainID = dstChainId;
+    message.save();
+
+    return message;
+  }
+
+  /**
    *
    * @param pool The pool where the liquidity was deposited.
    * @param amount The amount deposited of inputToken.
@@ -405,6 +483,35 @@ export class Account {
     }
     this.trackActivity(ActivityType.TRANSFER_OUT);
     this.account.transferOutCount += 1;
+    this.account.save();
+  }
+
+  /**
+   * Adds 1 to the account total MessageReceived count. (not yet ) If it is the first message received ever
+   * by this account it will also increase the number of unique message receivers in the protocol.
+   */
+  countMessageIn(): void {
+    /*
+    // enable this if it is necessary to track message receivers
+    if (this.account.messageReceivedCount == 0) {
+      this.protocol.addMessageReceiver();
+    }
+    */
+    this.trackActivity(ActivityType.MESSAGE);
+    this.account.messageReceivedCount += 1;
+    this.account.save();
+  }
+
+  /**
+   * Adds 1 to the account total MessageSent count. If it is the first message sent ever
+   * by this account it will also increase the number of unique message senders in the protocol.
+   */
+  countMessageOut(): void {
+    if (this.account.messageSentCount == 0) {
+      this.protocol.addMessageSender();
+    }
+    this.trackActivity(ActivityType.MESSAGE);
+    this.account.messageSentCount += 1;
     this.account.save();
   }
 }


### PR DESCRIPTION
Added `messageOut` and `messageIn` method for Account and necessary helper functions to handle messages sent/received across the bridge managed by the bridge protocol.

Note that there are protocol.cumulativeUniqueMessageSenders, UsageMetric.cumulativeUniqueMessageSenders and daily/hourlyActiveMessageSenders, but not protocol.cumulativeUniqueMessageReceivers or UsageMetric.daily/hourlyActiveMessageReceivers in the schema. As [jaimehgb explains](https://discord.com/channels/953684103012683796/961658223444787220/1063578350985150545), that is because receiving a message is not done by an account per se, but by a contract.