### PR TITLE
chore(): lint price-lib and sdk

### DIFF
--- a/subgraphs/_reference_/src/common/constants.ts
+++ b/subgraphs/_reference_/src/common/constants.ts
@@ -106,9 +106,9 @@ export namespace UsageType {
 //////////////////////////////
 
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-export const ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+export const ETH_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
-export const UNISWAP_V2_FACTORY = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f";
+export const UNISWAP_V2_FACTORY = "0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f";
 
 export const WETH_ADDRESS = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
 export const USDC_WETH_PAIR = "0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc"; // created 10008355
@@ -169,7 +169,7 @@ export const ETH_NAME = "Ether";
 ///// Protocol Specific /////
 /////////////////////////////
 
-export const FACTORY_ADDRESS = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f";
+export const FACTORY_ADDRESS = "0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f";
 export const TRADING_FEE = BigDecimal.fromString("3");
 export const PROTOCOL_FEE_TO_ON = BigDecimal.fromString("0.5");
 export const LP_FEE_TO_ON = BigDecimal.fromString("2.5");

--- a/subgraphs/_reference_/src/prices/config/arbitrum.ts
+++ b/subgraphs/_reference_/src/prices/config/arbitrum.ts
@@ -12,7 +12,7 @@ export const YEARN_LENS_CONTRACT_ADDRESS = new OracleContract(
   2396321
 );
 export const AAVE_ORACLE_CONTRACT_ADDRESS = new OracleContract(
-  "0xb56c2F0B653B2e0b10C9b928C8580Ac5Df02C7C7",
+  "0xb56c2f0b653b2e0b10c9b928c8580ac5df02c7c7",
   7740843
 );
 export const SUSHISWAP_CALCULATIONS_ADDRESS = new OracleContract(
@@ -31,8 +31,8 @@ export const CURVE_CALCULATIONS_ADDRESS = new OracleContract(
 );
 
 export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x445FE580eF8d70FF569aB36e80c647af338db351", 1362056),
-  new OracleContract("0x0E9fBb167DF83EdE3240D6a5fa5d40c6C6851e15", 4530115),
+  new OracleContract("0x445fe580ef8d70ff569ab36e80c647af338db351", 1362056),
+  new OracleContract("0x0e9fbb167df83ede3240d6a5fa5d40c6c6851e15", 4530115),
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -65,7 +65,7 @@ export const HARDCODED_STABLES: Address[] = [];
 export const USDC_TOKEN_DECIMALS = BigInt.fromI32(6);
 
 export const ETH_ADDRESS = Address.fromString(
-  "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 );
 export const WETH_ADDRESS = Address.fromString(
   "0x82af49447d8a07e3bd95bd0d56f35241523fbab1"

--- a/subgraphs/_reference_/src/prices/config/aurora.ts
+++ b/subgraphs/_reference_/src/prices/config/aurora.ts
@@ -19,7 +19,7 @@ export const SUSHISWAP_CALCULATIONS_ADDRESS = new OracleContract();
 export const CURVE_CALCULATIONS_ADDRESS = new OracleContract();
 
 export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858", 62440526),
+  new OracleContract("0x5b5cfe992adac0c9d48e05854b2d91c73a003858", 62440526),
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -27,7 +27,7 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x2CB45Edb4517d5947aFdE3BEAbF95A582506858B", 49607893), // TriSolaris
+  new OracleContract("0x2cb45edb4517d5947afde3beabf95a582506858b", 49607893), // TriSolaris
 ];
 
 ///////////////////////////////////////////////////////////////////////////

--- a/subgraphs/_reference_/src/prices/config/avalanche.ts
+++ b/subgraphs/_reference_/src/prices/config/avalanche.ts
@@ -12,7 +12,7 @@ export const CHAIN_LINK_CONTRACT_ADDRESS = new OracleContract();
 export const SUSHISWAP_CALCULATIONS_ADDRESS = new OracleContract();
 
 export const AAVE_ORACLE_CONTRACT_ADDRESS = new OracleContract(
-  "0xEBd36016B3eD09D4693Ed4251c67Bd858c3c7C9C",
+  "0xebd36016b3ed09d4693ed4251c67bd858c3c7c9c",
   11970477
 );
 
@@ -23,8 +23,8 @@ export const AAVE_ORACLE_CONTRACT_ADDRESS = new OracleContract(
 export const CURVE_CALCULATIONS_ADDRESS = new OracleContract();
 
 export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x8474DdbE98F5aA3179B3B3F5942D724aFcdec9f6", 5254206),
-  new OracleContract("0x90f421832199e93d01b64DaF378b183809EB0988", 9384663),
+  new OracleContract("0x8474ddbe98f5aa3179b3b3f5942d724afcdec9f6", 5254206),
+  new OracleContract("0x90f421832199e93d01b64daf378b183809eb0988", 9384663),
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -32,9 +32,9 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x60aE616a2155Ee3d9A68541Ba4544862310933d4", 2486393), // TraderJOE
-  new OracleContract("0xE54Ca86531e17Ef3616d22Ca28b0D458b6C89106", 56879), // Pangolin
-  new OracleContract("0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506", 506236), // Sushiswap
+  new OracleContract("0x60ae616a2155ee3d9a68541ba4544862310933d4", 2486393), // TraderJOE
+  new OracleContract("0xe54ca86531e17ef3616d22ca28b0d458b6c89106", 56879), // Pangolin
+  new OracleContract("0x1b02da8cb0d097eb8d57a175b88c7d8b47997506", 506236), // Sushiswap
 ];
 
 ///////////////////////////////////////////////////////////////////////////

--- a/subgraphs/_reference_/src/prices/config/bsc.ts
+++ b/subgraphs/_reference_/src/prices/config/bsc.ts
@@ -26,8 +26,8 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [];
 ///////////////////////////////////////////////////////////////////////////
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x10ED43C718714eb63d5aA57B78B54704E256024E", 6810080), // PancakeSwap v2
-  new OracleContract("0x05fF2B0DB69458A0750badebc4f9e13aDd608C7F", 586899), // PancakeSwap v1
+  new OracleContract("0x10ed43c718714eb63d5aa57b78b54704e256024e", 6810080), // PancakeSwap v2
+  new OracleContract("0x05ff2b0db69458a0750badebc4f9e13add608c7f", 586899), // PancakeSwap v1
 ];
 
 ///////////////////////////////////////////////////////////////////////////

--- a/subgraphs/_reference_/src/prices/config/cronos.ts
+++ b/subgraphs/_reference_/src/prices/config/cronos.ts
@@ -25,7 +25,7 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [];
 ///////////////////////////////////////////////////////////////////////////
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x145863Eb42Cf62847A6Ca784e6416C1682b1b2Ae", 5247), // VVS Finance
+  new OracleContract("0x145863eb42cf62847a6ca784e6416c1682b1b2ae", 5247), // VVS Finance
 ];
 
 ///////////////////////////////////////////////////////////////////////////

--- a/subgraphs/_reference_/src/prices/config/fantom.ts
+++ b/subgraphs/_reference_/src/prices/config/fantom.ts
@@ -28,8 +28,8 @@ export const CURVE_CALCULATIONS_ADDRESS = new OracleContract(
 );
 
 export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x0f854EA9F38ceA4B1c2FC79047E9D0134419D5d6", 5655918),
-  new OracleContract("0x4fb93D7d320E8A263F22f62C2059dFC2A8bCbC4c", 27552509),
+  new OracleContract("0x0f854ea9f38cea4b1c2fc79047e9d0134419d5d6", 5655918),
+  new OracleContract("0x4fb93d7d320e8a263f22f62c2059dfc2a8bcbc4c", 27552509),
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -38,7 +38,7 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
   new OracleContract("0xbe4fc72f8293f9d3512d58b969c98c3f676cb957", 3796241), // Uniswap v2
-  new OracleContract("0x16327E3FbDaCA3bcF7E38F5Af2599D2DDc33aE52", 4250168), // Spiritswap
+  new OracleContract("0x16327e3fbdaca3bcf7e38f5af2599d2ddc33ae52", 4250168), // Spiritswap
   new OracleContract("0x1b02da8cb0d097eb8d57a175b88c7d8b47997506", 2457904), // Sushiswap
 ];
 

--- a/subgraphs/_reference_/src/prices/config/fuse.ts
+++ b/subgraphs/_reference_/src/prices/config/fuse.ts
@@ -25,8 +25,8 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [];
 ///////////////////////////////////////////////////////////////////////////
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
-  new OracleContract("0xE3F85aAd0c8DD7337427B9dF5d0fB741d65EEEB5", 15645719), // Voltage Finance
-  new OracleContract("0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506", 12936314), // Sushiswap
+  new OracleContract("0xe3f85aad0c8dd7337427b9df5d0fb741d65eeeb5", 15645719), // Voltage Finance
+  new OracleContract("0x1b02da8cb0d097eb8d57a175b88c7d8b47997506", 12936314), // Sushiswap
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -51,13 +51,13 @@ export const HARDCODED_STABLES: Address[] = [];
 export const USDC_TOKEN_DECIMALS = BigInt.fromI32(6);
 
 export const ETH_ADDRESS = Address.fromString(
-  "0xa722c13135930332Eb3d749B2F0906559D2C5b99"
+  "0xa722c13135930332eb3d749b2f0906559d2c5b99"
 );
 export const WETH_ADDRESS = Address.fromString(
-  "0x0BE9e53fd7EDaC9F859882AfdDa116645287C629" // Wrapped Fuse (WFUSE)
+  "0x0be9e53fd7edac9f859882afdda116645287c629" // Wrapped Fuse (WFUSE)
 );
 export const USDC_ADDRESS = Address.fromString(
-  "0x620fd5fa44BE6af63715Ef4E65DDFA0387aD13F5"
+  "0x620fd5fa44be6af63715ef4e65ddfa0387ad13f5"
 );
 
 export class config implements Configurations {

--- a/subgraphs/_reference_/src/prices/config/gnosis.ts
+++ b/subgraphs/_reference_/src/prices/config/gnosis.ts
@@ -19,8 +19,8 @@ export const SUSHISWAP_CALCULATIONS_ADDRESS = new OracleContract();
 export const CURVE_CALCULATIONS_ADDRESS = new OracleContract();
 
 export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x55E91365697EB8032F98290601847296eC847210", 20754886),
-  new OracleContract("0x8A4694401bE8F8FCCbC542a3219aF1591f87CE17", 23334728),
+  new OracleContract("0x55e91365697eb8032f98290601847296ec847210", 20754886),
+  new OracleContract("0x8a4694401be8f8fccbc542a3219af1591f87ce17", 23334728),
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -28,7 +28,7 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506", 14735910), // SushiSwap
+  new OracleContract("0x1b02da8cb0d097eb8d57a175b88c7d8b47997506", 14735910), // SushiSwap
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -56,7 +56,7 @@ export const ETH_ADDRESS = Address.fromString(
   "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1"
 );
 export const WETH_ADDRESS = Address.fromString(
-  "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d"
+  "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d"
 );
 export const USDC_ADDRESS = Address.fromString(
   "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83"

--- a/subgraphs/_reference_/src/prices/config/harmony.ts
+++ b/subgraphs/_reference_/src/prices/config/harmony.ts
@@ -11,7 +11,7 @@ export const YEARN_LENS_CONTRACT_ADDRESS = new OracleContract();
 export const CHAIN_LINK_CONTRACT_ADDRESS = new OracleContract();
 export const SUSHISWAP_CALCULATIONS_ADDRESS = new OracleContract();
 export const AAVE_ORACLE_CONTRACT_ADDRESS = new OracleContract(
-  "0xb56c2F0B653B2e0b10C9b928C8580Ac5Df02C7C7",
+  "0xb56c2f0b653b2e0b10c9b928c8580ac5df02c7c7",
   23930344
 );
 
@@ -22,7 +22,7 @@ export const AAVE_ORACLE_CONTRACT_ADDRESS = new OracleContract(
 export const CURVE_CALCULATIONS_ADDRESS = new OracleContract();
 
 export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x0a53FaDa2d943057C47A301D25a4D9b3B8e01e8E", 18003250),
+  new OracleContract("0x0a53fada2d943057c47a301d25a4d9b3b8e01e8e", 18003250),
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -30,7 +30,7 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506", 11256069), // SushiSwap
+  new OracleContract("0x1b02da8cb0d097eb8d57a175b88c7d8b47997506", 11256069), // SushiSwap
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -55,13 +55,13 @@ export const HARDCODED_STABLES: Address[] = [];
 export const USDC_TOKEN_DECIMALS = BigInt.fromI32(6);
 
 export const ETH_ADDRESS = Address.fromString(
-  "0x6983D1E6DEf3690C4d616b13597A09e6193EA013"
+  "0x6983d1e6def3690c4d616b13597a09e6193ea013"
 );
 export const WETH_ADDRESS = Address.fromString(
-  "0xcF664087a5bB0237a0BAd6742852ec6c8d69A27a"
+  "0xcf664087a5bb0237a0bad6742852ec6c8d69a27a"
 );
 export const USDC_ADDRESS = Address.fromString(
-  "0x985458E523dB3d53125813eD68c274899e9DfAb4"
+  "0x985458e523db3d53125813ed68c274899e9dfab4"
 );
 
 export class config implements Configurations {

--- a/subgraphs/_reference_/src/prices/config/mainnet.ts
+++ b/subgraphs/_reference_/src/prices/config/mainnet.ts
@@ -12,12 +12,12 @@ export const YEARN_LENS_CONTRACT_ADDRESS = new OracleContract(
   12242339
 );
 export const CHAIN_LINK_CONTRACT_ADDRESS = new OracleContract(
-  "0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf",
+  "0x47fb2585d2c56fe188d0e6ec628a38b74fceeedf",
   12864088
 );
 export const AAVE_ORACLE_CONTRACT_ADDRESS = new OracleContract();
 export const SUSHISWAP_CALCULATIONS_ADDRESS = new OracleContract(
-  "0x8263e161A855B644f582d9C164C66aABEe53f927",
+  "0x8263e161a855b644f582d9c164c66aabee53f927",
   12692284
 );
 
@@ -26,13 +26,13 @@ export const SUSHISWAP_CALCULATIONS_ADDRESS = new OracleContract(
 ///////////////////////////////////////////////////////////////////////////
 
 export const CURVE_CALCULATIONS_ADDRESS = new OracleContract(
-  "0x25BF7b72815476Dd515044F9650Bf79bAd0Df655",
+  "0x25bf7b72815476dd515044f9650bf79bad0df655",
   12370088
 );
 
 export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x7D86446dDb609eD0F5f8684AcF30380a356b2B4c", 11154794),
-  new OracleContract("0x8F942C20D02bEfc377D41445793068908E2250D0", 13986752),
+  new OracleContract("0x7d86446ddb609ed0f5f8684acf30380a356b2b4c", 11154794),
+  new OracleContract("0x8f942c20d02befc377d41445793068908e2250d0", 13986752),
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -40,7 +40,7 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
-  new OracleContract("0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F", 10794261), // SushiSwap
+  new OracleContract("0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f", 10794261), // SushiSwap
   new OracleContract("0x7a250d5630b4cf539739df2c5dacb4c659f2488d", 10207858), // Uniswap
 ];
 
@@ -102,7 +102,7 @@ export const HARDCODED_STABLES: Address[] = [
 export const USDC_TOKEN_DECIMALS = BigInt.fromI32(6);
 
 export const ETH_ADDRESS = Address.fromString(
-  "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 );
 export const WETH_ADDRESS = Address.fromString(
   "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"

--- a/subgraphs/_reference_/src/prices/config/moonbeam.ts
+++ b/subgraphs/_reference_/src/prices/config/moonbeam.ts
@@ -19,7 +19,7 @@ export const SUSHISWAP_CALCULATIONS_ADDRESS = new OracleContract();
 export const CURVE_CALCULATIONS_ADDRESS = new OracleContract();
 
 export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
-  new OracleContract("0xC2b1DF84112619D190193E48148000e3990Bf627", 1452049),
+  new OracleContract("0xc2b1df84112619d190193e48148000e3990bf627", 1452049),
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -27,7 +27,7 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x445FE580eF8d70FF569aB36e80c647af338db351", 503734), // SushiSwap
+  new OracleContract("0x445fe580ef8d70ff569ab36e80c647af338db351", 503734), // SushiSwap
 ];
 
 ///////////////////////////////////////////////////////////////////////////

--- a/subgraphs/_reference_/src/prices/config/optimism.ts
+++ b/subgraphs/_reference_/src/prices/config/optimism.ts
@@ -13,7 +13,7 @@ export const YEARN_LENS_CONTRACT_ADDRESS = new OracleContract(
 );
 export const CHAIN_LINK_CONTRACT_ADDRESS = new OracleContract();
 export const AAVE_ORACLE_CONTRACT_ADDRESS = new OracleContract(
-  "0xD81eb3728a631871a7eBBaD631b5f424909f0c77",
+  "0xd81eb3728a631871a7ebbad631b5f424909f0c77",
   4365625
 );
 export const SUSHISWAP_CALCULATIONS_ADDRESS = new OracleContract(
@@ -31,8 +31,8 @@ export const CURVE_CALCULATIONS_ADDRESS = new OracleContract(
 );
 
 export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
-  new OracleContract("0xC5cfaDA84E902aD92DD40194f0883ad49639b023", 2373837),
-  new OracleContract("0x445FE580eF8d70FF569aB36e80c647af338db351", 3729171),
+  new OracleContract("0xc5cfada84e902ad92dd40194f0883ad49639b023", 2373837),
+  new OracleContract("0x445fe580ef8d70ff569ab36e80c647af338db351", 3729171),
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -40,7 +40,7 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x9c12939390052919aF3155f41Bf4160Fd3666A6f", 19702709), // Velodrame
+  new OracleContract("0x9c12939390052919af3155f41bf4160fd3666a6f", 19702709), // Velodrame
 ];
 ///////////////////////////////////////////////////////////////////////////
 /////////////////////////// BLACKLISTED TOKENS ////////////////////////////

--- a/subgraphs/_reference_/src/prices/config/polygon.ts
+++ b/subgraphs/_reference_/src/prices/config/polygon.ts
@@ -12,7 +12,7 @@ export const CHAIN_LINK_CONTRACT_ADDRESS = new OracleContract();
 export const SUSHISWAP_CALCULATIONS_ADDRESS = new OracleContract();
 
 export const AAVE_ORACLE_CONTRACT_ADDRESS = new OracleContract(
-  "0xb023e699F5a33916Ea823A16485e259257cA8Bd1",
+  "0xb023e699f5a33916ea823a16485e259257ca8bd1",
   25825996
 );
 
@@ -23,8 +23,8 @@ export const AAVE_ORACLE_CONTRACT_ADDRESS = new OracleContract(
 export const CURVE_CALCULATIONS_ADDRESS = new OracleContract();
 
 export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
-  new OracleContract("0x094d12e5b541784701FD8d65F11fc0598FBC6332", 13991825),
-  new OracleContract("0x47bB542B9dE58b970bA50c9dae444DDB4c16751a", 23556360),
+  new OracleContract("0x094d12e5b541784701fd8d65f11fc0598fbc6332", 13991825),
+  new OracleContract("0x47bb542b9de58b970ba50c9dae444ddb4c16751a", 23556360),
 ];
 
 ///////////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@ export const CURVE_REGISTRY_ADDRESSES: OracleContract[] = [
 
 export const UNISWAP_FORKS_ROUTER_ADDRESSES: OracleContract[] = [
   new OracleContract("0xa5e0829caced8ffdd4de3c43696c57f7d7a678ff", 4931900), // QuickSwap
-  new OracleContract("0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506", 11333235), // SushiSwap
+  new OracleContract("0x1b02da8cb0d097eb8d57a175b88c7d8b47997506", 11333235), // SushiSwap
 ];
 
 ///////////////////////////////////////////////////////////////////////////

--- a/subgraphs/_reference_/src/sdk/util/constants.ts
+++ b/subgraphs/_reference_/src/sdk/util/constants.ts
@@ -154,7 +154,7 @@ export namespace UsageType {
 //////////////////////////////
 
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-export const ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+export const ETH_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
 ////////////////////////
 ///// Type Helpers /////


### PR DESCRIPTION

Made all addresses in price-lib and SDK lowercase so that when using them in our subgraphs they don’t break the linter.