### PR TITLE
fix(#patch); aave v3; handle change to BalanceTransfer event

### DIFF
--- a/subgraphs/aave-v3/protocols/aave-v3/src/mappings/AToken.ts
+++ b/subgraphs/aave-v3/protocols/aave-v3/src/mappings/AToken.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, dataSource } from "@graphprotocol/graph-ts";
 import {
   AToken,
   BalanceTransfer,
@@ -17,6 +17,7 @@ import { updateUserLenderPosition } from "../entities/position";
 import { amountInUSD } from "../entities/price";
 import { getReserve, updateReserveATokenSupply } from "../entities/reserve";
 import { getTokenById } from "../entities/token";
+import { getUpdateBlock } from "../utils/constants";
 
 export function handleBurn(event: Burn): void {
   const contract = AToken.bind(event.address);
@@ -54,6 +55,16 @@ export function handleMint(event: Mint): void {
 
 export function handleBalanceTransfer(event: BalanceTransfer): void {
   const reserve = getReserve(event.address);
+  
+  // Interpret value based on current block compared to V3 -> V3.0.1 contract upgrade for that market
+  // Event update: https://github.com/aave/aave-v3-core/pull/682
+  let balanceTransferValue = event.params.value;
+  const network = dataSource.network();
+  const v301UpdateBlock = getUpdateBlock(network);
+  if (v301UpdateBlock !== -1 && event.block.number.toU32() > v301UpdateBlock) {
+    balanceTransferValue = balanceTransferValue.times(event.params.index);
+  }
+
   // Liquidation protocol fee gets transferred directly to treasury during liquidation (if activated)
   if (reserve.treasuryAddress == event.params.to.toHexString()) {
     const valueUSD = amountInUSD(event.params.value, getTokenById(reserve.id));

--- a/subgraphs/aave-v3/protocols/aave-v3/src/utils/constants.ts
+++ b/subgraphs/aave-v3/protocols/aave-v3/src/utils/constants.ts
@@ -5,3 +5,14 @@ export namespace PositionSide {
   export const LENDER = "LENDER";
   export const BORROWER = "BORROWER";
 }
+
+// returns block of market update to v3.0.1, or null if no upgrade
+export function getUpdateBlock(network: string): u32 {
+  let updateBlock = -1;
+  if (network === 'mainnet') {
+    updateBlock = 0;
+  }
+  // TODO: Add upgrade block numbers as they occur
+
+  return updateBlock;
+}


### PR DESCRIPTION
The `value` parameter of the `BalanceTransfer` event was updated in the [Aave 3.0.1 contract update](https://github.com/aave/aave-v3-core/pull/682) to be the scaled balance in place of current balance. 

This PR interprets `value` based on current block compared to V3 -> V3.0.1 contract upgrade for that market.

Once Aave V3 markets are upgraded to V3.0.1 via Governance, the update blocks will need to be added to this helper function and subgraphs re-deployed.