### PR TITLE
chore(); remove comp v3 decentralized network

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1855,10 +1855,6 @@
           "hosted-service": {
             "slug": "compound-v3-ethereum",
             "query-id": "compound-v3-ethereum"
-          },
-          "decentralized-network": {
-            "slug": "compound-v3-ethereum",
-            "query-id": "6PaB6tKFqrL6YoAELEhFGU6Gc39cEynLbo6ETZMF3sCy"
           }
         }
       }


### PR DESCRIPTION
Since our id's use Bytes and the Byte < > comparisons are only avail on the hosted service right now we need to avoid trying to query the decentralized network.

We will add this back in once the changes are persisted on the decentralized network.