### PR TITLE
fix(#minor); Uniswap V3; Update ticks so that it grabs liquidity net and gross when the entity is created. 

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3817,8 +3817,8 @@
         "network": "arbitrum",
         "status": "prod",
         "versions": {
-          "schema": "1.3.0",
-          "subgraph": "1.2.0",
+          "schema": "3.0.3",
+          "subgraph": "1.2.2",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-v3/schema.graphql
+++ b/subgraphs/uniswap-v3/schema.graphql
@@ -932,6 +932,8 @@ type Tick @entity {
 
   " Block number of the last time this entity was updated "
   lastUpdateBlockNumber: BigInt!
+
+  _new: Boolean!
 }
 
 #######################################

--- a/subgraphs/uniswap-v3/src/common/constants.ts
+++ b/subgraphs/uniswap-v3/src/common/constants.ts
@@ -150,3 +150,5 @@ export const PROTOCOL_FEE_TO_OFF = BigDecimal.fromString("0");
 export const MOST_RECENT_TRANSACTION = "MOST_RECENT_TRANSACTION";
 
 export const TICK_BASE = BigDecimal.fromString("1.0001");
+
+export const MINIMUM_LIQUIDITY = BigInt.fromI32(1000);

--- a/subgraphs/uniswap-v3/src/common/entities/tick.ts
+++ b/subgraphs/uniswap-v3/src/common/entities/tick.ts
@@ -1,12 +1,8 @@
-import { BigDecimal, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigDecimal, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { LiquidityPool, Tick } from "../../../generated/schema";
-import {
-  BIGDECIMAL_ONE,
-  BIGDECIMAL_ZERO,
-  BIGINT_ZERO,
-  INT_ZERO,
-} from "../constants";
+import { BIGDECIMAL_ONE, BIGINT_ZERO, INT_ZERO } from "../constants";
 import { bigDecimalExponated, safeDivBigDecimal } from "../utils/utils";
+import { Pool } from "../../../generated/Factory/Pool";
 
 export function getOrCreateTick(
   event: ethereum.Event,
@@ -17,6 +13,28 @@ export function getOrCreateTick(
   let tick = Tick.load(id);
 
   if (!tick) {
+    // Get tick info
+    const poolContract = Pool.bind(Address.fromBytes(pool.id));
+    const tick_info = poolContract.try_ticks(tickIndex.toI32());
+    let liquidityNet = BIGINT_ZERO;
+    let liquidityGross = BIGINT_ZERO;
+
+    if (!tick_info.reverted) {
+      liquidityGross = tick_info.value.value0;
+      liquidityNet = tick_info.value.value1;
+    }
+
+    // Update pool liquidity
+    pool.totalLiquidity = pool.totalLiquidity.plus(liquidityGross);
+    const liquidityPricePerUnit = safeDivBigDecimal(
+      pool.totalLiquidityUSD,
+      pool.totalLiquidity.toBigDecimal()
+    );
+    pool.totalLiquidityUSD = pool.totalLiquidity
+      .toBigDecimal()
+      .times(liquidityPricePerUnit);
+
+    // Create tick
     tick = new Tick(id);
     tick.index = tickIndex;
     tick.pool = pool.id;
@@ -27,18 +45,23 @@ export function getOrCreateTick(
       tick.index
     );
     tick.prices = [price0, safeDivBigDecimal(BIGDECIMAL_ONE, price0)];
-    tick.liquidityGross = BIGINT_ZERO;
-    tick.liquidityGrossUSD = BIGDECIMAL_ZERO;
-    tick.liquidityNet = BIGINT_ZERO;
-    tick.liquidityNetUSD = BIGDECIMAL_ZERO;
-
+    tick.liquidityGross = liquidityGross;
+    tick.liquidityGrossUSD = liquidityGross
+      .toBigDecimal()
+      .times(liquidityPricePerUnit);
+    tick.liquidityNet = liquidityNet;
+    tick.liquidityNetUSD = liquidityNet
+      .toBigDecimal()
+      .times(liquidityPricePerUnit);
     tick.lastSnapshotDayID = INT_ZERO;
     tick.lastSnapshotHourID = INT_ZERO;
     tick.lastUpdateBlockNumber = BIGINT_ZERO;
     tick.lastUpdateTimestamp = BIGINT_ZERO;
+    tick._new = true;
 
     tick.save();
   }
 
+  tick._new = false;
   return tick;
 }


### PR DESCRIPTION
Context:
Because of the re-genesis of the Optimism blockchain, the gross liquidity and net liquidity on the tick entities is not accurately tracked for this chain. This is because they are tracked as a cumulative value. By grabbing the data from the contract when the entity is instantiated, it fixes this problem. Also, this allows the total liquidity at the pool level to be tracked accurately as well from the gross liquidity,