### PR TITLE
fix(#patch): multichain; add missing pool destination tokens

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -6160,7 +6160,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.0.0",
-          "subgraph": "1.0.0",
+          "subgraph": "1.0.1",
           "methodology": "1.0.0"
         },
         "services": {
@@ -6182,7 +6182,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.0.0",
-          "subgraph": "1.0.0",
+          "subgraph": "1.0.1",
           "methodology": "1.0.0"
         },
         "services": {

--- a/subgraphs/multichain/src/common/getters.ts
+++ b/subgraphs/multichain/src/common/getters.ts
@@ -304,9 +304,24 @@ export function getOrCreatePoolRoute(
     poolRoute.createdBlockNumber = BIGINT_ZERO;
 
     protocol.totalPoolRouteCount += INT_ONE;
+    addCrosschainTokenToPoolIfNotExists(pool, crosschainToken);
   }
 
   return poolRoute;
+}
+
+function addCrosschainTokenToPoolIfNotExists(
+  pool: Pool,
+  crossToken: CrosschainToken
+): void {
+  if (pool.destinationTokens.indexOf(crossToken.id) >= 0) {
+    return;
+  }
+
+  const tokens = pool.destinationTokens;
+  tokens.push(crossToken.id);
+  pool.destinationTokens = tokens;
+  pool.save();
 }
 
 export function getOrCreatePoolDailySnapshot(


### PR DESCRIPTION

https://okgraph.xyz/?q=QmSoawPaM5fWFiSMH7yaGDwNprXXTwGoV3cv5JsebojWhn

`Pool.destinationTokens` is showing empty for multichain. Since destination tokens are linked to pool routes, whenever a new pool route is added to a pool, we’ll add the token too if not there already.