### PR TITLE
feat(#minor): Fix Options schema problem happening during compilation and deployment

### DIFF
--- a/schema-derivatives-options.graphql
+++ b/schema-derivatives-options.graphql
@@ -87,25 +87,31 @@ enum LiquidityPoolFeeType {
   " Some protocols use tiered fees instead of fixed fee (e.g. DYDX). Set `feePercentage` as 0 but handle the tiered fees in the mapping code. "
   TIERED_TRADING_FEE
 
-  " Some protocols use dynamic fees instead of fixed fee. Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
+  " Some protocols use dynamic fees instead of fixed fee (e.g. Balancer v2). Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
   DYNAMIC_TRADING_FEE
 
-  " Fixed fee that's paid to the LP, as a percentage of the traded amount."
+  " Fixed fee that's paid to the LP, as a percentage of the traded amount. e.g. 10% of fees to GMX LP providers (GLP holders). "
   FIXED_LP_FEE
 
-  " Some protocols use dynamic LP fees. Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
+  " Some protocols use dynamic LP fees . Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
   DYNAMIC_LP_FEE
 
-  " Fixed fee that's paid to the protocol, as a percentage of the traded amount. e.g. 0.05% for Sushiswap, 0.02% for Curve v1. "
+  " Fixed fee that's paid to the protocol, as a percentage of the traded amount. e.g. 10% of GMX fees to protocol. "
   FIXED_PROTOCOL_FEE
 
   " Some protocols use dynamic protocol fees. Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
   DYNAMIC_PROTOCOL_FEE
 
-  " One-time fee charged by the protocol during deposit, in percentages of the deposit token "
+  " Fixed fee that's paid to the stakers, as a percentage of the traded amount. e.g. 15% of all fees on GMX to stakers. "
+  FIXED_STAKE_FEE
+
+  " Some protocols use dynamic stakers fees. Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
+  DYNAMIC_STAKE_FEE
+
+  " One-time fee charged by the protocol during deposit, in percentages of the deposit token (e.g. dynamic fee collected for LP providers in GMX)"
   DEPOSIT_FEE
 
-  " One-time fee charged by the protocol during withdrawal, in percentages of the withdrawal token "
+  " One-time fee charged by the protocol (e.g. GMX charges a fee from certain pools with withdrawing) during withdrawal, in percentages of the withdrawal token "
   WITHDRAWAL_FEE
 }
 
@@ -154,6 +160,9 @@ interface Protocol {
   " Current TVL (Total Value Locked) of the entire protocol "
   totalValueLockedUSD: BigDecimal!
 
+  " Current PCV (Protocol Controlled Value). Only relevant for protocols with PCV. "
+  protocolControlledValueUSD: BigDecimal
+
   " Revenue claimed by suppliers to the protocol. LPs on DEXs (e.g. 0.25% of the swap fee in Sushiswap). Depositors on Lending Protocols. NFT sellers on OpenSea. "
   cumulativeSupplySideRevenueUSD: BigDecimal!
 
@@ -191,7 +200,7 @@ interface Protocol {
   cumulativeUniqueTakers: Int!
 
   " Notional value of all open positions "
-  openInterestUSD: Int!
+  openInterestUSD: BigDecimal!
 
   " Total number of open positions "
   openPositionCount: Int!
@@ -245,6 +254,9 @@ type DerivOptProtocol implements Protocol @entity {
 
   " Current TVL (Total Value Locked) of the entire protocol "
   totalValueLockedUSD: BigDecimal!
+
+  " Current PCV (Protocol Controlled Value). Only relevant for protocols with PCV. "
+  protocolControlledValueUSD: BigDecimal
 
   " All historical notional volume in USD taken of underlying at time of contract minting"
   cumulativeVolumeUSD: BigDecimal!
@@ -436,6 +448,9 @@ type FinancialsDailySnapshot @entity(immutable: true) {
   " Current TVL (Total Value Locked) of the entire protocol "
   totalValueLockedUSD: BigDecimal!
 
+  " Current PCV (Protocol Controlled Value). Only relevant for protocols with PCV. "
+  protocolControlledValueUSD: BigDecimal
+
   " Daily trade notional volume of underlying assets at contract mint, in USD "
   dailyVolumeUSD: BigDecimal!
 
@@ -455,7 +470,7 @@ type FinancialsDailySnapshot @entity(immutable: true) {
   cumulativeClosedVolumeUSD: BigDecimal!
 
   " Daily Notional value of all open positions "
-  dailyOpenInterestUSD: Int!
+  dailyOpenInterestUSD: BigDecimal!
 
   " Daily revenue claimed by suppliers to the protocol. LPs on DEXs (e.g. 0.25% of the swap fee in Sushiswap). Depositors on Lending Protocols. NFT sellers on OpenSea. "
   dailySupplySideRevenueUSD: BigDecimal!
@@ -646,7 +661,7 @@ type LiquidityPool @entity {
   cumulativeClosedVolumeUSD: BigDecimal!
 
   " Notional value of all open positions "
-  openInterestUSD: Int!
+  openInterestUSD: BigDecimal!
 
   " Total number of puts minted "
   putsMintedCount: Int!
@@ -757,7 +772,7 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) {
   dailyTotalRevenueUSD: BigDecimal!
 
   " Daily Notional value of all open positions "
-  dailyOpenInterestUSD: Int!
+  dailyOpenInterestUSD: BigDecimal!
 
   " Daily premium paid to enter a position. "
   dailyEntryPremiumUSD: BigDecimal!
@@ -796,55 +811,55 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) {
   cumulativeTotalLiquidityPremiumUSD: BigDecimal!
 
   " Daily number of puts minted "
-  dailyputsMintedCount: Int!
+  dailyPutsMintedCount: Int!
 
   " Total number of puts minted "
   putsMintedCount: Int!
 
   " Daily number of calls minted "
-  dailycallsMintedCount: Int!
+  dailyCallsMintedCount: Int!
 
   " Total number of calls minted "
   callsMintedCount: Int!
 
   " Daily number of contracts minted "
-  dailycontractsMintedCount: Int!
+  dailyContractsMintedCount: Int!
 
   " Total number of contracts minted "
   contractsMintedCount: Int!
 
   " Daily number of contracts taken"
-  dailycontractsTakenCount: Int!
+  dailyContractsTakenCount: Int!
 
   " Total number of contracts taken "
   contractsTakenCount: Int!
 
   " Daily number of contracts expired "
-  dailycontractsExpiredCount: Int!
+  dailyContractsExpiredCount: Int!
 
   " Total number of contracts expired "
   contractsExpiredCount: Int!
 
   " Daily number of contracts exercised "
-  dailycontractsExercisedCount: Int!
+  dailyContractsExercisedCount: Int!
 
   " Total number of contracts exercised "
   contractsExercisedCount: Int!
 
   " Daily number of contracts exercised+expired "
-  dailycontractsClosedCount: Int!
+  dailyContractsClosedCount: Int!
 
   " Total number of contracts exercised+expired "
   contractsClosedCount: Int!
 
   " Daily number of open positions (contracts minted-closed)"
-  dailyopenPositionCount: Int!
+  dailyOpenPositionCount: Int!
 
   " Total number of open positions (contracts minted-closed) "
   openPositionCount: Int!
 
   " Daily number of closed positions "
-  dailyclosedPositionCount: Int!
+  dailyClosedPositionCount: Int!
 
   " Total number of closed positions "
   closedPositionCount: Int!
@@ -865,28 +880,28 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) {
   dailyDepositedVolumeUSD: BigDecimal!
 
   " Daily Deposit trade notional volume for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  DailyDepositedVolumeByTokenAmount: [BigInt!]!
+  dailyDepositedVolumeByTokenAmount: [BigInt!]!
 
   " Daily Deposit trade notional volume for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  DailyDepositedVolumeByTokenUSD: [BigDecimal!]!
+  dailyDepositedVolumeByTokenUSD: [BigDecimal!]!
 
   " Deposit historical trade notional volume occurred in this pool, in USD "
   cumulativeDepositedVolumeUSD: BigDecimal!
 
   " Daily Withdraw trade notional volume occurred in USD "
-  DailyWithdrawVolumeUSD: BigDecimal!
+  dailyWithdrawVolumeUSD: BigDecimal!
 
   " Daily Withdraw trade notional volume for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  DailyWithdrawVolumeByTokenAmount: [BigInt!]!
+  dailyWithdrawVolumeByTokenAmount: [BigInt!]!
 
   " Daily Withdraw trade notional volume for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  DailyWithdrawVolumeByTokenUSD: [BigDecimal!]!
+  dailyWithdrawVolumeByTokenUSD: [BigDecimal!]!
 
   " Withdraw historical trade notional volume occurred in this pool, in USD "
   cumulativeWithdrawVolumeUSD: BigDecimal!
 
   " Daily notional volume in USD taken of underlying at time of contract closed but not exercised"
-  DailyClosedVolumeUSD: BigDecimal!
+  dailyClosedVolumeUSD: BigDecimal!
 
   " All historical notional volume in USD taken of underlying at time of contract closed but not exercised"
   cumulativeClosedVolumeUSD: BigDecimal!
@@ -956,7 +971,7 @@ type LiquidityPoolHourlySnapshot @entity(immutable: true) {
   hourlyTotalRevenueUSD: BigDecimal!
 
   " Hourly Notional value of all open positions "
-  hourlyOpenInterestUSD: Int!
+  hourlyOpenInterestUSD: BigDecimal!
 
   " Hourly premium paid to enter a position. "
   hourlyEntryPremiumUSD: BigDecimal!
@@ -1015,6 +1030,12 @@ type LiquidityPoolHourlySnapshot @entity(immutable: true) {
   " Hourly Deposit trade notional volume occurred in this pool for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
   hourlyDepositVolumeByTokenUSD: [BigDecimal!]!
 
+  " All Inflow trade notional volume occurred in this pool for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
+  _cumulativeDepositVolumeByTokenAmount: [BigInt!]!
+
+  " All Deposit trade notional volume occurred in this pool for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
+  _cumulativeDepositVolumeByTokenUSD: [BigDecimal!]!
+
   " Deposit historical trade notional volume occurred in this pool, in USD "
   cumulativeDepositVolumeUSD: BigDecimal!
 
@@ -1026,6 +1047,12 @@ type LiquidityPoolHourlySnapshot @entity(immutable: true) {
 
   " Hourly Withdraw trade notional volume occurred in this pool for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
   hourlyWithdrawVolumeByTokenUSD: [BigDecimal!]!
+
+  " All Withdraw trade notional volume occurred in this pool for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
+  _cumumativeWithdrawVolumeByTokenAmount: [BigInt!]!
+
+  " All Withdraw trade notional volume occurred in this pool for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
+  _cumulativeWithdrawVolumeByTokenUSD: [BigDecimal!]!
 
   " Withdraw historical trade notional volume occurred in this pool, in USD "
   cumulativeWithdrawVolumeUSD: BigDecimal!
@@ -1109,6 +1136,9 @@ type Deposit implements Event @entity(immutable: true) {
   " Address that sent the tokens "
   from: Bytes!
 
+  " Account that controls this transaction "
+  account: Account!
+
   " Block number of this event "
   blockNumber: BigInt!
 
@@ -1152,6 +1182,9 @@ type Withdraw implements Event @entity(immutable: true) {
 
   " Address that sent the tokens "
   from: Bytes!
+
+  " Account that controls this transaction "
+  account: Account!
 
   " Block number of this event "
   blockNumber: BigInt!
@@ -1245,9 +1278,17 @@ type ActiveAccount @entity {
   id: Bytes!
 }
 
+enum OptionType {
+  " Position opened as call "
+  CALL
+
+  " Position opened as put "
+  PUT
+}
+
 # A position describes a contract that a user has taken (either a call/put)
 # Note: A position snapshot is not necessary because the position is opened and closed with no other interaction
-#       All of the data we would get from a snapshot is already available in the position.
+# All of the data we would get from a snapshot is already available in the position.
 type Position @entity {
   " { Account address }-{ Pool address }-{ Position Side }-{ Counter } "
   id: Bytes!

--- a/schema-derivatives-options.graphql
+++ b/schema-derivatives-options.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Derivatives Options
-# Version: 1.1.1
+# Version: 1.2.0
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -168,9 +168,6 @@ interface Protocol {
   " Current TVL (Total Value Locked) of the entire protocol "
   totalValueLockedUSD: BigDecimal!
 
-  " Current PCV (Protocol Controlled Value). Only relevant for protocols with PCV. "
-  protocolControlledValueUSD: BigDecimal
-
   " Revenue claimed by suppliers to the protocol. LPs on DEXs (e.g. 0.25% of the swap fee in Sushiswap). Depositors on Lending Protocols. NFT sellers on OpenSea. "
   cumulativeSupplySideRevenueUSD: BigDecimal!
 
@@ -262,9 +259,6 @@ type DerivOptProtocol implements Protocol @entity {
 
   " Current TVL (Total Value Locked) of the entire protocol "
   totalValueLockedUSD: BigDecimal!
-
-  " Current PCV (Protocol Controlled Value). Only relevant for protocols with PCV. "
-  protocolControlledValueUSD: BigDecimal
 
   " All historical notional volume in USD taken of underlying at time of contract minting"
   cumulativeVolumeUSD: BigDecimal!
@@ -455,9 +449,6 @@ type FinancialsDailySnapshot @entity(immutable: true) {
 
   " Current TVL (Total Value Locked) of the entire protocol "
   totalValueLockedUSD: BigDecimal!
-
-  " Current PCV (Protocol Controlled Value). Only relevant for protocols with PCV. "
-  protocolControlledValueUSD: BigDecimal
 
   " Daily trade notional volume of underlying assets at contract mint, in USD "
   dailyVolumeUSD: BigDecimal!

--- a/schema-derivatives-options.graphql
+++ b/schema-derivatives-options.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Derivatives Options
-# Version: 1.1.0
+# Version: 1.1.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {

--- a/schema-derivatives-options.graphql
+++ b/schema-derivatives-options.graphql
@@ -90,28 +90,28 @@ enum LiquidityPoolFeeType {
   " Some protocols use dynamic fees instead of fixed fee (e.g. Balancer v2). Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
   DYNAMIC_TRADING_FEE
 
-  " Fixed fee that's paid to the LP, as a percentage of the traded amount. e.g. 10% of fees to GMX LP providers (GLP holders). "
+  " Fixed fee that's paid to the LP, as a percentage of the traded amount. "
   FIXED_LP_FEE
 
   " Some protocols use dynamic LP fees . Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
   DYNAMIC_LP_FEE
 
-  " Fixed fee that's paid to the protocol, as a percentage of the traded amount. e.g. 10% of GMX fees to protocol. "
+  " Fixed fee that's paid to the protocol, as a percentage of the traded amount. "
   FIXED_PROTOCOL_FEE
 
   " Some protocols use dynamic protocol fees. Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
   DYNAMIC_PROTOCOL_FEE
 
-  " Fixed fee that's paid to the stakers, as a percentage of the traded amount. e.g. 15% of all fees on GMX to stakers. "
+  " Fixed fee that's paid to the stakers, as a percentage of the traded amount. "
   FIXED_STAKE_FEE
 
   " Some protocols use dynamic stakers fees. Set `feePercentage` as 0 but handle the dynamic fees in the mapping code. "
   DYNAMIC_STAKE_FEE
 
-  " One-time fee charged by the protocol during deposit, in percentages of the deposit token (e.g. dynamic fee collected for LP providers in GMX)"
+  " One-time fee charged by the protocol during deposit, in percentages of the deposit token. "
   DEPOSIT_FEE
 
-  " One-time fee charged by the protocol (e.g. GMX charges a fee from certain pools with withdrawing) during withdrawal, in percentages of the withdrawal token "
+  " One-time fee charged by the protocol during withdrawal, in percentages of the withdrawal token "
   WITHDRAWAL_FEE
 }
 

--- a/schema-derivatives-options.graphql
+++ b/schema-derivatives-options.graphql
@@ -37,6 +37,14 @@ enum ProtocolType {
   # Will add more
 }
 
+enum OptionType {
+  " Position opened as call "
+  CALL
+
+  " Position opened as put "
+  PUT
+}
+
 type Token @entity {
   " Smart contract address of the token "
   id: Bytes!
@@ -1030,12 +1038,6 @@ type LiquidityPoolHourlySnapshot @entity(immutable: true) {
   " Hourly Deposit trade notional volume occurred in this pool for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
   hourlyDepositVolumeByTokenUSD: [BigDecimal!]!
 
-  " All Inflow trade notional volume occurred in this pool for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  _cumulativeDepositVolumeByTokenAmount: [BigInt!]!
-
-  " All Deposit trade notional volume occurred in this pool for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  _cumulativeDepositVolumeByTokenUSD: [BigDecimal!]!
-
   " Deposit historical trade notional volume occurred in this pool, in USD "
   cumulativeDepositVolumeUSD: BigDecimal!
 
@@ -1047,12 +1049,6 @@ type LiquidityPoolHourlySnapshot @entity(immutable: true) {
 
   " Hourly Withdraw trade notional volume occurred in this pool for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
   hourlyWithdrawVolumeByTokenUSD: [BigDecimal!]!
-
-  " All Withdraw trade notional volume occurred in this pool for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  _cumumativeWithdrawVolumeByTokenAmount: [BigInt!]!
-
-  " All Withdraw trade notional volume occurred in this pool for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  _cumulativeWithdrawVolumeByTokenUSD: [BigDecimal!]!
 
   " Withdraw historical trade notional volume occurred in this pool, in USD "
   cumulativeWithdrawVolumeUSD: BigDecimal!
@@ -1276,14 +1272,6 @@ type Account @entity {
 type ActiveAccount @entity {
   " { daily/hourly }-{ Address of the account }-{ Days/hours since Unix epoch } "
   id: Bytes!
-}
-
-enum OptionType {
-  " Position opened as call "
-  CALL
-
-  " Position opened as put "
-  PUT
 }
 
 # A position describes a contract that a user has taken (either a call/put)


### PR DESCRIPTION
Some small changes to Options schema in order to compile and deploy related dopex subgraph.

1. Some changes are needed as the errors happening when compiling, deploying and running subgraphs otherwise.
2. Add PCV as the subgraph dashboard will complain it does not comply with generic schema otherwise.
3. Add two extra kinds of fee type to be same with Perp schema.
4. Modify some entry names to be compliant with naming convention.