### PR TITLE
feat (); alpaca-finance-lending-fantom; added configuration & deployment

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -461,6 +461,28 @@
             "query-id": "alpaca-finance-lending-bsc"
           }
         }
+      },
+      "alpaca-finance-lending-fantom": {
+        "network": "fantom",
+        "status": "prod",
+        "versions": {
+          "schema": "2.0.1",
+          "subgraph": "1.0.0",
+          "methodology": "1.0.0"
+        },
+        "files": {
+          "template": "alpaca.finance.lending.template.yaml"
+        },
+        "options": {
+          "prepare:yaml": true,
+          "prepare:constants": false
+        },
+        "services": {
+          "hosted-service": {
+            "slug": "alpaca-finance-lending-fantom",
+            "query-id": "alpaca-finance-lending-fantom"
+          }
+        }
       }
     }
   },

--- a/subgraphs/alpaca-finance-lending/protocols/alpaca-finance-lending/config/deployments/alpaca-finance-lending-fantom/configurations.json
+++ b/subgraphs/alpaca-finance-lending/protocols/alpaca-finance-lending/config/deployments/alpaca-finance-lending-fantom/configurations.json
@@ -21,5 +21,8 @@
       "address": "0x60dDe8BBE160fe033fACB3446Cf7795cC575B171",
       "startBlock": 32934658
     }
-  ]
+  ],
+  "graftEnabled": false,
+  "subgraphId": "QmZnCmiy4kz6jCm9VBxq8XScAWXTRakbVM4KfdqhGHUFgr",
+  "graftStartBlock": 34488000
 }

--- a/subgraphs/alpaca-finance-lending/protocols/alpaca-finance-lending/config/deployments/alpaca-finance-lending-fantom/configurations.json
+++ b/subgraphs/alpaca-finance-lending/protocols/alpaca-finance-lending/config/deployments/alpaca-finance-lending-fantom/configurations.json
@@ -1,0 +1,25 @@
+{
+  "network": "fantom",
+  "vaults": [
+    {
+      "name": "ibFTM",
+      "address": "0xc1018f4Bba361A1Cc60407835e156595e92EF7Ad",
+      "startBlock": 30359865
+    },
+    {
+      "name": "ibUSDC",
+      "address": "0x831332f94C4A0092040b28ECe9377AfEfF34B25a",
+      "startBlock": 30360730
+    },
+    {
+      "name": "ibALPACA",
+      "address": "0x2E7f32e38EA5a5fcb4494d9B626d2d393B176B1E",
+      "startBlock": 31161333
+    },
+    {
+      "name": "ibTOMB",
+      "address": "0x60dDe8BBE160fe033fACB3446Cf7795cC575B171",
+      "startBlock": 32934658
+    }
+  ]
+}

--- a/subgraphs/alpaca-finance-lending/protocols/alpaca-finance-lending/config/templates/alpaca.finance.lending.template.yaml
+++ b/subgraphs/alpaca-finance-lending/protocols/alpaca-finance-lending/config/templates/alpaca.finance.lending.template.yaml
@@ -3,6 +3,14 @@ specVersion: 0.0.4
 repository: https://github.com/messari/subgraphs
 schema:
   file: ./schema.graphql
+{{#graftEnabled}}
+description: ...
+features:
+  - grafting
+graft:
+  base: {{subgraphId}} # Subgraph ID of base subgraph
+  block: {{graftStartBlock}} # Block number
+{{/graftEnabled}}  
 dataSources:
 #These valuts are not generated in a factory mode, so I have to list them here one by one.
   {{#vaults}}

--- a/subgraphs/alpaca-finance-lending/src/entities/market.ts
+++ b/subgraphs/alpaca-finance-lending/src/entities/market.ts
@@ -29,7 +29,7 @@ import {
 import { getOrCreateToken, getTokenById } from "./token";
 import { incrementProtocolTotalPoolCount } from "./usage";
 import { EventType } from "./event";
-import { getOrCreateInterestRates } from "./rate";
+import { getOrCreateInterestRateIds } from "./rate";
 import {
   BIGDECIMAL_NEGATIVE_ONE,
   BIGDECIMAL_ONE,
@@ -335,7 +335,7 @@ export function updateMarketRates(
   borrowerInterestRate: BigDecimal,
   lenderInterestRate: BigDecimal
 ): void {
-  const newRates = getOrCreateInterestRates(
+  const newRates = getOrCreateInterestRateIds(
     market.id,
     borrowerInterestRate,
     lenderInterestRate

--- a/subgraphs/alpaca-finance-lending/src/entities/rate.ts
+++ b/subgraphs/alpaca-finance-lending/src/entities/rate.ts
@@ -2,7 +2,7 @@ import { BigDecimal } from "@graphprotocol/graph-ts";
 import { InterestRate } from "../../generated/schema";
 import { InterestRateSide, InterestRateType } from "../utils/constants";
 
-function getOrCreateBorrowerVariableRate(
+function createBorrowerVariableRate(
   marketId: string,
   interestRate: BigDecimal
 ): InterestRate {
@@ -10,15 +10,16 @@ function getOrCreateBorrowerVariableRate(
   let rate = InterestRate.load(id);
   if (!rate) {
     rate = new InterestRate(id);
-    rate.rate = interestRate;
-    rate.side = InterestRateSide.BORROWER;
-    rate.type = InterestRateType.VARIABLE;
-    rate.save();
   }
+
+  rate.rate = interestRate;
+  rate.side = InterestRateSide.BORROWER;
+  rate.type = InterestRateType.VARIABLE;
+  rate.save();
   return rate;
 }
 
-function getOrCreateLenderVariableRate(
+function createLenderVariableRate(
   marketId: string,
   interestRate: BigDecimal
 ): InterestRate {
@@ -26,21 +27,22 @@ function getOrCreateLenderVariableRate(
   let rate = InterestRate.load(id);
   if (!rate) {
     rate = new InterestRate(id);
-    rate.rate = interestRate;
-    rate.side = InterestRateSide.LENDER;
-    rate.type = InterestRateType.VARIABLE;
-    rate.save();
   }
+  rate.rate = interestRate;
+  rate.side = InterestRateSide.LENDER;
+  rate.type = InterestRateType.VARIABLE;
+  rate.save();
+
   return rate;
 }
 
-export function getOrCreateInterestRates(
+export function getOrCreateInterestRateIds(
   marketId: string,
   borrowerInterestRate: BigDecimal,
   lenderInterestRate: BigDecimal
 ): string[] {
   return [
-    getOrCreateBorrowerVariableRate(marketId, borrowerInterestRate).id,
-    getOrCreateLenderVariableRate(marketId, lenderInterestRate).id,
+    createBorrowerVariableRate(marketId, borrowerInterestRate).id,
+    createLenderVariableRate(marketId, lenderInterestRate).id,
   ];
 }

--- a/subgraphs/alpaca-finance-lending/src/entities/token.ts
+++ b/subgraphs/alpaca-finance-lending/src/entities/token.ts
@@ -1,7 +1,7 @@
 import { Address } from "@graphprotocol/graph-ts";
 import { RewardToken, Token } from "../../generated/schema";
-import { IERC20Detailed } from "../../generated/ibUSDT/IERC20Detailed";
-import { IERC20DetailedBytes } from "../../generated/ibUSDT/IERC20DetailedBytes";
+import { IERC20Detailed } from "../../generated/ibALPACA/IERC20Detailed";
+import { IERC20DetailedBytes } from "../../generated/ibALPACA/IERC20DetailedBytes";
 import { prefixID } from "../utils/strings";
 
 export const UNKNOWN_TOKEN_VALUE = "unknown";


### PR DESCRIPTION
- [x] This PR adds configuration & deployment for alpaca-finance-lending-fantom, as requested in #1625

**Updated 2023/02/02**
- [x] There was a bug in setting interest rates for market and snapshots. The [abnormal rates @ishraq8 found](https://github.com/messari/subgraphs/pull/1631#issuecomment-1404215550) are the first rates in the market and never get updated. The bug affects both bsc and fantom subgraph. This should be reflected when the subgraph sync
- [x] The PR also fixes the `handleAddDebt` and `handleRemoveDebt`, which uses the incorrect `Work` event. This fix requires calculating `debtVal` from `event.params.debtShare` of the `Addebt` and `RemoveDebt` event.


### bsc
- test deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/alpaca-finance-lending-bsc
- data validation: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/name/tnkrxyz/alpaca-finance-lending-bsc&tab=protocol
### fantom
- test deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/alpaca-finance-lending-fantom
- data validation: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/name/tnkrxyz/alpaca-finance-lending-fantom&tab=protocol