### PR TITLE
fix(#patch); XDAI to Gnosis; Update schemas to use Gnosis instead of XDAI

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2828,8 +2828,8 @@
         "network": "gnosis",
         "status": "dev",
         "versions": {
-          "schema": "1.1.1",
-          "subgraph": "1.1.3",
+          "schema": "1.1.2",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3599,8 +3599,8 @@
         "network": "gnosis",
         "status": "prod",
         "versions": {
-          "schema": "1.3.0",
-          "subgraph": "1.1.4",
+          "schema": "1.3.1",
+          "subgraph": "1.1.5",
           "methodology": "1.0.1"
         },
         "files": {
@@ -4125,8 +4125,8 @@
         "network": "gnosis",
         "status": "prod",
         "versions": {
-          "schema": "1.3.0",
-          "subgraph": "1.1.10",
+          "schema": "1.3.1",
+          "subgraph": "1.1.11",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4299,8 +4299,8 @@
         "network": "gnosis",
         "status": "prod",
         "versions": {
-          "schema": "1.3.0",
-          "subgraph": "1.0.6",
+          "schema": "1.3.1",
+          "subgraph": "1.0.7",
           "methodology": "1.0.1"
         },
         "files": {

--- a/schema-bridge.graphql
+++ b/schema-bridge.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Bridge
-# Version: 1.1.0
+# Version: 1.1.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 enum Network {
   ARBITRUM_ONE
@@ -22,7 +22,7 @@ enum Network {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
   UBIQ
   SONGBIRD
   ELASTOS

--- a/schema-dex-agg.graphql
+++ b/schema-dex-agg.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: DEX AGG
-# Version: 1.0.1
+# Version: 1.0.2
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -23,7 +23,7 @@ enum Network {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum ProtocolType {

--- a/schema-dex-amm-extended.graphql
+++ b/schema-dex-amm-extended.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: DEX AMM (Extended)
-# Version: 3.0.3
+# Version: 3.0.4
 # See https://github.com/messari/subgraphs/blob/master/docs/Schema.md for details
 
 enum Network {
@@ -23,7 +23,7 @@ enum Network {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum ProtocolType {

--- a/schema-dex-amm.graphql
+++ b/schema-dex-amm.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: DEX AMM
-# Version: 1.3.0
+# Version: 1.3.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -23,7 +23,7 @@ enum Network {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum ProtocolType {

--- a/schema-generic.graphql
+++ b/schema-generic.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Generic
-# Version: 1.3.0
+# Version: 1.3.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -23,7 +23,7 @@ enum Network {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum ProtocolType {

--- a/schema-lending.graphql
+++ b/schema-lending.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Lending Protocol
-# Version: 3.0.0
+# Version: 3.0.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -23,7 +23,7 @@ enum Network {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum ProtocolType {

--- a/schema-network.graphql
+++ b/schema-network.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Network
-# Version: 1.1.1
+# Version: 1.1.2
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum SubgraphNetwork {
@@ -24,7 +24,7 @@ enum SubgraphNetwork {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum DataType {

--- a/schema-nft-marketplace.graphql
+++ b/schema-nft-marketplace.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: NFT Marketplace
-# Version: 2.0.0
+# Version: 2.0.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -23,7 +23,7 @@ enum Network {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum NftStandard {

--- a/schema-yield.graphql
+++ b/schema-yield.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Yield Aggregator
-# Version: 1.3.0
+# Version: 1.3.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -23,7 +23,7 @@ enum Network {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum ProtocolType {

--- a/subgraphs/network/protocols/evm/config/deployments/evm-gnosis/configurations.json
+++ b/subgraphs/network/protocols/evm/config/deployments/evm-gnosis/configurations.json
@@ -1,3 +1,3 @@
 {
-  "network": "xdai"
+  "network": "gnosis"
 }

--- a/subgraphs/network/schema.graphql
+++ b/subgraphs/network/schema.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Network
-# Version: 1.1.1
+# Version: 1.1.2
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum SubgraphNetwork {
@@ -24,7 +24,7 @@ enum SubgraphNetwork {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum DataType {

--- a/subgraphs/network/src/constants.ts
+++ b/subgraphs/network/src/constants.ts
@@ -30,7 +30,7 @@ export namespace Network {
   export const OPTIMISM = "OPTIMISM";
   export const OSMOSIS = "OSMOSIS";
   export const MATIC = "MATIC"; // aka Polygon
-  export const XDAI = "XDAI"; // aka Gnosis Chain
+  export const GNOSIS = "GNOSIS"; // aka Gnosis Chain
 }
 
 // This is how the Network displays on thegraph.com
@@ -57,7 +57,7 @@ export namespace SubgraphNetwork {
   export const OPTIMISM = "optimism";
   export const OSMOSIS = "osmosis-1";
   export const POLYGON = "matic";
-  export const XDAI = "xdai";
+  export const GNOSIS = "gnosis";
 }
 
 export namespace DataType {

--- a/subgraphs/qidao/protocols/qidao/config/deployments/qidao-gnosis/configurations.json
+++ b/subgraphs/qidao/protocols/qidao/config/deployments/qidao-gnosis/configurations.json
@@ -11,5 +11,8 @@
       "address": "0x014a177e9642d1b4e970418f894985dc1b85657f",
       "startBlock": 21666284
     }
-  ]
+  ],
+  "graftEnabled": false,
+  "subgraphId": "QmeDVCBsAN72oHaqMvnPdfXt9p8GHTv7gG9mDM3X7ZVt21",
+  "graftStartBlock": 26030934
 }

--- a/subgraphs/qidao/protocols/qidao/config/deployments/qidao-gnosis/configurations.json
+++ b/subgraphs/qidao/protocols/qidao/config/deployments/qidao-gnosis/configurations.json
@@ -1,5 +1,5 @@
 {
-  "chain": "xdai",
+  "chain": "gnosis",
   "erc20Vaults": [
     {
       "name": "WETH",

--- a/subgraphs/qidao/protocols/qidao/config/templates/qidao.template.yaml
+++ b/subgraphs/qidao/protocols/qidao/config/templates/qidao.template.yaml
@@ -2,6 +2,14 @@ specVersion: 0.0.4
 repository: https://github.com/messari/subgraphs
 schema:
   file: ./schema.graphql
+{{#graftEnabled}}
+description: ...
+graft:
+  base: {{subgraphId}} # Subgraph ID of base subgraph
+  block: {{graftStartBlock}} # Block number
+features:
+  - grafting
+{{/graftEnabled}}
 dataSources:
   {{#maticVault}}
   - kind: ethereum

--- a/subgraphs/qidao/schema.graphql
+++ b/subgraphs/qidao/schema.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Lending Protocol
-# Version: 1.3.0
+# Version: 1.3.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -23,7 +23,7 @@ enum Network {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum ProtocolType {

--- a/subgraphs/qidao/src/utils/constants.ts
+++ b/subgraphs/qidao/src/utils/constants.ts
@@ -37,7 +37,7 @@ export namespace Network {
   export const OPTIMISM = "OPTIMISM";
   export const OSMOSIS = "OSMOSIS";
   export const MATIC = "MATIC"; // aka Polygon
-  export const XDAI = "XDAI"; // aka Gnosis Chain
+  export const GNOSIS = "GNOSIS"; // aka Gnosis Chain
 }
 
 export namespace ProtocolType {
@@ -199,7 +199,7 @@ MAI_TOKEN_ADDRESS.set(
   "0x3f56e0c36d275367b8c502090edf38289b3dea0d"
 );
 MAI_TOKEN_ADDRESS.set(
-  Network.XDAI,
+  Network.GNOSIS,
   "0x3f56e0c36d275367b8c502090edf38289b3dea0d"
 );
 MAI_TOKEN_ADDRESS.set(

--- a/subgraphs/uniswap-forks/configurations/configurations/configurations.ts
+++ b/subgraphs/uniswap-forks/configurations/configurations/configurations.ts
@@ -11,7 +11,7 @@ import { SushiswapMainnetConfigurations } from "../../protocols/sushiswap/config
 import { SushiswapMaticConfigurations } from "../../protocols/sushiswap/config/deployments/sushiswap-polygon/configurations";
 import { SushiswapMoonbeamConfigurations } from "../../protocols/sushiswap/config/deployments/sushiswap-moonbeam/configurations";
 import { SushiswapMoonriverConfigurations } from "../../protocols/sushiswap/config/deployments/sushiswap-moonriver/configurations";
-import { SushiswapXdaiConfigurations } from "../../protocols/sushiswap/config/deployments/sushiswap-gnosis/configurations";
+import { SushiswapGnosisConfigurations } from "../../protocols/sushiswap/config/deployments/sushiswap-gnosis/configurations";
 import { SushiswapHarmonyConfigurations } from "../../protocols/sushiswap/config/deployments/sushiswap-harmony/configurations";
 import { SpookyswapFantomConfigurations } from "../../protocols/spookyswap/config/deployments/spookyswap-fantom/configurations";
 import { UbeswapCeloConfigurations } from "../../protocols/ubeswap/config/deployments/ubeswap-celo/configurations";
@@ -23,7 +23,7 @@ import { TrisolarisAuroraConfigurations } from "../../protocols/trisolaris/confi
 import { VSSFinanceCronosConfigurations } from "../../protocols/vvs-finance/config/deployments/vvs-finance-cronos/configurations";
 import { MMFinanceCronosConfigurations } from "../../protocols/mm-finance/config/deployments/mm-finance-cronos/configurations";
 import { MMFinanceMaticConfigurations } from "../../protocols/mm-finance/config/deployments/mm-finance-polygon/configurations";
-import { HoneyswapXdaiConfigurations } from "../../protocols/honeyswap/config/deployments/honeyswap-gnosis/configurations";
+import { HoneyswapGnosisConfigurations } from "../../protocols/honeyswap/config/deployments/honeyswap-gnosis/configurations";
 import { HoneyswapMaticConfigurations } from "../../protocols/honeyswap/config/deployments/honeyswap-polygon/configurations";
 import { PangolinAvalancheConfigurations } from "../../protocols/pangolin/config/deployments/pangolin-avalanche/configurations";
 import { BiswapBscConfigurations } from "../../protocols/biswap/config/deployments/biswap-bsc/configurations";
@@ -74,7 +74,7 @@ export function getNetworkConfigurations(deploy: i32): Configurations {
       return new SushiswapMoonriverConfigurations();
     }
     case Deploy.SUSHISWAP_GNOSIS: {
-      return new SushiswapXdaiConfigurations();
+      return new SushiswapGnosisConfigurations();
     }
     case Deploy.SUSHISWAP_HARMONY: {
       return new SushiswapHarmonyConfigurations();
@@ -107,7 +107,7 @@ export function getNetworkConfigurations(deploy: i32): Configurations {
       return new UbeswapCeloConfigurations();
     }
     case Deploy.HONEYSWAP_GNOSIS: {
-      return new HoneyswapXdaiConfigurations();
+      return new HoneyswapGnosisConfigurations();
     }
     case Deploy.HONEYSWAP_POLYGON: {
       return new HoneyswapMaticConfigurations();

--- a/subgraphs/uniswap-forks/protocols/honeyswap/config/deployments/honeyswap-gnosis/configurations.json
+++ b/subgraphs/uniswap-forks/protocols/honeyswap/config/deployments/honeyswap-gnosis/configurations.json
@@ -1,6 +1,6 @@
 {
   "deployment": "HONEYSWAP_GNOSIS",
-  "network": "xdai",
+  "network": "gnosis",
   "address": "0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7",
   "startBlock": 11813490,
   "honeyFarmAddress": "0xB44825cF0d8D4dD552f2434056c41582415AaAa1",

--- a/subgraphs/uniswap-forks/protocols/honeyswap/config/deployments/honeyswap-gnosis/configurations.ts
+++ b/subgraphs/uniswap-forks/protocols/honeyswap/config/deployments/honeyswap-gnosis/configurations.ts
@@ -16,9 +16,9 @@ import {
   PROTOCOL_SLUG,
 } from "../../../src/common/constants";
 
-export class HoneyswapXdaiConfigurations implements Configurations {
+export class HoneyswapGnosisConfigurations implements Configurations {
   getNetwork(): string {
-    return Network.XDAI;
+    return Network.GNOSIS;
   }
   getSchemaVersion(): string {
     return PROTOCOL_SCHEMA_VERSION;

--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/deployments/sushiswap-gnosis/configurations.json
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/deployments/sushiswap-gnosis/configurations.json
@@ -1,6 +1,6 @@
 {
   "deployment": "SUSHISWAP_GNOSIS",
-  "network": "xdai",
+  "network": "gnosis",
   "address": "0xc35dadb65012ec5796536bd9864ed8773abc74c4",
   "startBlock": 0,
   "miniChefAddress": "0xdDCbf776dF3dE60163066A5ddDF2277cB445E0F3",

--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/deployments/sushiswap-gnosis/configurations.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/deployments/sushiswap-gnosis/configurations.ts
@@ -21,9 +21,9 @@ import {
   toLowerCaseList,
 } from "../../../../../src/common/utils/utils";
 
-export class SushiswapXdaiConfigurations implements Configurations {
+export class SushiswapGnosisConfigurations implements Configurations {
   getNetwork(): string {
-    return Network.XDAI;
+    return Network.GNOSIS;
   }
   getSchemaVersion(): string {
     return PROTOCOL_SCHEMA_VERSION;

--- a/subgraphs/uniswap-forks/schema.graphql
+++ b/subgraphs/uniswap-forks/schema.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: DEX AMM
-# Version: 1.3.0
+# Version: 1.3.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -23,7 +23,7 @@ enum Network {
   OPTIMISM
   OSMOSIS
   MATIC # aka Polygon
-  XDAI # aka Gnosis Chain
+  GNOSIS
 }
 
 enum ProtocolType {

--- a/subgraphs/uniswap-forks/src/common/constants.ts
+++ b/subgraphs/uniswap-forks/src/common/constants.ts
@@ -38,7 +38,7 @@ export namespace Network {
   export const NEAR_MAINNET = "NEAR_MAINNET";
   export const OPTIMISM = "OPTIMISM";
   export const MATIC = "MATIC"; // aka Polygon
-  export const XDAI = "XDAI"; // aka Gnosis Chain
+  export const GNOSIS = "GNOSIS"; // aka Gnosis Chain
 }
 
 export namespace ProtocolType {

--- a/subgraphs/uniswap-forks/src/common/rewards.ts
+++ b/subgraphs/uniswap-forks/src/common/rewards.ts
@@ -280,7 +280,7 @@ function getStartingBlockRate(): BigDecimal {
     return BigDecimal.fromString("12.5");
   } else if (NetworkConfigs.getNetwork() == Network.MATIC) {
     return BigDecimal.fromString("2");
-  } else if (NetworkConfigs.getNetwork() == Network.XDAI) {
+  } else if (NetworkConfigs.getNetwork() == Network.GNOSIS) {
     return BigDecimal.fromString("5");
   } else if (NetworkConfigs.getNetwork() == Network.MOONBEAM) {
     return BigDecimal.fromString("13.39");


### PR DESCRIPTION
**Context:**
The Graph seems to be transitioning to referencing the Gnosis chain as Gnosis (prev xdai). In response, I have update the schemas to use the GNOSIS network in the namespace instead of XDAI. Also, we would like to update our current production subgraphs to follow this schema, so I have update those to conform. 