### PR TITLE
fix(#major); comp v3; ETH pricing

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1841,7 +1841,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.0.0",
-          "subgraph": "1.1.0",
+          "subgraph": "2.0.0",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/compound-v3/protocols/compound-v3/src/constants.ts
+++ b/subgraphs/compound-v3/protocols/compound-v3/src/constants.ts
@@ -32,6 +32,9 @@ export const DEFAULT_DECIMALS = 18;
 export const CONFIGURATOR_ADDRESS =
   "0x316f9708bB98af7dA9c68C1C3b5e79039cD336E3";
 export const REWARDS_ADDRESS = "0x1B0e765F6224C21223AeA2af16c1C46E38885a40";
+export const WETH_COMET_ADDRESS = "0xA17581A9E3356d9A858b789D68B4d866e593aE94";
+export const USDC_COMET_WETH_MARKET_ID =
+  "0xc3d688b66703497daa19211eedff47f25384cdc3c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
 
 /////////////////////////////
 ///// Protocol Specific /////


### PR DESCRIPTION
With the addition of the new ethereum market the prices are returned in ETH, unfortunately there is nothing on chain identifying this so we need to hardcode in logic to get the ETH price to get the real TVL.

Test: https://okgraph.xyz/?q=dmelotik%2Fcompound-v3-ethereum