### PR TITLE
chore(); comp v2; remove bad deployment ID

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1332,10 +1332,6 @@
           "hosted-service": {
             "slug": "compound-v2-ethereum",
             "query-id": "compound-v2-ethereum"
-          },
-          "decentralized-network": {
-            "slug": "compound-v2-ethereum",
-            "query-id": "6tGbL7WBx287EZwGUvvcQdL6m67JGMJrma3JSTtt5SV7"
           }
         }
       }


### PR DESCRIPTION
Until Compound V2 is fully synced on the decentralized network we want to ingest data from the hosted service subgraph to reduce downtime.