### PR TITLE
fix (#minor); makerdao-ethereum; fix crash due to negative position bal reported in #1855

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3160,7 +3160,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "2.2.0",
+          "subgraph": "2.3.0",
           "methodology": "1.1.0"
         },
         "files": {

--- a/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
+++ b/subgraphs/makerdao/protocols/makerdao/config/deployments/makerdao-ethereum/configurations.json
@@ -1,5 +1,5 @@
 {
   "graftEnabled": false,
-  "subgraphId": "QmdN5XkS372qmKv1mDVq9SJZ68PsMb9YXrXRZS3Qha3Xfc",
-  "graftStartBlock": 8958360
+  "subgraphId": "Qmcjdufq7fgKe5WBf9dfe2mEzqn55vSvktwKoW36NxDsvi",
+  "graftStartBlock": 16802254
 }

--- a/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
+++ b/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
@@ -20,7 +20,7 @@ dataSources:
       startBlock: 8928152
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -41,28 +41,35 @@ dataSources:
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x65fae35e00000000000000000000000000000000000000000000000000000000"
           handler: handleVatRely
+          receipt: true
         # function cage()
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x6924500900000000000000000000000000000000000000000000000000000000"
           handler: handleVatCage
+          receipt: true
         ### CDP Manipulation ###
         # function frob(bytes32 i, address u, address v, address w, int256 dink, int256 dart)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x7608870300000000000000000000000000000000000000000000000000000000"
           handler: handleVatFrob
+          receipt: true
         ### CDP Confiscation
+        # function frob(bytes32 i, address u, address v, address w, int256 dink, int256 dart)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x7bab3f4000000000000000000000000000000000000000000000000000000000"
-          handler: handleVatFrob
+          handler: handleVatGrab
+          receipt: true
         # function fork( bytes32 ilk, address src, address dst, int256 dink, int256 dart)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x870c616d00000000000000000000000000000000000000000000000000000000"
           handler: handleVatFork
+          receipt: true
         ### Collect stability fee ###
         # function fold(bytes32 i, address u, int256 rate)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0xb65337df00000000000000000000000000000000000000000000000000000000"
-          handler: handleVatFold  
+          handler: handleVatFold
+          receipt: true
 
   # Borrow rate
   - name: Jug
@@ -74,7 +81,7 @@ dataSources:
       startBlock: 8928160
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -101,7 +108,7 @@ dataSources:
       startBlock: 8928160
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -137,7 +144,7 @@ dataSources:
       startBlock: 8928152
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -172,7 +179,7 @@ dataSources:
       startBlock: 8928165
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -203,7 +210,7 @@ dataSources:
       startBlock: 10742907
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -233,7 +240,7 @@ dataSources:
       startBlock: 12246358
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -263,7 +270,7 @@ dataSources:
       startBlock: 8928198
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -305,7 +312,7 @@ dataSources:
       startBlock: 5834580
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -329,7 +336,7 @@ dataSources:
       startBlock: 11478006
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -355,7 +362,7 @@ dataSources:
       startBlock: 13057085
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -381,7 +388,7 @@ dataSources:
       startBlock: 13684200
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       abis:
@@ -406,7 +413,7 @@ templates:
       abi: Flip
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       entities:
@@ -443,7 +450,7 @@ templates:
       abi: Clip
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       entities:

--- a/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
+++ b/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
@@ -41,18 +41,15 @@ dataSources:
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x65fae35e00000000000000000000000000000000000000000000000000000000"
           handler: handleVatRely
-          receipt: true
         # function cage()
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x6924500900000000000000000000000000000000000000000000000000000000"
           handler: handleVatCage
-          receipt: true
         ### CDP Manipulation ###
         # function frob(bytes32 i, address u, address v, address w, int256 dink, int256 dart)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x7608870300000000000000000000000000000000000000000000000000000000"
           handler: handleVatFrob
-          receipt: true
         ### CDP Confiscation
         # function frob(bytes32 i, address u, address v, address w, int256 dink, int256 dart)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
@@ -63,13 +60,11 @@ dataSources:
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x870c616d00000000000000000000000000000000000000000000000000000000"
           handler: handleVatFork
-          receipt: true
         ### Collect stability fee ###
         # function fold(bytes32 i, address u, int256 rate)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0xb65337df00000000000000000000000000000000000000000000000000000000"
           handler: handleVatFold
-          receipt: true
 
   # Borrow rate
   - name: Jug

--- a/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
+++ b/subgraphs/makerdao/protocols/makerdao/config/templates/makerdao.template.yaml
@@ -50,6 +50,10 @@ dataSources:
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x7608870300000000000000000000000000000000000000000000000000000000"
           handler: handleVatFrob
+        ### CDP Confiscation
+        - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
+          topic0: "0x7bab3f4000000000000000000000000000000000000000000000000000000000"
+          handler: handleVatFrob
         # function fork( bytes32 ilk, address src, address dst, int256 dink, int256 dart)
         - event: LogNote(indexed bytes4,indexed bytes32,indexed bytes32,indexed bytes32,bytes)
           topic0: "0x870c616d00000000000000000000000000000000000000000000000000000000"

--- a/subgraphs/makerdao/src/common/helpers.ts
+++ b/subgraphs/makerdao/src/common/helpers.ts
@@ -511,7 +511,7 @@ export function updatePosition(
       );
 
       if (deltaCollateral.le(BIGINT_ZERO)) {
-        log.critical(
+        log.error(
           "[updatePosition]Creating a new lender position {} with deltaCollateral ={} <= 0 at tx {}-{}",
           [
             lenderPosition.id,
@@ -520,6 +520,7 @@ export function updatePosition(
             event.transactionLogIndex.toString(),
           ]
         );
+        log.critical("", []);
       }
 
       protocol.openPositionCount += INT_ONE;
@@ -536,7 +537,7 @@ export function updatePosition(
 
     lenderPosition.balance = lenderPosition.balance.plus(deltaCollateral);
     if (lenderPosition.balance.lt(BIGINT_ZERO)) {
-      log.critical(
+      log.error(
         "[updatePosition]A negative lender balance of {} for position {} with tx {}-{}",
         [
           lenderPosition.balance.toString(),
@@ -545,6 +546,7 @@ export function updatePosition(
           event.transactionLogIndex.toString(),
         ]
       );
+      log.critical("", []);
     }
 
     if (deltaCollateral.gt(BIGINT_ZERO)) {
@@ -602,7 +604,7 @@ export function updatePosition(
       );
 
       if (deltaDebt.le(BIGINT_ZERO)) {
-        log.critical(
+        log.error(
           "[updatePosition]Creating a new lender position {} with deltaDebt={} <= 0 at tx {}-{}",
           [
             borrowerPosition.id,
@@ -611,6 +613,7 @@ export function updatePosition(
             event.transactionLogIndex.toString(),
           ]
         );
+        log.critical("", []);
       }
 
       protocol.openPositionCount += INT_ONE;
@@ -626,15 +629,8 @@ export function updatePosition(
 
     borrowerPosition.balance = borrowerPosition.balance.plus(deltaDebt);
 
-    // this may be less than 0, but not too negative (>-100), e.g.
-    // 1. at block 12507581, urn 0x03453d22095c0edd61cd40c3ccdc394a0e85dc1a
-    // repaid -203334964101176257798573 dai, when the borrow balance
-    // was 203334964101176257798572
-    // 2. at block 14055178, urn 0x1c47bb6773db2a441264c1af2c943d8bdfaf19fe
-    // repaid -30077488379451392498995529 dai, when the borrow balance
-    // was 30077488379451392498995503
     if (borrowerPosition.balance.lt(BIGINT_ZERO)) {
-      log.critical(
+      log.error(
         "[updatePosition] A negative borrow balance of {} for position {} with tx {}-{}",
         [
           borrowerPosition.balance.toString(),
@@ -643,6 +639,7 @@ export function updatePosition(
           event.transactionLogIndex.toString(),
         ]
       );
+      log.critical("", []);
     }
 
     if (deltaDebt.gt(BIGINT_ZERO)) {
@@ -691,7 +688,7 @@ export function updatePosition(
   account.save();
 
   if (account.openPositionCount < 0) {
-    log.critical(
+    log.error(
       "[updatePosition]urn {} for account {} openPositionCount={} at tx {}-{}",
       [
         urn,
@@ -701,6 +698,7 @@ export function updatePosition(
         event.transactionLogIndex.toString(),
       ]
     );
+    log.critical("", []);
   }
 }
 

--- a/subgraphs/makerdao/src/common/helpers.ts
+++ b/subgraphs/makerdao/src/common/helpers.ts
@@ -611,18 +611,22 @@ export function updatePosition(
 
     borrowerPosition.balance = borrowerPosition.balance.plus(deltaDebt);
 
-    assert(
-      // this may be less than 0, but not too negative (>-100)
-      // 1. at block 12507581, urn 0x03453d22095c0edd61cd40c3ccdc394a0e85dc1a
-      // repaid -203334964101176257798573 dai, when the borrow balance
-      // was 203334964101176257798572
-      // 2. at block 14055178, urn 0x1c47bb6773db2a441264c1af2c943d8bdfaf19fe
-      // repaid -30077488379451392498995529 dai, when the borrow balance
-      // was 30077488379451392498995503
-      //borrowerPosition.balance.ge(BIGINT_ZERO),
-      borrowerPosition.balance.ge(BIGINT_NEG_HUNDRED),
-      `[updatePosition]balance for position ${borrowerPosition.id} ${borrowerPosition.balance} < 0`
-    );
+    // this may be less than 0, but not too negative (>-100), e.g.
+    // 1. at block 12507581, urn 0x03453d22095c0edd61cd40c3ccdc394a0e85dc1a
+    // repaid -203334964101176257798573 dai, when the borrow balance
+    // was 203334964101176257798572
+    // 2. at block 14055178, urn 0x1c47bb6773db2a441264c1af2c943d8bdfaf19fe
+    // repaid -30077488379451392498995529 dai, when the borrow balance
+    // was 30077488379451392498995503
+    //borrowerPosition.balance.ge(BIGINT_ZERO),
+    if (borrowerPosition.balance.ge(BIGINT_NEG_HUNDRED)) {
+      log.critical("[updatePosition] position {} balance = {} < 0 tx={}-{}", [
+        borrowerPosition.id,
+        borrowerPosition.balance.toString(),
+        event.transaction.hash.toHexString(),
+        event.transactionLogIndex.toString(),
+      ]);
+    }
     if (
       borrowerPosition.balance.lt(BIGINT_ZERO) &&
       borrowerPosition.balance.gt(BIGINT_NEG_HUNDRED)

--- a/subgraphs/makerdao/src/mapping.ts
+++ b/subgraphs/makerdao/src/mapping.ts
@@ -1,9 +1,11 @@
 import {
   Bytes,
   BigDecimal,
+  ByteArray,
   ethereum,
   log,
   Address,
+  crypto,
 } from "@graphprotocol/graph-ts";
 import { ERC20 } from "../generated/Vat/ERC20";
 import { GemJoin } from "../generated/Vat/GemJoin";
@@ -211,6 +213,40 @@ export function handleVatCage(event: VatNoteEvent): void {
     market.canBorrowFrom = false;
     market.save();
   }
+}
+
+export function handleVatGrab(event: ethereum.Event): void {
+  // only needed for non-liquidations
+  if (!event.receipt) {
+    log.error("[handleVatGrab]no receipt found. Tx Hash: {}", [
+      event.transaction.hash.toHexString(),
+    ]);
+    return;
+  }
+
+  const liquidationSigs = [
+    crypto.keccak256(
+      ByteArray.fromUTF8(
+        "Bite(indexed bytes32,indexed address,uint256,uint256,uint256,address,uint256)"
+      )
+    ),
+
+    crypto.keccak256(
+      ByteArray.fromUTF8(
+        "Bark(indexed bytes32,indexed address,uint256,uint256,uint256,address,indexed uint256)"
+      )
+    ),
+  ];
+
+  for (let i = 0; i < event.receipt!.logs.length; i++) {
+    const txLog = event.receipt!.logs[i];
+    if (liquidationSigs.includes(txLog.topics.at(0))) {
+      // it is a liquidation transaction; skip
+      return;
+    }
+  }
+
+  handleVatFrob(event);
 }
 
 // Borrow/Repay/Deposit/Withdraw

--- a/subgraphs/makerdao/src/mapping.ts
+++ b/subgraphs/makerdao/src/mapping.ts
@@ -216,11 +216,6 @@ export function handleVatCage(event: VatNoteEvent): void {
 }
 
 export function handleVatGrab(event: VatNoteEvent): void {
-  log.info("[handleVatGrab]tx={}-{}", [
-    event.transaction.hash.toHexString(),
-    event.transactionLogIndex.toString(),
-  ]);
-
   // only needed for non-liquidations
   if (!event.receipt) {
     log.error("[handleVatGrab]no receipt found. Tx Hash: {}", [
@@ -245,17 +240,6 @@ export function handleVatGrab(event: VatNoteEvent): void {
 
   for (let i = 0; i < event.receipt!.logs.length; i++) {
     const txLog = event.receipt!.logs[i];
-    log.info(
-      "[handleVatGrab]LogIndex={},signature={},liquidationSigs=[{}, {}], signature==Sigs[0]?{}, signature==Sigs[1]?{}",
-      [
-        txLog.logIndex.toString(),
-        txLog.topics.at(0).toHexString(),
-        liquidationSigs[0].toHexString(),
-        liquidationSigs[1].toHexString(),
-        txLog.topics.at(0).equals(liquidationSigs[0]).toString(),
-        txLog.topics.at(0).equals(liquidationSigs[1]).toString(),
-      ]
-    );
 
     if (liquidationSigs.includes(txLog.topics.at(0))) {
       // it is a liquidation transaction; skip


### PR DESCRIPTION
This PR fixes crash of makerdao subgraph (#1855) due to negative borrower balance in the D3MHub because the subgraph didn't account for fees in D3MHub contract.

### deployment & dashboard (drafting/sync in progress)
- deployment 1: https://thegraph.com/hosted-service/subgraph/tnkrxyz/makerdao-ethereum?version=pending (drafted from messari/makerdao-ethereum)
- deployment 2: https://thegraph.com/hosted-service/subgraph/tnkrxyz/test-subgraph (sync from scratch)
- dashboard: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/id/QmeVJZYjMnmL3KUQXAJjkFLLXFnnwhnz8SNxSj96fQ2A5y&tab=protocol