### PR TITLE
fix(#minor); Uniswap V3 Optimism; Instantiate ticks at re-genesis

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3996,7 +3996,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.0.3",
-          "subgraph": "1.3.5",
+          "subgraph": "1.3.6",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4022,7 +4022,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.0.3",
-          "subgraph": "1.2.10",
+          "subgraph": "1.2.11",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4048,7 +4048,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.0.3",
-          "subgraph": "1.3.5",
+          "subgraph": "1.3.6",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4074,7 +4074,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.0.3",
-          "subgraph": "1.2.6",
+          "subgraph": "1.3.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4096,7 +4096,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.0.3",
-          "subgraph": "1.2.8",
+          "subgraph": "1.2.9",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4126,7 +4126,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.0.3",
-          "subgraph": "1.1.0",
+          "subgraph": "1.1.1",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4148,7 +4148,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.0.3",
-          "subgraph": "1.1.0",
+          "subgraph": "1.1.1",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-v3-forks/abis/pancakeswap-v3/TickLens.json
+++ b/subgraphs/uniswap-v3-forks/abis/pancakeswap-v3/TickLens.json
@@ -1,0 +1,31 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "pool", "type": "address" },
+      { "internalType": "int16", "name": "tickBitmapIndex", "type": "int16" }
+    ],
+    "name": "getPopulatedTicksInWord",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "int24", "name": "tick", "type": "int24" },
+          {
+            "internalType": "int128",
+            "name": "liquidityNet",
+            "type": "int128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "liquidityGross",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct ITickLens.PopulatedTick[]",
+        "name": "populatedTicks",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/uniswap-v3-forks/abis/uniswap-v3/TickLens.json
+++ b/subgraphs/uniswap-v3-forks/abis/uniswap-v3/TickLens.json
@@ -1,0 +1,31 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "pool", "type": "address" },
+      { "internalType": "int16", "name": "tickBitmapIndex", "type": "int16" }
+    ],
+    "name": "getPopulatedTicksInWord",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "int24", "name": "tick", "type": "int24" },
+          {
+            "internalType": "int128",
+            "name": "liquidityNet",
+            "type": "int128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "liquidityGross",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct ITickLens.PopulatedTick[]",
+        "name": "populatedTicks",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/uniswap-v3-forks/protocols/pancakeswap-v3/config/templates/pancakeswapV3Template.yaml
+++ b/subgraphs/uniswap-v3-forks/protocols/pancakeswap-v3/config/templates/pancakeswapV3Template.yaml
@@ -36,6 +36,8 @@ dataSources:
           file: ./abis/pancakeswap-v3/Pool.json
         - name: Factory
           file: ./abis/pancakeswap-v3/Factory.json
+        - name: TickLens
+          file: ./abis/uniswap-v3/TickLens.json
         - name: ERC20
           file: ./abis/ERC20.json
         - name: ERC20SymbolBytes

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/templates/uniswapV3Template.yaml
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/templates/uniswapV3Template.yaml
@@ -36,6 +36,8 @@ dataSources:
           file: ./abis/uniswap-v3/Pool.json
         - name: Factory
           file: ./abis/uniswap-v3/Factory.json
+        - name: TickLens
+          file: ./abis/uniswap-v3/TickLens.json
         - name: ERC20
           file: ./abis/ERC20.json
         - name: ERC20SymbolBytes

--- a/subgraphs/uniswap-v3-forks/src/common/entities/tick.ts
+++ b/subgraphs/uniswap-v3-forks/src/common/entities/tick.ts
@@ -1,4 +1,4 @@
-import { BigDecimal, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { BigDecimal, Bytes, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { LiquidityPool, Tick } from "../../../generated/schema";
 import {
   BIGDECIMAL_ONE,
@@ -6,7 +6,7 @@ import {
   BIGINT_ZERO,
   INT_ZERO,
 } from "../constants";
-import { bigDecimalExponated, safeDivBigDecimal } from "../utils/utils";
+import { bigDecimalExponentiated, safeDivBigDecimal } from "../utils/utils";
 
 export function getOrCreateTick(
   event: ethereum.Event,
@@ -22,7 +22,7 @@ export function getOrCreateTick(
     tick.pool = pool.id;
     tick.createdTimestamp = event.block.timestamp;
     tick.createdBlockNumber = event.block.number;
-    const price0 = bigDecimalExponated(
+    const price0 = bigDecimalExponentiated(
       BigDecimal.fromString("1.0001"),
       tick.index
     );

--- a/subgraphs/uniswap-v3-forks/src/common/entities/tick.ts
+++ b/subgraphs/uniswap-v3-forks/src/common/entities/tick.ts
@@ -1,4 +1,4 @@
-import { BigDecimal, Bytes, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { BigDecimal, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { LiquidityPool, Tick } from "../../../generated/schema";
 import {
   BIGDECIMAL_ONE,

--- a/subgraphs/uniswap-v3-forks/src/common/entities/token.ts
+++ b/subgraphs/uniswap-v3-forks/src/common/entities/token.ts
@@ -64,7 +64,7 @@ export function getOrCreateToken(
   }
 
   if (
-    token.lastPriceBlockNumber &&
+    token.lastPriceBlockNumber! &&
     event.block.number.minus(token.lastPriceBlockNumber!).gt(BIGINT_TEN) &&
     getNewPrice
   ) {

--- a/subgraphs/uniswap-v3-forks/src/common/utils/backfill.ts
+++ b/subgraphs/uniswap-v3-forks/src/common/utils/backfill.ts
@@ -1,4 +1,4 @@
-import { Address, ethereum, log, BigInt } from "@graphprotocol/graph-ts";
+import { Address, ethereum, BigInt } from "@graphprotocol/graph-ts";
 import { BIGINT_TWO, BIGINT_ZERO, INT_ONE, INT_ZERO } from "../constants";
 import { Pool } from "../../../generated/Factory/Pool";
 import { TickLens } from "../../../generated/Factory/TickLens";

--- a/subgraphs/uniswap-v3-forks/src/common/utils/backfill.ts
+++ b/subgraphs/uniswap-v3-forks/src/common/utils/backfill.ts
@@ -73,6 +73,7 @@ export function populateEmptyPools(event: ethereum.Event): void {
 
     // https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickMath.sol
     // https://docs.uniswap.org/contracts/v3/reference/periphery/lens/TickLens
+    // Min and Max tick are the range of ticks that a position can be in
     const maxTick: number = customCeil(887272 / tickSpacing) * tickSpacing;
     const minTick: number = -maxTick;
     const ticksPerWord: number = 256 * tickSpacing;

--- a/subgraphs/uniswap-v3-forks/src/common/utils/backfill.ts
+++ b/subgraphs/uniswap-v3-forks/src/common/utils/backfill.ts
@@ -1,6 +1,7 @@
-import { Address, ethereum } from "@graphprotocol/graph-ts";
-import { INT_ONE, INT_ZERO } from "../constants";
+import { Address, ethereum, log, BigInt } from "@graphprotocol/graph-ts";
+import { BIGINT_TWO, BIGINT_ZERO, INT_ONE, INT_ZERO } from "../constants";
 import { Pool } from "../../../generated/Factory/Pool";
+import { TickLens } from "../../../generated/Factory/TickLens";
 import { ERC20 } from "../../../generated/Factory/ERC20";
 import { convertTokenToDecimal } from "./utils";
 import { POOL_MAPPINGS } from "./poolMappings";
@@ -11,6 +12,7 @@ import {
 } from "../entities/pool";
 import { getOrCreateProtocol } from "../entities/protocol";
 import { getOrCreateToken } from "../entities/token";
+import { getOrCreateTick } from "../entities/tick";
 
 /**
  * Create entries in store for each pool and token
@@ -18,6 +20,9 @@ import { getOrCreateToken } from "../entities/token";
  */
 export function populateEmptyPools(event: ethereum.Event): void {
   const length = POOL_MAPPINGS.length;
+  const tickLensContract = TickLens.bind(
+    Address.fromString("0xbfd8137f7d1516d3ea5ca83523914859ec47f573")
+  );
 
   for (let i = 0; i < length; ++i) {
     const poolMapping = POOL_MAPPINGS[i];
@@ -64,6 +69,42 @@ export function populateEmptyPools(event: ethereum.Event): void {
     pool.totalLiquidity = poolContract.liquidity();
     pool.activeLiquidity = pool.totalLiquidity;
 
+    const tickSpacing = poolContract.tickSpacing();
+
+    const maxTick: number = customCeil(887272 / tickSpacing) * tickSpacing;
+    const minTick: number = -maxTick;
+    const ticksPerWord: number = 256 * tickSpacing;
+    const wordsCount: number = customCeil((maxTick - minTick) / ticksPerWord);
+
+    let totalLiquidityGross = BIGINT_ZERO;
+    for (let i = 0; i < wordsCount; i++) {
+      const tickBitmapIndex = customFloor(minTick / ticksPerWord) + i;
+      const populatedTicks = tickLensContract.getPopulatedTicksInWord(
+        poolAddress,
+        tickBitmapIndex as i32
+      );
+
+      for (let j = 0; j < populatedTicks.length; j++) {
+        const populatedTick = populatedTicks[j];
+        const tick = getOrCreateTick(
+          event,
+          pool,
+          BigInt.fromI32(populatedTick.tick as i32)
+        );
+        tick.liquidityGross = populatedTick.liquidityGross;
+        tick.liquidityNet = populatedTick.liquidityNet;
+        tick.lastUpdateTimestamp = event.block.timestamp;
+        tick.lastUpdateBlockNumber = event.block.number;
+        tick.save();
+
+        totalLiquidityGross = totalLiquidityGross.plus(
+          populatedTick.liquidityGross
+        );
+      }
+    }
+
+    pool.totalLiquidity = totalLiquidityGross.div(BIGINT_TWO);
+
     poolAmounts.save();
     pool.save();
   }
@@ -72,4 +113,20 @@ export function populateEmptyPools(event: ethereum.Event): void {
 
   protocol._regenesis = true;
   protocol.save();
+}
+
+function customFloor(value: number): number {
+  return value % 1 === 0
+    ? value
+    : value > 0
+    ? parseInt(value.toString())
+    : parseInt(value.toString()) - 1;
+}
+
+function customCeil(value: number): number {
+  return value % 1 === 0
+    ? value
+    : value > 0
+    ? parseInt(value.toString()) + 1
+    : parseInt(value.toString());
 }

--- a/subgraphs/uniswap-v3-forks/src/common/utils/backfill.ts
+++ b/subgraphs/uniswap-v3-forks/src/common/utils/backfill.ts
@@ -71,6 +71,8 @@ export function populateEmptyPools(event: ethereum.Event): void {
 
     const tickSpacing = poolContract.tickSpacing();
 
+    // https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickMath.sol
+    // https://docs.uniswap.org/contracts/v3/reference/periphery/lens/TickLens
     const maxTick: number = customCeil(887272 / tickSpacing) * tickSpacing;
     const minTick: number = -maxTick;
     const ticksPerWord: number = 256 * tickSpacing;

--- a/subgraphs/uniswap-v3-forks/src/common/utils/utils.ts
+++ b/subgraphs/uniswap-v3-forks/src/common/utils/utils.ts
@@ -13,6 +13,7 @@ import {
   BIGINT_TEN,
   BIGDECIMAL_NEG_ONE,
   BIGINT_HUNDRED,
+  BIGINT_TWO,
 } from "../constants";
 import { getLiquidityPoolFee } from "../entities/pool";
 
@@ -142,25 +143,26 @@ export function toLowerCase(list: string[]): string[] {
   return list;
 }
 
-export function bigDecimalExponated(
-  value: BigDecimal,
-  power: BigInt
+export function bigDecimalExponentiated(
+  base: BigDecimal,
+  exponent: BigInt
 ): BigDecimal {
-  if (power.equals(BIGINT_ZERO)) {
-    return BIGDECIMAL_ONE;
-  }
-  const negativePower = power.lt(BIGINT_ZERO);
-  let result = BIGDECIMAL_ZERO.plus(value);
-  const powerAbs = power.abs();
-  for (let i = BIGINT_ONE; i.lt(powerAbs); i = i.plus(BIGINT_ONE)) {
-    result = result.times(value);
+  let x = base;
+  let y = BIGDECIMAL_ONE;
+  let n = exponent;
+
+  while (n > BIGINT_ONE) {
+    if (n.mod(BIGINT_TWO) == BIGINT_ZERO) {
+      x = x.times(x);
+      n = n.div(BIGINT_TWO);
+    } else {
+      y = y.times(x);
+      x = x.times(x);
+      n = n.minus(BIGINT_ONE).div(BIGINT_TWO);
+    }
   }
 
-  if (negativePower) {
-    result = safeDiv(BIGDECIMAL_ONE, result);
-  }
-
-  return result;
+  return x.times(y);
 }
 
 // Turn a list of BigInts into a list of absolute value BigInts


### PR DESCRIPTION
**Context:**
The `liquidityGross` and `liquidityNet` values on the tick entities and the `totalLiquidity` value on the liquidity pool entities were incorrect for this network because there was a re-genesis of Optimism, and all previous data was lost. Because these values are usually tracked in an accumulating manner, this breaks the calculation for Optimism. This PR addresses this issue by running contract calls at the beginning of indexing to pull these liquidity values for each tick and updating the necessary fields before continuing with the regular indexing protocol. This was an adjustment to the backfill already done with the Optimism pools, and it should not impact the data of any other chain for Uniswap or Pancakeswap. 

**Changes:**
- Improved the performance of the exponentiation utility function to avoid computational limits. 
- Added the TickLens ABI and used the contract to pull tick data in the Optimism backfill. 
- Updated the Optimism backfill process to include the instantiation of ticks with current liquidity values and the `totalLiquidity` field on liquidity pool entities that is an aggregate of these values.

**Deployment:**
https://thegraph.com/hosted-service/subgraph/steegecs/uniswap-v3-optimism?version=pending