### PR TITLE
fix(#minor); Uniswap V3 Arbitrum; Blacklist some tokens

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3817,8 +3817,8 @@
         "network": "arbitrum",
         "status": "prod",
         "versions": {
-          "schema": "1.3.0",
-          "subgraph": "1.2.0",
+          "schema": "3.0.3",
+          "subgraph": "1.2.3",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3895,8 +3895,8 @@
         "network": "optimism",
         "status": "prod",
         "versions": {
-          "schema": "1.3.0",
-          "subgraph": "1.1.2",
+          "schema": "3.0.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3917,8 +3917,8 @@
         "network": "polygon",
         "status": "prod",
         "versions": {
-          "schema": "1.3.0",
-          "subgraph": "1.1.4",
+          "schema": "3.0.3",
+          "subgraph": "1.1.6",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.ts
+++ b/subgraphs/uniswap-v3/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.ts
@@ -67,7 +67,11 @@ export class UniswapV3ArbitrumConfigurations implements Configurations {
     return stringToBytesList([]);
   }
   getUntrackedTokens(): Bytes[] {
-    return stringToBytesList([]);
+    return stringToBytesList([
+      "0x916c1daf79236700eb67e593dc2456890ffba548",
+      "0x73e7d8bad2677656c8cfbe6e18a9257c6be2b87f",
+      "0x7a6717ceabe536bb9a6bb39182a4cd575d4e222e",
+    ]);
   }
   getMinimumLiquidityThreshold(): BigDecimal {
     return BigDecimal.fromString("100000");


### PR DESCRIPTION
**Context:**
- Pricing outliers for Trident, Blue, and Arbitrum. These are all fake versions of these tokens and they are screwing up the metrics. So here I blacklist them. 