### PR TITLE
Add Event Interface to Generic Schema

### DIFF
--- a/schema-generic.graphql
+++ b/schema-generic.graphql
@@ -479,6 +479,59 @@ type PoolHourlySnapshot @entity {
   blockNumber: BigInt!
 }
 
+    ##### Event Data #####
+    ##### Different Protocols will emit varying events #####
+    ##### The Event interface can be used for querying an activity feed #####
+
+interface Event {
+  " { Transaction hash }-{ Log index } "
+  id: ID!
+
+  " Transaction hash of the transaction that emitted this event "
+  hash: String!
+
+  " Event log index. "
+  logIndex: Int!
+
+  " Block number of this event "
+  blockNumber: BigInt!
+
+  " Timestamp of this event "
+  timestamp: BigInt!
+
+  " Account that caused the event to be emitted "
+  account: Account!
+
+  " Amount of token transferred for the event in native units, null if the event does not emit some type of value "
+  amount: BigInt
+}
+
+## This sample event should be duplicated for each of the events that would be desirable for an activity log for the protocol ##
+## E.g. deposits, withdrawals, staking, swaps, delegations, votes, etc. ##
+## Events that implement the Event interface can be extended for unique properties ##
+type SampleEvent implements Event @entity(immutable: true) {
+   " { Transaction hash }-{ Log index } "
+  id: ID!
+
+  " Transaction hash of the transaction that emitted this event "
+  hash: String!
+
+  " Event log index. "
+  logIndex: Int!
+
+  " Block number of this event "
+  blockNumber: BigInt!
+
+  " Timestamp of this event "
+  timestamp: BigInt!
+
+  " Account that caused the event to be emitted "
+  account: Account!
+
+  " Amount of token transferred for the event in native units, null if the event does not emit some type of value "
+  amount: BigInt
+}
+
 # An account is a unique Ethereum address
 # Helps to accumulate total unique users
 type Account @entity {

--- a/schema-generic.graphql
+++ b/schema-generic.graphql
@@ -479,13 +479,20 @@ type PoolHourlySnapshot @entity {
   blockNumber: BigInt!
 }
 
-    ##### Event Data #####
-    ##### Different Protocols will emit varying events #####
-    ##### The Event interface can be used for querying an activity feed #####
+##### Event Data #####
+##### Different Protocols will emit varying events #####
+##### The Event interface can be used for querying an activity feed #####
+
+enum Event {
+  SampleEvent
+}
 
 interface Event {
   " { Transaction hash }-{ Log index } "
   id: ID!
+  
+  " The Event Name "
+  event: Event!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -512,6 +519,8 @@ interface Event {
 type SampleEvent implements Event @entity(immutable: true) {
    " { Transaction hash }-{ Log index } "
   id: ID!
+  
+  event: Event!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!

--- a/schema-generic.graphql
+++ b/schema-generic.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Generic
-# Version: 2.0.0
+# Version: 2.0.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {


### PR DESCRIPTION
Added an Event Interface to the Generic Schema.

Protocols typically have a set of events that would useful to display to users to see an activity feed for the protocol, a market or their account. Each protocol may have varying events, but they can be standardly queried using an Event interface and using __typename to return the event type.

Below is a sample query would accomplish this: 
```
query UserEventLog($skip: Int = 0, $first: Int = 10, $account: String = "0x0xabc123") {
  events(first: $first, skip: $skip, where: {account: $account}) {
    hash
    timestamp
    account {
      id
    }
    amount
    market {
      id
      name
    }
    __typename
  }
}
```