### PR TITLE
fix(#major); rpl; fix oneshot

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -56,6 +56,8 @@ There are two use cases for `schemaVersion`:
 
 The field `subgraphVersion` this is mainly used for the specific subgraph developer to keep track the implementation. For example, if there is a major refactor, we should bump this version, but this has nothing to do with the schema and will no impact on downstream consumers. There may also be repository-wide implementation upgrades. For example, we might need to reimplement everything in Rust somewhere down the road (for substream upgrades), they it'll be a major upgrade on the implementation (major version bump) but again, no impact on schema or downstream consumer.
 
+> Read more about how to upgrade schema version in [`./CONTIBUTING.md`](CONTRIBUTING.md)
+
 ### Methodology Version
 
 The field `methodologyVersion` is mainly used for data consumers to track how we calculate our metrics, and to which version of the code/subgraph that methodology corresponds to. For example, if Yahoo Finance uses our data and wants to know when we changed the definition of TVL, this is the best way to diff against that. With a single version, you can't immediately tell if the methodology has been changed
@@ -209,3 +211,15 @@ In general, feel free to add extra entities that tracks the internal state of th
 Make sure these changes are **strictly** additive. If you need to **modify** existing entities, please let me know and we can go through it together.
 
 When adding entities, make sure you document them with comments in your schema. User-facing comments should be done in double quotes and developer-facing comments should be done with hash tags.
+
+## Immutable Field Assumptions
+
+There are some fields that we (and subgraph consumers) are going to expect to be immutable. There are technical limitations as to why we cannot force this on a subgraph level, but we want to be very cautious when we change these fields in `prod` subgraphs especially.
+
+Scenario: We expect the `market.id` field to not change on deployments, and a DB ingesting our subgraph will expect this to be the case. But then we change `market.id` and the DB thinks there is a new `market` when in actuality, we just updated the identifier.
+
+In general you should not change the following fields across deployments before consulting with the downstream users:
+
+- IDs
+- Names (market names, protocol names, etc.)
+- Static protocol/market metadata

--- a/subgraphs/rocket-pool/protocols/rocket-pool/config/deployments/rocket-pool-ethereum/configurations.json
+++ b/subgraphs/rocket-pool/protocols/rocket-pool/config/deployments/rocket-pool-ethereum/configurations.json
@@ -1,1 +1,5 @@
-{}
+{
+  "graftEnabled": true,
+  "subgraphId": "QmPD7QiavdnvW61CAAcjn6LwvvHKQUR1UvWmBQaWPPpFUc",
+  "graftStartBlock": 16606175
+}

--- a/subgraphs/rocket-pool/protocols/rocket-pool/config/templates/rocket-pool.template.yaml
+++ b/subgraphs/rocket-pool/protocols/rocket-pool/config/templates/rocket-pool.template.yaml
@@ -1,6 +1,14 @@
 specVersion: 0.0.5
 schema:
   file: ./schema.graphql
+{{#graftEnabled}}
+description: ...
+features:
+  - grafting
+graft:
+  base: {{subgraphId}} # Subgraph ID of base subgraph
+  block: {{graftStartBlock}} # Block number
+{{/graftEnabled}}
 dataSources:
   - kind: ethereum/contract
     name: rocketTokenRETH
@@ -95,6 +103,8 @@ dataSources:
       eventHandlers:
         - event: BalancesUpdated(uint256,uint256,uint256,uint256,uint256)
           handler: handleBalancesUpdated
+        - event: BalancesSubmitted(indexed address,uint256,uint256,uint256,uint256,uint256)
+          handler: handleBalancesSubmitted
       file: ./src/mappings/rocketNetworkBalancesMapping.ts
 
   - kind: ethereum/contract

--- a/subgraphs/rocket-pool/src/mappings/rocketNetworkBalancesMapping.ts
+++ b/subgraphs/rocket-pool/src/mappings/rocketNetworkBalancesMapping.ts
@@ -29,6 +29,74 @@ import {
 import { bigIntToBigDecimal } from "../utils/numbers";
 import { BIGINT_SIXTEEN, BIGINT_THIRTYTWO } from "../utils/constants";
 
+export function handleBalancesSubmitted(event: BalancesUpdated): void {
+  let protocol = generalUtilities.getRocketPoolProtocolEntity();
+  if (!protocol) {
+    protocol = rocketPoolEntityFactory.createRocketPoolProtocol();
+  }
+  if (!protocol) return;
+  const rETHContract = rocketTokenRETH.bind(
+    Address.fromString(ROCKET_TOKEN_RETH_CONTRACT_ADDRESS)
+  );
+  const rocketDepositPoolContract = rocketDepositPool.bind(
+    Address.fromString(ROCKET_DEPOSIT_POOL_CONTRACT_ADDRESS)
+  );
+  const depositPoolExcessBalance = rocketDepositPoolContract.getExcessBalance();
+
+  const depositPoolBalance = rocketDepositPoolContract.getBalance();
+  const stakerETHInRocketETHContract = getRocketETHBalance(
+    depositPoolExcessBalance,
+    rETHContract.getTotalCollateral()
+  );
+  const rETHExchangeRate = rETHContract.getExchangeRate();
+
+  const checkpoint =
+    rocketPoolEntityFactory.createNetworkStakerBalanceCheckpoint(
+      generalUtilities.extractIdForEntity(event),
+      protocol.lastNetworkStakerBalanceCheckPoint,
+      event,
+      depositPoolBalance,
+      stakerETHInRocketETHContract,
+      rETHExchangeRate
+    );
+  if (checkpoint === null) return;
+
+  const previousCheckpointId = protocol.lastNetworkStakerBalanceCheckPoint;
+  let previousTotalStakerETHRewards = BigInt.fromI32(0);
+  let previousTotalStakersWithETHRewards = BigInt.fromI32(0);
+  let previousRETHExchangeRate = BigInt.fromI32(1);
+  let previousCheckpoint: NetworkStakerBalanceCheckpoint | null = null;
+  if (previousCheckpointId) {
+    previousCheckpoint =
+      NetworkStakerBalanceCheckpoint.load(previousCheckpointId);
+    if (previousCheckpoint) {
+      previousTotalStakerETHRewards = previousCheckpoint.totalStakerETHRewards;
+      previousTotalStakersWithETHRewards =
+        previousCheckpoint.totalStakersWithETHRewards;
+      previousRETHExchangeRate = previousCheckpoint.rETHExchangeRate;
+      previousCheckpoint.nextCheckpointId = checkpoint.id;
+    }
+  }
+  const balanceCheckpoint = NetworkNodeBalanceCheckpoint.load(
+    protocol.lastNetworkNodeBalanceCheckPoint!
+  );
+  const averageFeeForActiveMinipools =
+    balanceCheckpoint!.averageFeeForActiveMinipools;
+
+  // Handle the staker impact.
+  generateStakerBalanceCheckpoints(
+    event.block,
+    protocol.activeStakers,
+    checkpoint,
+    previousCheckpoint !== null ? previousCheckpoint : null,
+    previousRETHExchangeRate,
+    event.block.number,
+    event.block.timestamp,
+    protocol,
+    averageFeeForActiveMinipools
+  );
+}
+
 /**
  * When enough ODAO members votes on a balance and a consensus threshold is reached, the staker beacon chain state is persisted to the smart contracts.
  */
@@ -89,40 +157,40 @@ export function handleBalancesUpdated(event: BalancesUpdated): void {
   if (checkpoint === null) return;
 
   // Retrieve previous checkpoint.
-  const previousCheckpointId = protocol.lastNetworkStakerBalanceCheckPoint;
+  // const previousCheckpointId = protocol.lastNetworkStakerBalanceCheckPoint;
   let previousTotalStakerETHRewards = BigInt.fromI32(0);
   let previousTotalStakersWithETHRewards = BigInt.fromI32(0);
-  let previousRETHExchangeRate = BigInt.fromI32(1);
+  // let previousRETHExchangeRate = BigInt.fromI32(1);
   let previousCheckpoint: NetworkStakerBalanceCheckpoint | null = null;
-  if (previousCheckpointId) {
-    previousCheckpoint =
-      NetworkStakerBalanceCheckpoint.load(previousCheckpointId);
-    if (previousCheckpoint) {
-      previousTotalStakerETHRewards = previousCheckpoint.totalStakerETHRewards;
-      previousTotalStakersWithETHRewards =
-        previousCheckpoint.totalStakersWithETHRewards;
-      previousRETHExchangeRate = previousCheckpoint.rETHExchangeRate;
-      previousCheckpoint.nextCheckpointId = checkpoint.id;
-    }
-  }
+  // if (previousCheckpointId) {
+  //   previousCheckpoint =
+  //     NetworkStakerBalanceCheckpoint.load(previousCheckpointId);
+  //   if (previousCheckpoint) {
+  //     previousTotalStakerETHRewards = previousCheckpoint.totalStakerETHRewards;
+  //     previousTotalStakersWithETHRewards =
+  //       previousCheckpoint.totalStakersWithETHRewards;
+  //     previousRETHExchangeRate = previousCheckpoint.rETHExchangeRate;
+  //     previousCheckpoint.nextCheckpointId = checkpoint.id;
+  //   }
+  // }
   const balanceCheckpoint = NetworkNodeBalanceCheckpoint.load(
     protocol.lastNetworkNodeBalanceCheckPoint!
   );
-  const averageFeeForActiveMinipools =
-    balanceCheckpoint!.averageFeeForActiveMinipools;
+  // const averageFeeForActiveMinipools =
+  //   balanceCheckpoint!.averageFeeForActiveMinipools;
 
   // Handle the staker impact.
-  generateStakerBalanceCheckpoints(
-    event.block,
-    protocol.activeStakers,
-    checkpoint,
-    previousCheckpoint !== null ? previousCheckpoint : null,
-    previousRETHExchangeRate,
-    event.block.number,
-    event.block.timestamp,
-    protocol,
-    averageFeeForActiveMinipools
-  );
+  // generateStakerBalanceCheckpoints(
+  //   event.block,
+  //   protocol.activeStakers,
+  //   checkpoint,
+  //   previousCheckpoint !== null ? previousCheckpoint : null,
+  //   previousRETHExchangeRate,
+  //   event.block.number,
+  //   event.block.timestamp,
+  //   protocol,
+  //   averageFeeForActiveMinipools
+  // );
 
   // If for some reason the running summary totals up to this checkpoint was 0, then we try to set it based on the previous checkpoint.
   if (checkpoint.totalStakerETHRewards == BigInt.fromI32(0)) {
@@ -216,7 +284,7 @@ function generateStakerBalanceCheckpoints(
   // Loop through all the staker id's in the protocol.
   for (let index = 0; index < activeStakerIds.length; index++) {
     // Determine current staker ID.
-    const stakerId = <string>activeStakerIds[index];
+    const stakerId = activeStakerIds[index];
     if (stakerId == null || stakerId == ZERO_ADDRESS_STRING) continue;
 
     // Load the indexed staker.
@@ -227,7 +295,7 @@ function generateStakerBalanceCheckpoints(
 
     // Get the current & previous balances for this staker and update the staker balance for the current exchange rate.
     const stakerBalance = stakerUtilities.getStakerBalance(
-      <Staker>staker,
+      staker,
       networkCheckpoint.rETHExchangeRate
     );
     staker.ethBalance = stakerBalance.currentETHBalance;
@@ -243,7 +311,7 @@ function generateStakerBalanceCheckpoints(
       );
     stakerUtilities.handleEthRewardsSincePreviousCheckpoint(
       ethRewardsSincePreviousCheckpoint,
-      <Staker>staker,
+      staker,
       networkCheckpoint,
       protocol
     );


### PR DESCRIPTION
Issue: we are getting a onesot called error on rocket pool sugraph. This is usually caused by excess memory usage. the handler `handleBalanceChanged()` is likely the cultprit with lengthy logic, contract calls, and a for loop through a large array.