### PR TITLE
feat (); bridge sdk; support non-evm addresses for transfer and token

### DIFF
--- a/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
@@ -158,7 +158,7 @@ export class Account {
   transferOut(
     pool: Pool,
     route: PoolRoute,
-    destination: Address,
+    destination: Bytes,
     amount: BigInt,
     transactionID: Bytes | null = null,
     updateMetrics: boolean = true
@@ -190,7 +190,7 @@ export class Account {
   transferIn(
     pool: Pool,
     route: PoolRoute,
-    source: Address,
+    source: Bytes,
     amount: BigInt,
     transactionID: Bytes | null = null,
     updateMetrics: boolean = true
@@ -210,7 +210,7 @@ export class Account {
   private transfer(
     pool: Pool,
     route: PoolRoute,
-    counterparty: Address,
+    counterparty: Bytes,
     amount: BigInt,
     isOutgoing: boolean,
     transactionID: Bytes | null,

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
@@ -145,17 +145,17 @@ export class Account {
 
   /**
    * Creates a BridgeTransfer entity for a transfer away from this chain
-   * and updates the volumes at PoolRoute, Pool and Protocol.
+   * to a non-EVM chain and updates the volumes at PoolRoute, Pool and Protocol.
    *
    * @param pool The pool the transfer was made on.
    * @param route The route the transfer went through.
-   * @param destination The account receiving the funds.
+   * @param destination The non-EVM account receiving the funds.
    * @param amount The amount of tokens transferred.
    * @param transactionID Optional transaction ID on the source chain.
    * @param updateMetrics Optional, defaults to true. If true, volumes will be updated at PoolRoute, Pool and Protocol. Make it false if you want to update these manually for some reason. Activity counts and transaction counts will still be updated.
    * @returns BridgeTransfer
    */
-  transferOut(
+  nonEVMTransferOut(
     pool: Pool,
     route: PoolRoute,
     destination: Bytes,
@@ -176,6 +176,70 @@ export class Account {
   }
 
   /**
+   * Creates a BridgeTransfer entity for a transfer away from this chain
+   * and updates the volumes at PoolRoute, Pool and Protocol.
+   *
+   * @param pool The pool the transfer was made on.
+   * @param route The route the transfer went through.
+   * @param destination The account receiving the funds.
+   * @param amount The amount of tokens transferred.
+   * @param transactionID Optional transaction ID on the source chain.
+   * @param updateMetrics Optional, defaults to true. If true, volumes will be updated at PoolRoute, Pool and Protocol. Make it false if you want to update these manually for some reason. Activity counts and transaction counts will still be updated.
+   * @returns BridgeTransfer
+   */
+  transferOut(
+    pool: Pool,
+    route: PoolRoute,
+    destination: Address,
+    amount: BigInt,
+    transactionID: Bytes | null = null,
+    updateMetrics: boolean = true
+  ): BridgeTransfer {
+    this.countTransferOut();
+    return this.transfer(
+      pool,
+      route,
+      destination,
+      amount,
+      true,
+      transactionID,
+      updateMetrics
+    );
+  }
+
+  /**
+   * Creates a BridgeTransfer entity for a transfer arriving to this chain
+   * from a non-EVM address and updates the volumes at PoolRoute, Pool and Protocol.
+   *
+   * @param pool The pool the transfer was made on.
+   * @param route The route the transfer went through.
+   * @param source The non-EVM account sending the funds.
+   * @param amount The amount of tokens transferred.
+   * @param transactionID Optional transaction ID on the source chain.
+   * @param updateMetrics Optional, defaults to true. If true, volumes will be updated at PoolRoute, Pool and Protocol. Make it false if you want to update these manually for some reason. Activity counts and transaction counts will still be updated.
+   * @returns BridgeTransfer
+   */
+  nonEVMTransferIn(
+    pool: Pool,
+    route: PoolRoute,
+    source: Bytes,
+    amount: BigInt,
+    transactionID: Bytes | null = null,
+    updateMetrics: boolean = true
+  ): BridgeTransfer {
+    this.countTransferIn();
+    return this.transfer(
+      pool,
+      route,
+      source,
+      amount,
+      false,
+      transactionID,
+      updateMetrics
+    );
+  }
+
+  /**
    * Creates a BridgeTransfer entity for a transfer arriving to this chain
    * and updates the volumes at PoolRoute, Pool and Protocol.
    *
@@ -190,7 +254,7 @@ export class Account {
   transferIn(
     pool: Pool,
     route: PoolRoute,
-    source: Bytes,
+    source: Address,
     amount: BigInt,
     transactionID: Bytes | null = null,
     updateMetrics: boolean = true

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/tokens.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/tokens.ts
@@ -10,7 +10,7 @@ import { Bridge } from "./protocol";
 import { RewardTokenType } from "../../util/constants";
 
 export interface TokenInitializer {
-  getTokenParams(address: Address): TokenParams;
+  getTokenParams(address: Bytes): TokenParams;
 }
 
 export interface TokenPresaver {
@@ -37,7 +37,7 @@ export class TokenManager {
     this.presaver = presaver;
   }
 
-  getOrCreateToken(address: Address): Token {
+  getOrCreateToken(address: Bytes): Token {
     let token = Token.load(address);
     if (token) {
       return token;
@@ -82,9 +82,9 @@ export class TokenManager {
 
   getOrCreateCrosschainToken(
     chainID: BigInt,
-    address: Address,
+    address: Bytes,
     type: string,
-    token: Address
+    token: Bytes
   ): CrosschainToken {
     const id = changetype<Bytes>(Bytes.fromBigInt(chainID)).concat(address);
     let ct = CrosschainToken.load(id);


### PR DESCRIPTION
Changed the type from Address to Bytes in transferIn, transferOut, and transfer, and token addresses, so non-EVM address can be supported.