### PR TITLE
fix (#minor); alpaca-finance-lending; fixed incorrect borrowbalanceUSD

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -478,7 +478,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.0.1",
+          "subgraph": "1.2.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -500,7 +500,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.0.0",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/alpaca-finance-lending/src/entities/market.ts
+++ b/subgraphs/alpaca-finance-lending/src/entities/market.ts
@@ -303,11 +303,9 @@ export function addMarketVolume(
 export function changeMarketBorrowBalance(
   event: ethereum.Event,
   market: Market,
-  borrowBalance: BigInt,
-  balanceChange: BigInt
+  borrowBalance: BigInt
 ): void {
   const token = getTokenById(market.inputToken);
-  const changeUSD = amountInUSD(balanceChange, token, event.block.number);
   const totalBBUSD = amountInUSD(borrowBalance, token, event.block.number);
   // this can change because of balance and price
   const deltaTotalBBUSD = totalBBUSD.minus(market.totalBorrowBalanceUSD);

--- a/subgraphs/alpaca-finance-lending/src/mappings/vault.ts
+++ b/subgraphs/alpaca-finance-lending/src/mappings/vault.ts
@@ -9,7 +9,11 @@ import {
 import { ConfigurableInterestVaultConfig } from "../../generated/ibALPACA/ConfigurableInterestVaultConfig";
 import { FairLaunch } from "../../generated/ibALPACA/FairLaunch";
 import { Market, MarketDailySnapshot } from "../../generated/schema";
-import { getOrCreateToken, getOrCreateRewardToken } from "../entities/token";
+import {
+  getOrCreateToken,
+  getOrCreateRewardToken,
+  getTokenById,
+} from "../entities/token";
 import {
   createDeposit,
   createWithdraw,
@@ -181,14 +185,20 @@ export function handleAddDebt(event: AddDebt): void {
   updateInterest(event, market);
   const contract = Vault.bind(event.address);
   const trytoken = contract.try_token();
-  const tryDebtVal = contract.try_debtShareToVal(event.params.debtShare);
-  if (trytoken.reverted || tryDebtVal.reverted) {
+  const tryTotalDebtVal = contract.try_vaultDebtVal();
+  const tryDeltaDebtVal = contract.try_debtShareToVal(event.params.debtShare);
+  if (
+    trytoken.reverted ||
+    tryDeltaDebtVal.reverted ||
+    tryTotalDebtVal.reverted
+  ) {
     log.error("[handleAddDebt]Failed to handle add debt for market {} tx={}", [
       market.id,
       event.transaction.hash.toHexString(),
     ]);
     return;
   }
+
   const tryPositions = contract.try_positions(event.params.id);
   if (tryPositions.reverted) {
     return;
@@ -198,14 +208,19 @@ export function handleAddDebt(event: AddDebt): void {
     market,
     trytoken.value,
     tryPositions.value.getOwner(),
-    tryDebtVal.value
+    tryDeltaDebtVal.value
   );
-  changeMarketBorrowBalance(event, market, tryDebtVal.value);
+  changeMarketBorrowBalance(
+    event,
+    market,
+    tryTotalDebtVal.value,
+    tryDeltaDebtVal.value
+  );
   updateUserPosition(
     event,
     tryPositions.value.getOwner(),
     market,
-    tryDebtVal.value,
+    tryDeltaDebtVal.value,
     PositionSide.BORROWER,
     false
   );
@@ -216,14 +231,20 @@ export function handleRemoveDebt(event: RemoveDebt): void {
   updateInterest(event, market);
   const contract = Vault.bind(event.address);
   const trytoken = contract.try_token();
-  const tryDebtVal = contract.try_debtShareToVal(event.params.debtShare);
-  if (trytoken.reverted || tryDebtVal.reverted) {
+  const tryTotalDebtVal = contract.try_vaultDebtVal();
+  const tryDeltaDebtVal = contract.try_debtShareToVal(event.params.debtShare);
+  if (
+    trytoken.reverted ||
+    tryDeltaDebtVal.reverted ||
+    tryTotalDebtVal.reverted
+  ) {
     log.error(
       "[handleRemoveDebt]Failed to handle remove debt from market {} tx={}",
       [market.id, event.transaction.hash.toHexString()]
     );
     return;
   }
+
   const tryPositions = contract.try_positions(event.params.id);
   if (tryPositions.reverted) {
     return;
@@ -233,18 +254,19 @@ export function handleRemoveDebt(event: RemoveDebt): void {
     market,
     trytoken.value,
     tryPositions.value.getOwner(),
-    tryDebtVal.value
+    tryDeltaDebtVal.value
   );
   changeMarketBorrowBalance(
     event,
     market,
-    tryDebtVal.value.times(BIGINT_NEGATIVE_ONE)
+    tryTotalDebtVal.value,
+    tryDeltaDebtVal.value.times(BIGINT_NEGATIVE_ONE)
   );
   updateUserPosition(
     event,
     tryPositions.value.getOwner(),
     market,
-    tryDebtVal.value,
+    tryDeltaDebtVal.value,
     PositionSide.BORROWER,
     false
   );
@@ -344,18 +366,7 @@ export function updateInterest(event: ethereum.Event, market: Market): void {
     .times(BIGDECIMAL_ONE.minus(PROTOCOL_LENDING_FEE.div(BIGDECIMAL_HUNDRED)))
     .div(totalTokenAmount.toBigDecimal());
   updateMarketRates(event, market, borrowerAPY, lenderAPY);
-  log.info(
-    "[updateInterestRate]market={},vaultDebtValu={},totalToken={},RatePerSec={},borrowerAPY={},lenderAPY={},tx={}",
-    [
-      market.id,
-      vaultDebtVal.toString(),
-      totalTokenAmount.toString(),
-      ratePerSec.toString(),
-      borrowerAPY.toString(),
-      lenderAPY.toString(),
-      event.transaction.hash.toHexString(),
-    ]
-  );
+
   const dailyInterest = ratePerSec
     .times(vaultDebtVal)
     .times(BIGINT_SECONDS_PER_DAY)

--- a/subgraphs/alpaca-finance-lending/src/mappings/vault.ts
+++ b/subgraphs/alpaca-finance-lending/src/mappings/vault.ts
@@ -9,11 +9,7 @@ import {
 import { ConfigurableInterestVaultConfig } from "../../generated/ibALPACA/ConfigurableInterestVaultConfig";
 import { FairLaunch } from "../../generated/ibALPACA/FairLaunch";
 import { Market, MarketDailySnapshot } from "../../generated/schema";
-import {
-  getOrCreateToken,
-  getOrCreateRewardToken,
-  getTokenById,
-} from "../entities/token";
+import { getOrCreateToken, getOrCreateRewardToken } from "../entities/token";
 import {
   createDeposit,
   createWithdraw,
@@ -210,12 +206,7 @@ export function handleAddDebt(event: AddDebt): void {
     tryPositions.value.getOwner(),
     tryDeltaDebtVal.value
   );
-  changeMarketBorrowBalance(
-    event,
-    market,
-    tryTotalDebtVal.value,
-    tryDeltaDebtVal.value
-  );
+  changeMarketBorrowBalance(event, market, tryTotalDebtVal.value);
   updateUserPosition(
     event,
     tryPositions.value.getOwner(),
@@ -256,12 +247,7 @@ export function handleRemoveDebt(event: RemoveDebt): void {
     tryPositions.value.getOwner(),
     tryDeltaDebtVal.value
   );
-  changeMarketBorrowBalance(
-    event,
-    market,
-    tryTotalDebtVal.value,
-    tryDeltaDebtVal.value.times(BIGINT_NEGATIVE_ONE)
-  );
+  changeMarketBorrowBalance(event, market, tryTotalDebtVal.value);
   updateUserPosition(
     event,
     tryPositions.value.getOwner(),


### PR DESCRIPTION
This PR fixes issue reported [here](https://github.com/messari/subgraphs/pull/1631#issuecomment-1419563809) and in #1766. The `changeMarketBorrowBalance` only updates the USD amount for each borrow/repay, not repricing the total borrow balance in the market, while `updateMarketTVL` reprices inputToken balance using the latest price for each deposit/withdraw. This causes the totalBorrowBalanceUSD much higher than TVL ($23M > $5.3M for the USDC market).

### Deployment and validation
- Fantom deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/alpaca-finance-lending-fantom
- Fantom validation dashboard: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/name/tnkrxyz/alpaca-finance-lending-fantom&tab=protocol
- BSC deployment: 
- BSC validation: