### PR TITLE
feat(); deployment.json; Add project tag to the deployment.json

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3,6 +3,7 @@
     "schema": "lending",
     "base": "abracadabra",
     "protocol": "abracadabra",
+    "project": "abracadabra",
     "deployments": {
       "abracadabra-arbitrum": {
         "network": "arbitrum",
@@ -124,6 +125,7 @@
     "schema": "lending",
     "base": "aave-forks",
     "protocol": "aave-arc",
+    "project": "aave",
     "deployments": {
       "aave-arc-ethereum": {
         "network": "ethereum",
@@ -157,6 +159,7 @@
     "schema": "lending",
     "base": "aave-forks",
     "protocol": "aave-amm",
+    "project": "aave",
     "deployments": {
       "aave-amm-ethereum": {
         "network": "ethereum",
@@ -190,6 +193,7 @@
     "schema": "lending",
     "base": "aave-forks",
     "protocol": "aave-rwa",
+    "project": "aave",
     "deployments": {
       "aave-rwa-ethereum": {
         "network": "ethereum",
@@ -223,6 +227,7 @@
     "schema": "lending",
     "base": "aave-forks",
     "protocol": "aave-v2",
+    "project": "aave",
     "deployments": {
       "aave-v2-avalanche": {
         "network": "avalanche",
@@ -300,6 +305,7 @@
     "schema": "lending",
     "base": "aave-forks",
     "protocol": "aave-v3",
+    "project": "aave",
     "deployments": {
       "aave-v3-arbitrum": {
         "network": "arbitrum",
@@ -465,6 +471,7 @@
     "schema": "lending",
     "base": "alpaca-finance-lending",
     "protocol": "alpaca-finance-lending",
+    "project": "alpaca",
     "deployments": {
       "alpaca-finance-lending-bsc": {
         "network": "bsc",
@@ -516,6 +523,7 @@
     "schema": "yield-aggregator",
     "base": "arrakis-finance",
     "protocol": "arrakis-finance",
+    "project": "arrakis",
     "deployments": {
       "arrakis-finance-ethereum": {
         "network": "ethereum",
@@ -593,6 +601,7 @@
     "schema": "yield-aggregator",
     "base": "convex-finance",
     "protocol": "convex-finance",
+    "project": "convex",
     "deployments": {
       "convex-finance-ethereum": {
         "network": "ethereum",
@@ -626,6 +635,7 @@
     "schema": "dex-amm",
     "base": "balancer-forks",
     "protocol": "balancer-v2",
+    "project": "balancer",
     "deployments": {
       "balancer-v2-arbitrum": {
         "network": "arbitrum",
@@ -703,6 +713,7 @@
     "schema": "dex-amm",
     "base": "balancer-forks",
     "protocol": "beethoven-x",
+    "project": "balancer",
     "deployments": {
       "beethoven-x-fantom": {
         "network": "fantom",
@@ -754,6 +765,7 @@
     "schema": "yield-aggregator",
     "base": "beefy-finance",
     "protocol": "beefy-finance",
+    "project": "beefy",
     "deployments": {
       "beefy-finance-arbitrum": {
         "network": "arbitrum",
@@ -1046,7 +1058,7 @@
   "belt-finance": {
     "schema": "yield-aggregator",
     "base": "belt-finance",
-    "protocol": "belt-finance",
+    "protocol": "belt",
     "deployments": {
       "belt-finance-bsc": {
         "network": "bsc",
@@ -1076,6 +1088,7 @@
     "schema": "dex-amm",
     "base": "bancor-v3",
     "protocol": "bancor-v3",
+    "project": "bancor",
     "deployments": {
       "bancor-v3-ethereum": {
         "network": "ethereum",
@@ -1109,6 +1122,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "aurigami",
+    "project": "aurigami",
     "deployments": {
       "aurigami-aurora": {
         "network": "aurora",
@@ -1138,6 +1152,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "banker-joe",
+    "project": "banker-joe",
     "deployments": {
       "banker-joe-avalanche": {
         "network": "avalanche",
@@ -1167,6 +1182,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "tectonic",
+    "project": "tectonic",
     "deployments": {
       "tectonic-cronos": {
         "network": "cronos",
@@ -1196,6 +1212,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "bastion-protocol",
+    "project": "bastion-protocol",
     "deployments": {
       "bastion-protocol-aurora": {
         "network": "aurora",
@@ -1225,6 +1242,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "benqi",
+    "project": "benqi",
     "deployments": {
       "benqi-avalanche": {
         "network": "avalanche",
@@ -1254,6 +1272,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "biswap",
+    "project": "biswap",
     "deployments": {
       "biswap-bsc": {
         "network": "bsc",
@@ -1283,6 +1302,7 @@
     "schema": "lending",
     "base": "burrow",
     "protocol": "burrow",
+    "project": "burrow",
     "deployments": {
       "burrow-near": {
         "network": "near-mainnet",
@@ -1312,6 +1332,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "compound-v2",
+    "project": "compound",
     "deployments": {
       "compound-v2-ethereum": {
         "network": "ethereum",
@@ -1345,6 +1366,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "cream-finance",
+    "project": "cream",
     "deployments": {
       "cream-finance-arbitrum": {
         "network": "arbitrum",
@@ -1444,6 +1466,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "dforce",
+    "project": "dforce",
     "deployments": {
       "dforce-arbitrum": {
         "network": "arbitrum",
@@ -1587,6 +1610,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "iron-bank",
+    "project": "iron-bank",
     "deployments": {
       "iron-bank-avalanche": {
         "network": "avalanche",
@@ -1686,6 +1710,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "moonwell",
+    "project": "moonwell",
     "deployments": {
       "moonwell-moonbeam": {
         "network": "moonbeam",
@@ -1737,6 +1762,7 @@
     "schema": "lending",
     "base": "notional-finance",
     "protocol": "notional-finance",
+    "project": "notional",
     "deployments": {
       "notional-finance-ethereum": {
         "network": "ethereum",
@@ -1770,6 +1796,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "rari-fuse",
+    "project": "rari",
     "deployments": {
       "rari-fuse-arbitrum": {
         "network": "arbitrum",
@@ -1825,6 +1852,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "scream",
+    "project": "scream",
     "deployments": {
       "scream-fantom": {
         "network": "fantom",
@@ -1854,6 +1882,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "sonne-finance",
+    "project": "sonne",
     "deployments": {
       "sonne-finance-optimism": {
         "network": "optimism",
@@ -1883,6 +1912,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "venus",
+    "project": "venus",
     "deployments": {
       "venus-protocol-bsc": {
         "network": "bsc",
@@ -1912,6 +1942,7 @@
     "schema": "lending",
     "base": "compound-v3",
     "protocol": "compound-v3",
+    "project": "compound",
     "deployments": {
       "compound-v3-ethereum": {
         "network": "ethereum",
@@ -1941,6 +1972,7 @@
     "schema": "dex-amm",
     "base": "curve-finance",
     "protocol": "curve-finance",
+    "project": "curve",
     "deployments": {
       "curve-finance-arbitrum": {
         "network": "arbitrum",
@@ -2172,6 +2204,7 @@
     "schema": "dex-amm",
     "base": "ellipsis-finance",
     "protocol": "ellipsis-finance",
+    "project": "ellipsis",
     "deployments": {
       "ellipsis-finance-bsc": {
         "network": "bsc",
@@ -2201,6 +2234,7 @@
     "schema": "erc721",
     "base": "erc721-holders",
     "protocol": "erc721-holders",
+    "project": "erc721",
     "deployments": {
       "erc721-holders-ethereum": {
         "network": "ethereum",
@@ -2230,6 +2264,7 @@
     "schema": "erc721",
     "base": "erc721-metadata",
     "protocol": "erc721-metadata",
+    "project": "erc721",
     "deployments": {
       "erc721-metadata-ethereum": {
         "network": "ethereum",
@@ -2259,6 +2294,7 @@
     "schema": "lending",
     "base": "euler-finance",
     "protocol": "euler-finance",
+    "project": "euler",
     "deployments": {
       "euler-finance-ethereum": {
         "network": "ethereum",
@@ -2292,6 +2328,7 @@
     "schema": "lending",
     "base": "goldfinch",
     "protocol": "goldfinch",
+    "project": "goldfinch",
     "deployments": {
       "goldfinch-ethereum": {
         "network": "ethereum",
@@ -2325,6 +2362,7 @@
     "schema": "lending",
     "base": "inverse-finance",
     "protocol": "inverse-finance",
+    "project": "inverse",
     "deployments": {
       "inverse-finance-ethereum": {
         "network": "ethereum",
@@ -2358,6 +2396,7 @@
     "schema": "generic",
     "base": "lido",
     "protocol": "lido",
+    "project": "lido",
     "deployments": {
       "lido-ethereum": {
         "network": "ethereum",
@@ -2391,6 +2430,7 @@
     "schema": "lending",
     "base": "liquity",
     "protocol": "liquity",
+    "project": "liquity",
     "deployments": {
       "liquity-ethereum": {
         "network": "ethereum",
@@ -2424,6 +2464,7 @@
     "schema": "lending",
     "base": "vesta-finance",
     "protocol": "vesta-finance",
+    "project": "vesta",
     "deployments": {
       "vesta-finance-arbitrum": {
         "network": "arbitrum",
@@ -2453,6 +2494,7 @@
     "schema": "lending",
     "base": "truefi",
     "protocol": "truefi",
+    "project": "truefi",
     "deployments": {
       "truefi-ethereum": {
         "network": "ethereum",
@@ -2486,6 +2528,7 @@
     "schema": "network",
     "base": "network",
     "protocol": "arweave",
+    "project": "arweave",
     "deployments": {
       "arweave-mainnet": {
         "network": "arweave-mainnet",
@@ -2515,6 +2558,7 @@
     "schema": "network",
     "base": "network",
     "protocol": "cosmos",
+    "project": "cosmos",
     "deployments": {
       "cosmoshub": {
         "network": "cosmos",
@@ -2566,6 +2610,7 @@
     "schema": "network",
     "base": "network",
     "protocol": "evm",
+    "project": "evm",
     "deployments": {
       "evm-arbitrum": {
         "network": "arbitrum",
@@ -2929,6 +2974,7 @@
     "schema": "network",
     "base": "network",
     "protocol": "near",
+    "project": "near",
     "deployments": {
       "near-mainnet": {
         "network": "near-mainnet",
@@ -2958,6 +3004,7 @@
     "schema": "yield-aggregator",
     "base": "gamma-strategies",
     "protocol": "gamma-strategies",
+    "project": "gamma-strategies",
     "deployments": {
       "gamma-strategies-arbitrum": {
         "network": "arbitrum",
@@ -3057,6 +3104,7 @@
     "schema": "lending",
     "base": "makerdao",
     "protocol": "makerdao",
+    "project": "makerdao",
     "deployments": {
       "makerdao-ethereum": {
         "network": "ethereum",
@@ -3090,6 +3138,7 @@
     "schema": "lending",
     "base": "maple-finance",
     "protocol": "maple-finance",
+    "project": "maple-finance",
     "deployments": {
       "maple-finance-ethereum": {
         "network": "ethereum",
@@ -3123,6 +3172,7 @@
     "schema": "lending",
     "base": "maple-finance-v2",
     "protocol": "maple-finance-v2",
+    "project": "maple",
     "deployments": {
       "maple-finance-v2-ethereum": {
         "network": "ethereum",
@@ -3152,6 +3202,7 @@
     "schema": "lending",
     "base": "silo-finance",
     "protocol": "silo-finance",
+    "project": "silo",
     "deployments": {
       "silo-finance-ethereum": {
         "network": "ethereum",
@@ -3181,6 +3232,7 @@
     "schema": "lending",
     "base": "synthetix",
     "protocol": "synthetix",
+    "project": "synthetix",
     "deployments": {
       "synthetix-ethereum": {
         "network": "ethereum",
@@ -3232,6 +3284,7 @@
     "schema": "lending",
     "base": "morpho",
     "protocol": "morpho",
+    "project": "morpho",
     "deployments": {
       "morpho-aave-ethereum": {
         "network": "ethereum",
@@ -3283,6 +3336,7 @@
     "schema": "yield-aggregator",
     "base": "harvest-finance",
     "protocol": "harvest-finance",
+    "project": "harvest",
     "deployments": {
       "harvest-finance-ethereum": {
         "network": "ethereum",
@@ -3356,6 +3410,7 @@
     "schema": "yield-aggregator",
     "base": "ribbon-finance",
     "protocol": "ribbon-finance",
+    "project": "ribbon",
     "deployments": {
       "ribbon-finance-ethereum": {
         "network": "ethereum",
@@ -3407,6 +3462,7 @@
     "schema": "yield-aggregator",
     "base": "yield-yak",
     "protocol": "yield-yak",
+    "project": "yield-yak",
     "deployments": {
       "yield-yak-avalanche": {
         "network": "avalanche",
@@ -3436,6 +3492,7 @@
     "schema": "yield-aggregator",
     "base": "stakedao",
     "protocol": "stakedao",
+    "project": "stakedao",
     "deployments": {
       "stakedao-ethereum": {
         "network": "ethereum",
@@ -3465,6 +3522,7 @@
     "schema": "dex-amm",
     "base": "saddle-finance",
     "protocol": "saddle-finance",
+    "project": "saddle",
     "deployments": {
       "saddle-finance-arbitrum": {
         "network": "arbitrum",
@@ -3560,6 +3618,7 @@
     "schema": "lending",
     "base": "aave-forks",
     "protocol": "geist-finance",
+    "project": "geist",
     "deployments": {
       "geist-finance-fantom": {
         "network": "fantom",
@@ -3589,6 +3648,7 @@
     "schema": "lending",
     "base": "aave-forks",
     "protocol": "radiant-capital",
+    "project": "radiant",
     "deployments": {
       "radiant-capital-arbitrum": {
         "network": "arbitrum",
@@ -3618,6 +3678,7 @@
     "schema": "lending",
     "base": "aave-forks",
     "protocol": "uwu-lend",
+    "project": "uwu",
     "deployments": {
       "uwu-lend-ethereum": {
         "network": "ethereum",
@@ -3651,6 +3712,7 @@
     "schema": "yield-aggregator",
     "base": "tokemak",
     "protocol": "tokemak",
+    "project": "tokemak",
     "deployments": {
       "tokemak-ethereum": {
         "network": "ethereum",
@@ -3680,6 +3742,7 @@
     "schema": "dex-amm",
     "base": "uniswap-v3",
     "protocol": "uniswap-v3",
+    "project": "uniswap",
     "deployments": {
       "uniswap-v3-arbitrum": {
         "network": "arbitrum",
@@ -3801,6 +3864,7 @@
     "schema": "dex-amm",
     "base": "osmosis-dex",
     "protocol": "osmosis-dex",
+    "project": "osmosis",
     "deployments": {
       "osmosis-dex-osmosis": {
         "network": "osmosis",
@@ -3830,6 +3894,7 @@
     "schema": "lending",
     "base": "qidao",
     "protocol": "qidao",
+    "project": "qidao",
     "deployments": {
       "qidao-arbitrum": {
         "network": "arbitrum",
@@ -4065,6 +4130,7 @@
     "schema": "yield-aggregator",
     "base": "rari-vaults",
     "protocol": "rari-vaults",
+    "project": "rari",
     "deployments": {
       "rari-vaults-ethereum": {
         "network": "ethereum",
@@ -4098,6 +4164,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "apeswap",
+    "project": "apeswap",
     "deployments": {
       "apeswap-bsc": {
         "network": "bsc",
@@ -4149,6 +4216,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "mm-finance",
+    "project": "mm",
     "deployments": {
       "mm-finance-polygon": {
         "network": "polygon",
@@ -4200,6 +4268,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "quickswap",
+    "project": "quickswap",
     "deployments": {
       "quickswap-polygon": {
         "network": "polygon",
@@ -4229,6 +4298,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "solarbeam",
+    "project": "solarbeam",
     "deployments": {
       "solarbeam-moonriver": {
         "network": "moonriver",
@@ -4258,6 +4328,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "spiritswap",
+    "project": "spiritswap",
     "deployments": {
       "spiritswap-fantom": {
         "network": "fantom",
@@ -4287,6 +4358,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "spookyswap",
+    "project": "spookyswap",
     "deployments": {
       "spookyswap-fantom": {
         "network": "fantom",
@@ -4316,6 +4388,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "sushiswap",
+    "project": "sushiswap",
     "deployments": {
       "sushiswap-arbitrum": {
         "network": "arbitrum",
@@ -4595,6 +4668,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "trader-joe",
+    "project": "joe",
     "deployments": {
       "trader-joe-avalanche": {
         "network": "avalanche",
@@ -4653,6 +4727,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "ubeswap",
+    "project": "ubeswap",
     "deployments": {
       "ubeswap-celo": {
         "network": "celo",
@@ -4682,6 +4757,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "uniswap-v2",
+    "project": "uniswap",
     "deployments": {
       "uniswap-v2-ethereum": {
         "network": "ethereum",
@@ -4711,6 +4787,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "vvs-finance",
+    "project": "vvs",
     "deployments": {
       "vvs-finance-cronos": {
         "network": "cronos",
@@ -4740,6 +4817,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "honeyswap",
+    "project": "honeyswap",
     "deployments": {
       "honeyswap-gnosis": {
         "network": "gnosis",
@@ -4795,6 +4873,7 @@
     "schema": "dex-amm",
     "base": "velodrome-finance",
     "protocol": "velodrome-finance",
+    "project": "velodrome",
     "deployments": {
       "velodrome-finance-optimism": {
         "network": "optimism",
@@ -4824,6 +4903,7 @@
     "schema": "yield-aggregator",
     "base": "yearn-v2",
     "protocol": "yearn-v2",
+    "project": "yearn",
     "deployments": {
       "yearn-v2-arbitrum": {
         "network": "arbitrum",
@@ -4901,6 +4981,7 @@
     "schema": "governance",
     "base": "maker-governance",
     "protocol": "maker-governance",
+    "project": "maker",
     "deployments": {
       "maker-governance-ethereum": {
         "network": "ethereum",
@@ -4930,6 +5011,7 @@
     "schema": "governance",
     "base": "aave-governance",
     "protocol": "aave-governance",
+    "project": "aave",
     "deployments": {
       "aave-governance-ethereum": {
         "network": "ethereum",
@@ -4959,6 +5041,7 @@
     "schema": "governance",
     "base": "aave-governance",
     "protocol": "dydx-governance",
+    "project": "dydx",
     "deployments": {
       "dydx-governance-ethereum": {
         "network": "ethereum",
@@ -4988,6 +5071,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "angle-governance",
+    "project": "angle",
     "deployments": {
       "angle-governance-ethereum": {
         "network": "ethereum",
@@ -5017,6 +5101,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "code4rena-governance",
+    "project": "code4rena",
     "deployments": {
       "code4rena-governance-polygon": {
         "network": "polygon",
@@ -5046,6 +5131,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "ens-governance",
+    "project": "ens",
     "deployments": {
       "ens-governance-ethereum": {
         "network": "ethereum",
@@ -5079,6 +5165,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "euler-governance",
+    "project": "euler",
     "deployments": {
       "euler-governance-ethereum": {
         "network": "ethereum",
@@ -5112,6 +5199,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "fei-governance",
+    "project": "fei",
     "deployments": {
       "fei-governance-ethereum": {
         "network": "ethereum",
@@ -5141,6 +5229,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "hop-governance",
+    "project": "hop",
     "deployments": {
       "hop-governance-ethereum": {
         "network": "ethereum",
@@ -5174,6 +5263,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "silo-governance",
+    "project": "silo",
     "deployments": {
       "silo-governance-ethereum": {
         "network": "ethereum",
@@ -5207,6 +5297,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "truefi-governance",
+    "project": "truefi",
     "deployments": {
       "truefi-governance-ethereum": {
         "network": "ethereum",
@@ -5240,6 +5331,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "unlock-governance",
+    "project": "unlock",
     "deployments": {
       "unlock-governance-ethereum": {
         "network": "ethereum",
@@ -5273,6 +5365,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "rarible-governance",
+    "project": "rarible",
     "deployments": {
       "rarible-governance-ethereum": {
         "network": "ethereum",
@@ -5302,6 +5395,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "ousd-governance",
+    "project": "ousd",
     "deployments": {
       "ousd-governance-ethereum": {
         "network": "ethereum",
@@ -5331,6 +5425,7 @@
     "schema": "governance",
     "base": "openzeppelin-governor",
     "protocol": "threshold-governance",
+    "project": "threshold",
     "deployments": {
       "threshold-governance-ethereum": {
         "network": "ethereum",
@@ -5360,6 +5455,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "ampleforth-governance",
+    "project": "ampleforth",
     "deployments": {
       "ampleforth-governance-ethereum": {
         "network": "ethereum",
@@ -5389,6 +5485,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "compound-governance",
+    "project": "compound",
     "deployments": {
       "compound-governance-ethereum": {
         "network": "ethereum",
@@ -5418,6 +5515,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "compound-governance-v1",
+    "project": "compound",
     "deployments": {
       "compound-governance-v1-ethereum": {
         "network": "ethereum",
@@ -5447,6 +5545,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "cryptex-governance",
+    "project": "cryptex",
     "deployments": {
       "cryptex-governance-ethereum": {
         "network": "ethereum",
@@ -5476,6 +5575,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "gitcoin-governance",
+    "project": "gitcoin",
     "deployments": {
       "gitcoin-governance-ethereum": {
         "network": "ethereum",
@@ -5505,6 +5605,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "idle-governance",
+    "project": "idle",
     "deployments": {
       "idle-governance-ethereum": {
         "network": "ethereum",
@@ -5534,6 +5635,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "idle-governance-v1",
+    "project": "idle",
     "deployments": {
       "idle-governance-v1-ethereum": {
         "network": "ethereum",
@@ -5563,6 +5665,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "indexed-governance",
+    "project": "indexed",
     "deployments": {
       "indexed-governance-ethereum": {
         "network": "ethereum",
@@ -5592,6 +5695,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "lilnouns-governance",
+    "project": "lilnouns",
     "deployments": {
       "lilnouns-governance-ethereum": {
         "network": "ethereum",
@@ -5621,6 +5725,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "nouns-governance",
+    "project": "nouns",
     "deployments": {
       "nouns-governance-ethereum": {
         "network": "ethereum",
@@ -5650,6 +5755,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "ooki-governance",
+    "project": "ooki",
     "deployments": {
       "ooki-governance-ethereum": {
         "network": "ethereum",
@@ -5679,6 +5785,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "pooltogether-governance",
+    "project": "pooltogether",
     "deployments": {
       "pooltogether-governance-ethereum": {
         "network": "ethereum",
@@ -5708,6 +5815,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "radicle-governance",
+    "project": "radicle",
     "deployments": {
       "radicle-governance-ethereum": {
         "network": "ethereum",
@@ -5737,6 +5845,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "reflexer-governance",
+    "project": "reflexer",
     "deployments": {
       "reflexer-governance-ethereum": {
         "network": "ethereum",
@@ -5766,6 +5875,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "uniswap-governance",
+    "project": "uniswap",
     "deployments": {
       "uniswap-governance-ethereum": {
         "network": "ethereum",
@@ -5795,6 +5905,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "uniswap-governance-v1",
+    "project": "uniswap",
     "deployments": {
       "uniswap-governance-v1-ethereum": {
         "network": "ethereum",
@@ -5824,6 +5935,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "uniswap-governance-v2",
+    "project": "uniswap",
     "deployments": {
       "uniswap-governance-v2-ethereum": {
         "network": "ethereum",
@@ -5853,6 +5965,7 @@
     "schema": "governance",
     "base": "governor-alpha-bravo",
     "protocol": "unslashed-governance",
+    "project": "unslashed",
     "deployments": {
       "unslashed-governance-ethereum": {
         "network": "ethereum",
@@ -5882,6 +5995,7 @@
     "schema": "yield-aggregator",
     "base": "vesper-finance",
     "protocol": "vesper-finance",
+    "project": "vesper",
     "deployments": {
       "vesper-finance-ethereum": {
         "network": "ethereum",
@@ -5915,6 +6029,7 @@
     "schema": "yield-aggregator",
     "base": "badgerdao",
     "protocol": "badgerdao",
+    "project": "badger",
     "deployments": {
       "badgerdao-ethereum": {
         "network": "ethereum",
@@ -5944,6 +6059,7 @@
     "schema": "dex-amm",
     "base": "platypus-finance",
     "protocol": "platypus-finance",
+    "project": "platypus",
     "deployments": {
       "platypus-finance-avalanche": {
         "network": "avalanche",
@@ -5973,6 +6089,7 @@
     "schema": "erc20",
     "base": "erc20",
     "protocol": "erc20",
+    "project": "erc20",
     "deployments": {
       "erc20-holders-2017": {
         "network": "ethereum",
@@ -6112,6 +6229,7 @@
     "schema": "nft-marketplace",
     "base": "opensea",
     "protocol": "opensea-v1",
+    "project": "opensea",
     "deployments": {
       "opensea-v1-ethereum": {
         "network": "ethereum",
@@ -6145,6 +6263,7 @@
     "schema": "nft-marketplace",
     "base": "opensea",
     "protocol": "opensea-v2",
+    "project": "opensea",
     "deployments": {
       "opensea-v2-ethereum": {
         "network": "ethereum",
@@ -6178,6 +6297,7 @@
     "schema": "nft-marketplace",
     "base": "seaport",
     "protocol": "seaport",
+    "project": "opensea",
     "deployments": {
       "opensea-seaport-ethereum": {
         "network": "ethereum",
@@ -6211,6 +6331,7 @@
     "schema": "nft-marketplace",
     "base": "x2y2",
     "protocol": "x2y2",
+    "project": "x2y2",
     "deployments": {
       "x2y2-ethereum": {
         "network": "ethereum",
@@ -6240,6 +6361,7 @@
     "schema": "nft-marketplace",
     "base": "looksrare",
     "protocol": "looksrare",
+    "project": "looksrare",
     "deployments": {
       "looksrare-ethereum": {
         "network": "ethereum",
@@ -6273,6 +6395,7 @@
     "schema": "generic",
     "base": "tornado-cash",
     "protocol": "tornado-cash",
+    "project": "tornado-cash",
     "deployments": {
       "tornado-cash-classic-ethereum": {
         "network": "ethereum",
@@ -6328,6 +6451,7 @@
     "schema": "generic",
     "base": "the-graph",
     "protocol": "the-graph",
+    "project": "the-graph",
     "deployments": {
       "the-graph-ethereum": {
         "network": "ethereum",
@@ -6361,6 +6485,7 @@
     "schema": "yield-aggregator",
     "base": "aura-finance",
     "protocol": "aura-finance",
+    "project": "aura",
     "deployments": {
       "aura-finance-ethereum": {
         "network": "ethereum",
@@ -6394,6 +6519,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "pangolin",
+    "project": "pangolin",
     "deployments": {
       "pangolin-avalanche": {
         "network": "avalanche",
@@ -6423,6 +6549,7 @@
     "schema": "generic",
     "base": "rocket-pool",
     "protocol": "rocket-pool",
+    "project": "rocket-pool",
     "deployments": {
       "rocket-pool-ethereum": {
         "network": "ethereum",
@@ -6456,6 +6583,7 @@
     "schema": "nft-marketplace",
     "base": "cryptopunks",
     "protocol": "cryptopunks",
+    "project": "cryptopunks",
     "deployments": {
       "cryptopunks-ethereum": {
         "network": "ethereum",
@@ -6489,6 +6617,7 @@
     "schema": "bridge",
     "base": "multichain",
     "protocol": "multichain",
+    "project": "multichain",
     "deployments": {
       "multichain-ethereum": {
         "network": "ethereum",
@@ -6540,6 +6669,7 @@
     "schema": "bridge",
     "base": "stargate",
     "protocol": "stargate",
+    "project": "stargate",
     "deployments": {
       "stargate-ethereum": {
         "network": "ethereum",
@@ -6701,6 +6831,7 @@
     "schema": "bridge",
     "base": "polygon-bridge",
     "protocol": "polygon-bridge",
+    "project": "polygon",
     "deployments": {
       "polygon-bridge-ethereum": {
         "network": "ethereum",
@@ -6752,6 +6883,7 @@
     "schema": "bridge",
     "base": "across-v2",
     "protocol": "across-v2",
+    "project": "across",
     "deployments": {
       "across-v2-ethereum": {
         "network": "ethereum",
@@ -6869,6 +7001,7 @@
     "schema": "bridge",
     "base": "arbitrum-bridge",
     "protocol": "arbitrum-bridge",
+    "project": "arbitrum",
     "deployments": {
       "arbitrum-bridge-ethereum": {
         "network": "ethereum",
@@ -6920,6 +7053,7 @@
     "schema": "bridge",
     "base": "hop-protocol",
     "protocol": "hop-protocol",
+    "project": "hop",
     "deployments": {
       "hop-protocol-ethereum": {
         "network": "ethereum",
@@ -7037,6 +7171,7 @@
     "schema": "bridge",
     "base": "portal",
     "protocol": "portal",
+    "project": "portal",
     "deployments": {
       "portal-ethereum": {
         "network": "ethereum",
@@ -7066,6 +7201,7 @@
     "schema": "bridge",
     "base": "optimism-bridge-v2",
     "protocol": "optimism-bridge-v2",
+    "project": "optimism",
     "deployments": {
       "optimism-bridge-v2-ethereum": {
         "network": "ethereum",
@@ -7116,7 +7252,7 @@
   "orbit-bridge": {
     "schema": "bridge",
     "base": "orbit-bridge",
-    "protocol": "orbit-bridge",
+    "protocol": "orbit",
     "deployments": {
       "orbit-bridge-ethereum": {
         "network": "ethereum",
@@ -7212,6 +7348,7 @@
     "schema": "bridge",
     "base": "axelar",
     "protocol": "axelar",
+    "project": "axelar",
     "deployments": {
       "axelar-ethereum": {
         "network": "ethereum",
@@ -7241,6 +7378,7 @@
     "schema": "bridge",
     "base": "celer-bridge",
     "protocol": "celer-bridge",
+    "project": "celer",
     "deployments": {
       "celer-bridge-ethereum": {
         "network": "ethereum",
@@ -7556,6 +7694,7 @@
     "schema": "derivatives-perpfutures",
     "base": "gmx",
     "protocol": "gmx",
+    "project": "gmx",
     "deployments": {
       "gmx-arbitrum": {
         "network": "arbitrum",
@@ -7607,6 +7746,7 @@
     "schema": "derivatives-options",
     "base": "opyn",
     "protocol": "opyn",
+    "project": "opyn",
     "deployments": {
       "opyn-ethereum": {
         "network": "ethereum",

--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1058,7 +1058,8 @@
   "belt-finance": {
     "schema": "yield-aggregator",
     "base": "belt-finance",
-    "protocol": "belt",
+    "protocol": "belt-finance",
+    "project": "belt",
     "deployments": {
       "belt-finance-bsc": {
         "network": "bsc",
@@ -1152,7 +1153,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "banker-joe",
-    "project": "banker-joe",
+    "project": "trader-joe",
     "deployments": {
       "banker-joe-avalanche": {
         "network": "avalanche",
@@ -1796,7 +1797,7 @@
     "schema": "lending",
     "base": "compound-forks",
     "protocol": "rari-fuse",
-    "project": "rari",
+    "project": "rari-capital",
     "deployments": {
       "rari-fuse-arbitrum": {
         "network": "arbitrum",
@@ -3138,7 +3139,7 @@
     "schema": "lending",
     "base": "maple-finance",
     "protocol": "maple-finance",
-    "project": "maple-finance",
+    "project": "maple",
     "deployments": {
       "maple-finance-ethereum": {
         "network": "ethereum",
@@ -4130,7 +4131,7 @@
     "schema": "yield-aggregator",
     "base": "rari-vaults",
     "protocol": "rari-vaults",
-    "project": "rari",
+    "project": "rari-capital",
     "deployments": {
       "rari-vaults-ethereum": {
         "network": "ethereum",
@@ -4668,7 +4669,7 @@
     "schema": "dex-amm",
     "base": "uniswap-forks",
     "protocol": "trader-joe",
-    "project": "joe",
+    "project": "trader-joe",
     "deployments": {
       "trader-joe-avalanche": {
         "network": "avalanche",
@@ -4981,7 +4982,7 @@
     "schema": "governance",
     "base": "maker-governance",
     "protocol": "maker-governance",
-    "project": "maker",
+    "project": "makerdao",
     "deployments": {
       "maker-governance-ethereum": {
         "network": "ethereum",
@@ -7252,7 +7253,8 @@
   "orbit-bridge": {
     "schema": "bridge",
     "base": "orbit-bridge",
-    "protocol": "orbit",
+    "protocol": "orbit-bridge",
+    "project": "orbit",
     "deployments": {
       "orbit-bridge-ethereum": {
         "network": "ethereum",


### PR DESCRIPTION
**Context:**
@yulesa requested to have a project tag within the deployment.json. The project tag encompasses all related subgraphs under the same organization. For example, Aave V2, Aave V3, Aave RWA, Aave AMM, Aave ARC, and Aave Governance will receive the project tag of `aave`. Balancer V2 and Beethoven X will receive the project tag of `balancer`. Osmosis DEX and Osmosis chain will receive a tag of `osmosis.` This will be used to reference subgraphs by a project category in protocol metrics so that you can view all of the different facets of Aave, for example.  