### PR TITLE
fix(#minor); Saddle && Platypus; Fix compatibility with the required fields from graph version update.

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3530,7 +3530,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.6",
+          "subgraph": "1.1.7",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3552,7 +3552,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.6",
+          "subgraph": "1.1.7",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3574,7 +3574,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.6",
+          "subgraph": "1.1.7",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3596,7 +3596,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.6",
+          "subgraph": "1.1.7",
           "methodology": "1.0.0"
         },
         "files": {
@@ -6068,7 +6068,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.3.1",
+          "subgraph": "1.3.2",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/platypus-finance/src/common/getters.ts
+++ b/subgraphs/platypus-finance/src/common/getters.ts
@@ -45,10 +45,10 @@ export function getOrCreateToken(event: ethereum.Event, tokenAddress: Address): 
     token.lastPriceBlockNumber = event.block.number;
   }
 
-  if (token.lastPriceBlockNumber! < event.block.number) {
+  if (token.lastPriceBlockNumber && token.lastPriceBlockNumber! < event.block.number) {
     token.lastPriceUSD = getUsdPrice(tokenAddress, BigDecimal.fromString("1"));
-    if (token.lastPriceUSD == BIGDECIMAL_ZERO) {
-      token.lastPriceUSD = BigDecimal.fromString("1");
+    if (!token.lastPriceUSD) {
+      token.lastPriceUSD = BIGDECIMAL_ZERO;
     }
     token.lastPriceBlockNumber = event.block.number;
   }

--- a/subgraphs/saddle-finance/src/utils/price.ts
+++ b/subgraphs/saddle-finance/src/utils/price.ts
@@ -59,7 +59,10 @@ export function getPriceUSD(token: Token, event: ethereum.Event): BigDecimal {
   if (USD_TOKENS.has(symbol)) {
     return BIGDECIMAL_ONE;
   }
-  if (token.lastPriceBlockNumber == event.block.number) {
+  if (
+    token.lastPriceBlockNumber &&
+    token.lastPriceBlockNumber! == event.block.number
+  ) {
     return token.lastPriceUSD!;
   }
   // No market for SDL yet
@@ -230,7 +233,11 @@ function calculateSwap(
   if (!pool._basePool) {
     call = contract.try_calculateSwap(inputIndex, outputIndex, amount);
   } else {
-    call = contract.try_calculateSwapUnderlying(inputIndex, outputIndex, amount);
+    call = contract.try_calculateSwapUnderlying(
+      inputIndex,
+      outputIndex,
+      amount
+    );
   }
   if (call.reverted) {
     log.error(


### PR DESCRIPTION
**Context:**
Fix subgraph as there was a backward compatibility break from when I upgraded the new CLI version. The fix was very simple. I just had to fix assertions for some non-required fields on the Token entity. There were a few instances where I just had. to check if the field existed because running another condition on the value. 

Second, I noticed in Platypus to null return values from the price lib were given a value of `1`. It makes more sense to set the price to 0 if no price is returned. It is possible that setting these null values to 1 could throw off our pricing if the actual cost of the token is much lower. 