### PR TITLE
fix(#minor); aave forks; fix liquidations

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -130,7 +130,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.18",
+          "subgraph": "1.3.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -163,7 +163,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.18",
+          "subgraph": "1.3.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -196,7 +196,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.18",
+          "subgraph": "1.3.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -229,7 +229,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.17",
+          "subgraph": "1.3.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -251,7 +251,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.17",
+          "subgraph": "1.3.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -277,7 +277,7 @@
         "status": "dev",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.2.18",
+          "subgraph": "1.3.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -306,7 +306,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.0",
+          "subgraph": "1.2.0",
           "methodology": "1.0.1"
         },
         "files": {
@@ -328,7 +328,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.0",
+          "subgraph": "1.2.0",
           "methodology": "1.0.1"
         },
         "files": {
@@ -350,7 +350,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.0",
+          "subgraph": "1.2.0",
           "methodology": "1.0.1"
         },
         "files": {
@@ -372,7 +372,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.0",
+          "subgraph": "1.2.0",
           "methodology": "1.0.1"
         },
         "files": {
@@ -394,7 +394,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.0",
+          "subgraph": "1.2.0",
           "methodology": "1.0.1"
         },
         "files": {
@@ -416,7 +416,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.1.0",
+          "subgraph": "1.2.0",
           "methodology": "1.0.1"
         },
         "files": {
@@ -438,7 +438,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.0.0",
+          "subgraph": "1.1.0",
           "methodology": "1.0.1"
         },
         "files": {
@@ -3227,7 +3227,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.0.13",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3256,7 +3256,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.0.4",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3285,7 +3285,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.0.7",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/aave-forks/protocols/aave-amm/src/mapping.ts
+++ b/subgraphs/aave-forks/protocols/aave-amm/src/mapping.ts
@@ -363,7 +363,8 @@ export function handleLiquidationCall(event: LiquidationCall): void {
     getProtocolData(),
     event.params.liquidator,
     event.params.user,
-    event.params.debtAsset
+    event.params.debtAsset,
+    event.params.debtToCover
   );
 }
 

--- a/subgraphs/aave-forks/protocols/aave-arc/src/mapping.ts
+++ b/subgraphs/aave-forks/protocols/aave-arc/src/mapping.ts
@@ -363,7 +363,8 @@ export function handleLiquidationCall(event: LiquidationCall): void {
     getProtocolData(),
     event.params.liquidator,
     event.params.user,
-    event.params.debtAsset
+    event.params.debtAsset,
+    event.params.debtToCover
   );
 }
 

--- a/subgraphs/aave-forks/protocols/aave-rwa/src/mapping.ts
+++ b/subgraphs/aave-forks/protocols/aave-rwa/src/mapping.ts
@@ -363,7 +363,8 @@ export function handleLiquidationCall(event: LiquidationCall): void {
     getProtocolData(),
     event.params.liquidator,
     event.params.user,
-    event.params.debtAsset
+    event.params.debtAsset,
+    event.params.debtToCover
   );
 }
 

--- a/subgraphs/aave-forks/protocols/aave-v2/src/mapping.ts
+++ b/subgraphs/aave-forks/protocols/aave-v2/src/mapping.ts
@@ -368,7 +368,8 @@ export function handleLiquidationCall(event: LiquidationCall): void {
     getProtocolData(),
     event.params.liquidator,
     event.params.user,
-    event.params.debtAsset
+    event.params.debtAsset,
+    event.params.debtToCover
   );
 }
 

--- a/subgraphs/aave-forks/protocols/aave-v3/src/mapping.ts
+++ b/subgraphs/aave-forks/protocols/aave-v3/src/mapping.ts
@@ -501,7 +501,8 @@ export function handleLiquidationCall(event: LiquidationCall): void {
     protocolData,
     event.params.liquidator,
     event.params.user,
-    debtMarketId
+    debtMarketId,
+    event.params.debtToCover
   );
 }
 

--- a/subgraphs/aave-forks/protocols/geist-finance/src/mapping.ts
+++ b/subgraphs/aave-forks/protocols/geist-finance/src/mapping.ts
@@ -342,7 +342,8 @@ export function handleLiquidationCall(event: LiquidationCall): void {
     getProtocolData(),
     event.params.liquidator,
     event.params.user,
-    event.params.debtAsset
+    event.params.debtAsset,
+    event.params.debtToCover
   );
 }
 

--- a/subgraphs/aave-forks/protocols/radiant-capital/src/mapping.ts
+++ b/subgraphs/aave-forks/protocols/radiant-capital/src/mapping.ts
@@ -255,7 +255,8 @@ export function handleLiquidationCall(event: LiquidationCall): void {
     getProtocolData(),
     event.params.liquidator,
     event.params.user,
-    event.params.debtAsset
+    event.params.debtAsset,
+    event.params.debtToCover
   );
 }
 

--- a/subgraphs/aave-forks/protocols/uwu-lend/src/mapping.ts
+++ b/subgraphs/aave-forks/protocols/uwu-lend/src/mapping.ts
@@ -280,7 +280,8 @@ export function handleLiquidationCall(event: LiquidationCall): void {
     getProtocolData(),
     event.params.liquidator,
     event.params.user,
-    event.params.debtAsset
+    event.params.debtAsset,
+    event.params.debtToCover
   );
 }
 

--- a/subgraphs/aave-forks/src/mapping.ts
+++ b/subgraphs/aave-forks/src/mapping.ts
@@ -1007,7 +1007,7 @@ export function _handleLiquidate(
   liquidate.hash = event.transaction.hash.toHexString();
   liquidate.nonce = event.transaction.nonce;
   liquidate.logIndex = event.logIndex.toI32();
-  liquidate.asset = inputToken!.id;
+  liquidate.asset = debtAsset!.id;
   liquidate.amount = amount;
   liquidate.amountUSD = amount
     .toBigDecimal()

--- a/subgraphs/aave-forks/src/mapping.ts
+++ b/subgraphs/aave-forks/src/mapping.ts
@@ -878,7 +878,8 @@ export function _handleLiquidate(
   protocolData: ProtocolData,
   liquidator: Address,
   borrower: Address, // account liquidated
-  repayToken: Address // token repaid to cover debt
+  debtToken: Address, // token repaid to cover debt,
+  debtToCover: BigInt // the amount of debt repaid by liquidator
 ): void {
   const market = Market.load(marketId.toHexString());
   if (!market) {
@@ -940,10 +941,10 @@ export function _handleLiquidate(
     protocol.save();
   }
 
-  const repayTokenMarket = Market.load(repayToken.toHexString());
+  const repayTokenMarket = Market.load(debtToken.toHexString());
   if (!repayTokenMarket) {
     log.warning("[Liquidate] Repay token market not found on protocol: {}", [
-      repayToken.toHexString(),
+      debtToken.toHexString(),
     ]);
     return;
   }
@@ -989,6 +990,14 @@ export function _handleLiquidate(
     event
   );
 
+  const debtAsset = Token.load(debtToken.toHexString());
+  if (!debtAsset) {
+    log.warning("[Liquidate] Debt asset not found on protocol: {}", [
+      debtToken.toHexString(),
+    ]);
+    return;
+  }
+
   liquidate.position = positionId;
   liquidate.blockNumber = event.block.number;
   liquidate.timestamp = event.block.timestamp;
@@ -1004,8 +1013,11 @@ export function _handleLiquidate(
     .toBigDecimal()
     .div(exponentToBigDecimal(inputToken!.decimals))
     .times(market.inputTokenPriceUSD);
-  liquidate.profitUSD = liquidate.amountUSD.times(
-    market.liquidationPenalty.div(BIGDECIMAL_HUNDRED)
+  liquidate.profitUSD = liquidate.amountUSD.minus(
+    debtToCover
+      .toBigDecimal()
+      .div(exponentToBigDecimal(debtAsset.decimals))
+      .times(repayTokenMarket.inputTokenPriceUSD)
   );
   liquidate.save();
 


### PR DESCRIPTION
Liquidations were not properly mapped. Fixed:
- `liquidate.asset` is now the asset that is borrowed, not the collateral asset
- `liquidate.profitUSD` is now the difference between the amount seized and the amount of debt paid by the liquidator.

Test deployment: https://okgraph.xyz/?q=dmelotik%2Faave-v2-ethereum