### PR TITLE
fix (#minor); makerdao; fixed inaccurate TVL

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3112,7 +3112,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "2.0.2",
+          "subgraph": "2.1.0",
           "methodology": "1.1.0"
         },
         "files": {

--- a/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
+++ b/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
@@ -1,5 +1,5 @@
 {
-  "graftEnabled": false,
-  "subgraphId": "Qmb5N7F76ARWsfRVrR7iT96v5aCcLYRcNyBXxkKP4t1iYy",
-  "graftStartBlock": 16126312
+  "graftEnabled": true,
+  "subgraphId": "QmTJScYCuTsFxkWnAw8vrh51w1bEfFRJbZEiKk9cpb524R",
+  "graftStartBlock": 16674408
 }

--- a/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
+++ b/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
@@ -1,5 +1,5 @@
 {
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "Qmb5N7F76ARWsfRVrR7iT96v5aCcLYRcNyBXxkKP4t1iYy",
   "graftStartBlock": 16126312
 }

--- a/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
+++ b/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
@@ -48,6 +48,10 @@ dataSources:
         ### CDP Manipulation ###
         # function frob(bytes32 i, address u, address v, address w, int256 dink, int256 dart)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
+          topic0: "0x7cdd3fde00000000000000000000000000000000000000000000000000000000"
+          handler: handleVatSlip
+        # function frob(bytes32 i, address u, address v, address w, int256 dink, int256 dart)
+        - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x7608870300000000000000000000000000000000000000000000000000000000"
           handler: handleVatFrob
         # function fork( bytes32 ilk, address src, address dst, int256 dink, int256 dart)
@@ -58,7 +62,7 @@ dataSources:
         # function fold(bytes32 i, address u, int256 rate)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0xb65337df00000000000000000000000000000000000000000000000000000000"
-          handler: handleVatFold
+          handler: handleVatFold  
 
   # Borrow rate
   - name: Jug

--- a/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
+++ b/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
@@ -48,10 +48,6 @@ dataSources:
         ### CDP Manipulation ###
         # function frob(bytes32 i, address u, address v, address w, int256 dink, int256 dart)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
-          topic0: "0x7cdd3fde00000000000000000000000000000000000000000000000000000000"
-          handler: handleVatSlip
-        # function frob(bytes32 i, address u, address v, address w, int256 dink, int256 dart)
-        - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x7608870300000000000000000000000000000000000000000000000000000000"
           handler: handleVatFrob
         # function fork( bytes32 ilk, address src, address dst, int256 dink, int256 dart)

--- a/subgraphs/makerdao/schema.graphql
+++ b/subgraphs/makerdao/schema.graphql
@@ -1299,6 +1299,8 @@ type _FlipBidsStore @entity {
   bid: BigInt!
   " Is the auction ended "
   ended: Boolean
+  " Liquidated Position Ids"
+  positions: [Position!]
 }
 
 # Helper entity for liquidate transaction (Clip contract)
@@ -1322,6 +1324,8 @@ type _ClipTakeStore @entity {
   tab: BigInt!
   " amount of debt to be repaid "
   tab0: BigInt
+  " Liquidated Position Ids"
+  positions: [Position!]
 }
 
 # Helper entity for calculating supply side revenue

--- a/subgraphs/makerdao/schema.graphql
+++ b/subgraphs/makerdao/schema.graphql
@@ -1369,3 +1369,32 @@ type _PositionCounter @entity {
   " Next count "
   nextCount: Int!
 }
+
+type _TokenInOut @entity {
+  " tx hash-logIndex "
+  id: ID!
+  ilk: String!
+  block: BigInt!
+  handler: String!
+  token: String!
+  urn: String
+  v: String
+  w: String
+  amount: BigInt!
+  inputTokenBalance_: BigInt!
+  onChainWETHBalance: BigInt!
+}
+
+type _gem @entity {
+  " ilk "
+  id: ID!
+  block: BigInt!
+  balance: BigInt!
+}
+
+type _gemSnapshot @entity {
+  " ilk-block# "
+  id: ID!
+  block: BigInt!
+  balance: BigInt!
+}

--- a/subgraphs/makerdao/src/common/helpers.ts
+++ b/subgraphs/makerdao/src/common/helpers.ts
@@ -7,7 +7,6 @@ import {
   Withdraw,
   Borrow,
   Repay,
-  Liquidate,
   Token,
   Position,
   PositionSnapshot,

--- a/subgraphs/makerdao/src/mapping.ts
+++ b/subgraphs/makerdao/src/mapping.ts
@@ -292,8 +292,9 @@ export function handleVatFrob(event: VatNoteEvent): void {
   const dink = bytesToSignedBigInt(extractCallData(event.params.data, 132, 164)); // change to collateral
   // 6th arg dart: start = 4 (signature) + 4 * 32, end = start + 32
   const dart = bytesToSignedBigInt(extractCallData(event.params.data, 164, 196)); // change to debt
-
-  log.info("[handleVatFrob]block#={}, ilk={}, u={}, v={}, w={}, dink={}, dart={}", [
+  const tx = event.transaction.hash.toHexString().concat("-").concat(event.transactionLogIndex.toString());
+  log.info("[handleVatFrob]tx {} block {}: ilk={}, u={}, v={}, w={}, dink={}, dart={}", [
+    tx,
     event.block.number.toString(),
     ilk.toString(),
     u,
@@ -304,7 +305,6 @@ export function handleVatFrob(event: VatNoteEvent): void {
   ]);
 
   const urn = u;
-  const tx = event.transaction.hash.toHexString();
   const migrationCaller = getMigrationCaller(u, v, w, event);
   if (migrationCaller != null && ilk.toString() == "SAI") {
     // Ignore vat.frob calls not of interest
@@ -337,6 +337,14 @@ export function handleVatFrob(event: VatNoteEvent): void {
   const token = getOrCreateToken(market.inputToken);
   const deltaCollateral = bigIntChangeDecimals(dink, WAD, token.decimals);
   const deltaCollateralUSD = bigIntToBDUseDecimals(deltaCollateral, token.decimals).times(token.lastPriceUSD!);
+
+  log.info("[handleVatFrob]tx {} block {}: token.decimals={}, deltaCollateral={}, deltaCollateralUSD={}", [
+    tx,
+    event.block.number.toString(),
+    token.decimals.toString(),
+    deltaCollateral.toString(),
+    deltaCollateralUSD.toString(),
+  ]);
 
   market.inputTokenPriceUSD = token.lastPriceUSD!;
   // change in borrowing amount
@@ -812,6 +820,7 @@ export function handleFlipEndAuction(event: FlipNoteEvent): void {
   const ilk = Bytes.fromHexString(flipBidsStore.ilk);
   const urn = flipBidsStore.urn;
   const sides = [PositionSide.LENDER, PositionSide.BORROWER];
+  //TODO: remove
   log.info("[]txhash={}", [event.transaction.hash.toHexString()]);
   for (let si = 0; si <= 1; si++) {
     const side = sides[si];

--- a/subgraphs/makerdao/src/mapping.ts
+++ b/subgraphs/makerdao/src/mapping.ts
@@ -269,7 +269,11 @@ export function handleVatSlip(event: VatNoteEvent): void {
   }
   //let usr = bytes32ToAddressHexString(event.params.arg2);
   const wad = bytesToSignedBigInt(event.params.arg3);
-  const market: Market = getMarketFromIlk(ilk)!;
+  const market = getMarketFromIlk(ilk);
+  if (!market) {
+    log.warning("[handleVatSlip]Failed to get market for ilk {}/{}", [ilk.toString(), ilk.toHexString()]);
+    return;
+  }
 
   const urn = bytes32ToAddressHexString(event.params.arg2);
   logTokenInOut(ilk, market, wad, event, "slip", urn);


### PR DESCRIPTION
This PR fixes inaccurate TVL/inputTokenBalance in maker markets, esp. ETH-A and ETH-B, as reported in #1695 . Basically, a refactoring I did to consolidate handlers causes liquidated collateral not removed from TVL. To fix this, I moved liquidatePosition call up to `Cat.Bite()` and `Dog.Bark()` when liquidation auction was first set up, from when liquidation auction ends (`handleFlipEndAuction()` and `handleClipTakeBid()`).

### Deployment & validation (sync in progress)
- test deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/makerdao-ethereum?version=pending&selected=logs
- validation dashboard: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/id/QmdWkF7LsHEq88hrMAMHdoCeNxLyzSqNZdd2qyHiCCpCXQ&tab=protocol