### PR TITLE
fix (#minor); makerdao-ethereum; fixed procotoal side rev from wrong liquidation penality #1785

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3112,7 +3112,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "2.1.0",
+          "subgraph": "2.2.0",
           "methodology": "1.1.0"
         },
         "files": {

--- a/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
+++ b/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
@@ -1,5 +1,5 @@
 {
-  "graftEnabled": true,
-  "subgraphId": "QmZfrSy1yBUsiTB4FyYsEpkSemK1Hx1QtaHvdjBkufaGHQ",
+  "graftEnabled": false,
+  "subgraphId": "QmdN5XkS372qmKv1mDVq9SJZ68PsMb9YXrXRZS3Qha3Xfc",
   "graftStartBlock": 8958360
 }

--- a/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
+++ b/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
@@ -1,5 +1,5 @@
 {
   "graftEnabled": true,
-  "subgraphId": "QmTJScYCuTsFxkWnAw8vrh51w1bEfFRJbZEiKk9cpb524R",
-  "graftStartBlock": 16674408
+  "subgraphId": "QmZfrSy1yBUsiTB4FyYsEpkSemK1Hx1QtaHvdjBkufaGHQ",
+  "graftStartBlock": 8958360
 }

--- a/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
+++ b/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
@@ -6,8 +6,8 @@ description: ...
 features:
   - grafting
 graft:
-  base: {{subgraphId}} # Subgraph ID of base subgraph
-  block: {{graftStartBlock}} # Block number
+  base: {{subgraphId}}
+  block: {{graftStartBlock}}
 {{/graftEnabled}}
 dataSources:
   # Vault

--- a/subgraphs/makerdao/src/common/constants.ts
+++ b/subgraphs/makerdao/src/common/constants.ts
@@ -187,6 +187,7 @@ export const VAT_ADDRESS = "0x35d1b3f3d7966a1dfe207aa4514c12a259a0492b".toLowerC
 export const VOW_ADDRESS = "0xa950524441892a31ebddf91d3ceefa04bf454466".toLowerCase();
 export const DAI_ADDRESS = "0x6b175474e89094c44da98b954eedeac495271d0f".toLowerCase();
 export const MIGRATION_ADDRESS = "0xc73e0383f3aff3215e6f04b0331d58cecf0ab849";
+export const CAT_V1_ADDRESS = "0x78f2c2af65126834c51822f56be0d7469d7a523e";
 
 // unconventional token requiring special handling
 export const ILK_SAI = "0x5341490000000000000000000000000000000000000000000000000000000000";


### PR DESCRIPTION
This fixes the issue in protocol side revenue (#1785) due to liquidity penalty using incorrect decimals for the Cat V1 contract.

- cat v1: https://etherscan.io/address/0x78f2c2af65126834c51822f56be0d7469d7a523e#code
- cat v2: https://etherscan.io/address/0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea#code


### deployment & validation
- deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/makerdao-ethereum?version=pending
- validation dashboard: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/id/QmdN5XkS372qmKv1mDVq9SJZ68PsMb9YXrXRZS3Qha3Xfc&tab=protocol