### PR TITLE
Feat(#minor); Added `collateralvolume` on options schema 

### DIFF
--- a/schema-derivatives-options.graphql
+++ b/schema-derivatives-options.graphql
@@ -462,6 +462,9 @@ type FinancialsDailySnapshot @entity(immutable: true) {
   " All historical trade notional volume of underylying assets in USD "
   cumulativeVolumeUSD: BigDecimal!
 
+  " Current Collateral assets in USD in this pool that was used for trading, amount taken at snapshot"
+  collateralUsedUSD: BigDecimal
+
   " Daily volume of Collateral assets in USD in this pool that was used for trading"
   dailyCollateralVolumeUSD: BigDecimal
 
@@ -895,6 +898,9 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) {
 
   " Daily trade notional volume occurred when contract created, in USD "
   dailyVolumeUSD: BigDecimal!
+
+  " Current Collateral assets in USD in this pool that was used for trading, amount taken at snapshot"
+  collateralUsedUSD: BigDecimal
 
   " Daily volume of collateral when contract created, in USD, that was used for trading "
   dailyCollateralVolumeUSD: BigDecimal

--- a/schema-derivatives-options.graphql
+++ b/schema-derivatives-options.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Derivatives Options
-# Version: 1.3.0
+# Version: 1.3.1
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {

--- a/schema-derivatives-options.graphql
+++ b/schema-derivatives-options.graphql
@@ -263,7 +263,7 @@ type DerivOptProtocol implements Protocol @entity {
   " All historical notional volume in USD taken of underlying at time of contract minting"
   cumulativeVolumeUSD: BigDecimal!
 
-  " All historical volume of Collateral assets in USD in this pool"
+  " All historical volume of Collateral assets in USD in this pool that was used for trading"
   cumulativeCollateralVolumeUSD: BigDecimal
 
   " All historical notional volume in USD taken of underlying at time of contract exercise"
@@ -462,10 +462,10 @@ type FinancialsDailySnapshot @entity(immutable: true) {
   " All historical trade notional volume of underylying assets in USD "
   cumulativeVolumeUSD: BigDecimal!
 
-  " Daily volume of Collateral assets in USD in this pool"
+  " Daily volume of Collateral assets in USD in this pool that was used for trading"
   dailyCollateralVolumeUSD: BigDecimal
 
-  " All historical volume of Collateral assets in USD in this pool"
+  " All historical volume of Collateral assets in USD in this pool that was used for trading"
   cumulativeCollateralVolumeUSD: BigDecimal
 
   " Daily notional volume in USD taken of underlying at time of contract exercise"
@@ -659,7 +659,7 @@ type LiquidityPool @entity {
   " All historical trade notional volume of underylying assets in USD in this pool "
   cumulativeVolumeUSD: BigDecimal!
 
-  " All historical volume of Collateral assets in USD in this pool "
+  " All historical volume of Collateral assets in USD in this pool, that was used for trading "
   cumulativeCollateralVolumeUSD: BigDecimal
 
   " All historical deposit notional volume occurred in this pool, in USD "
@@ -896,7 +896,7 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) {
   " Daily trade notional volume occurred when contract created, in USD "
   dailyVolumeUSD: BigDecimal!
 
-  " Daily volume of collateral when contract created, in USD "
+  " Daily volume of collateral when contract created, in USD, that was used for trading "
   dailyCollateralVolumeUSD: BigDecimal
 
   " Daily trade notional volume for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
@@ -908,7 +908,7 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) {
   " All historical trade notional volume occurred in this pool, in USD "
   cumulativeVolumeUSD: BigDecimal!
 
-  " All historical volume of Collateral assets in USD in this pool"
+  " All historical volume of Collateral assets in USD in this pool, that was used for trading"
   cumulativeCollateralVolumeUSD: BigDecimal
 
   " All trade notional volume for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "

--- a/schema-derivatives-options.graphql
+++ b/schema-derivatives-options.graphql
@@ -263,6 +263,9 @@ type DerivOptProtocol implements Protocol @entity {
   " All historical notional volume in USD taken of underlying at time of contract minting"
   cumulativeVolumeUSD: BigDecimal!
 
+  " All historical volume of Collateral assets in USD in this pool"
+  cumulativeCollateralVolumeUSD: BigDecimal
+
   " All historical notional volume in USD taken of underlying at time of contract exercise"
   cumulativeExercisedVolumeUSD: BigDecimal!
 
@@ -458,6 +461,12 @@ type FinancialsDailySnapshot @entity(immutable: true) {
 
   " All historical trade notional volume of underylying assets in USD "
   cumulativeVolumeUSD: BigDecimal!
+
+  " Daily volume of Collateral assets in USD in this pool"
+  dailyCollateralVolumeUSD: BigDecimal
+
+  " All historical volume of Collateral assets in USD in this pool"
+  cumulativeCollateralVolumeUSD: BigDecimal
 
   " Daily notional volume in USD taken of underlying at time of contract exercise"
   dailyExercisedVolumeUSD: BigDecimal!

--- a/schema-derivatives-options.graphql
+++ b/schema-derivatives-options.graphql
@@ -650,6 +650,9 @@ type LiquidityPool @entity {
   " All historical trade notional volume of underylying assets in USD in this pool "
   cumulativeVolumeUSD: BigDecimal!
 
+  " All historical volume of Collateral assets in USD in this pool "
+  cumulativeCollateralVolumeUSD: BigDecimal
+
   " All historical deposit notional volume occurred in this pool, in USD "
   cumulativeDepositedVolumeUSD: BigDecimal!
 
@@ -884,6 +887,9 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) {
   " Daily trade notional volume occurred when contract created, in USD "
   dailyVolumeUSD: BigDecimal!
 
+  " Daily volume of collateral when contract created, in USD "
+  dailyCollateralVolumeUSD: BigDecimal
+
   " Daily trade notional volume for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
   dailyVolumeByTokenAmount: [BigInt!]!
 
@@ -892,6 +898,9 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) {
 
   " All historical trade notional volume occurred in this pool, in USD "
   cumulativeVolumeUSD: BigDecimal!
+
+  " All historical volume of Collateral assets in USD in this pool"
+  cumulativeCollateralVolumeUSD: BigDecimal
 
   " All trade notional volume for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
   cumulativeVolumeByTokenAmount: [BigInt!]!


### PR DESCRIPTION
`VolumeUSD` currently refers to notional volume at pool level. This is the most relevant metric. in discussions from dopex it was suggested to add `collateralVolume` as an additional metric as it can also be tracked. it is a less relevant metric but makes our schema more comprehensive. 