### PR TITLE
chore(); Arbitrum Migration; Migrate decentralized network subgraphs to Arbitrum

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -4724,6 +4724,10 @@
           "hosted-service": {
             "slug": "sushiswap-arbitrum",
             "query-id": "sushiswap-arbitrum"
+          },
+          "decentralized-network": {
+            "slug": "sushiswap-arbitrum",
+            "query-id": "UNKNOWN"
           }
         }
       },
@@ -4746,6 +4750,10 @@
           "hosted-service": {
             "slug": "sushiswap-avalanche",
             "query-id": "sushiswap-avalanche"
+          },
+          "decentralized-network": {
+            "slug": "sushiswap-avalanche",
+            "query-id": "UNKNOWN"
           }
         }
       },
@@ -5008,6 +5016,10 @@
           "hosted-service": {
             "slug": "trader-joe-avalanche",
             "query-id": "trader-joe-avalanche"
+          },
+          "decentralized-network": {
+            "slug": "trader-joe-avalanche",
+            "query-id": "UNKNOWN"
           }
         }
       }
@@ -6895,6 +6907,10 @@
           "hosted-service": {
             "slug": "pangolin-avalanche",
             "query-id": "pangolin-avalanche"
+          },
+          "decentralized-network": {
+            "slug": "pangolin-avalanche",
+            "query-id": "UNKNOWN"
           }
         },
         "files": {

--- a/subgraphs/balancer-forks/protocols/balancer-v2/config/deployments/balancer-v2-ethereum/configurations.json
+++ b/subgraphs/balancer-forks/protocols/balancer-v2/config/deployments/balancer-v2-ethereum/configurations.json
@@ -19,7 +19,7 @@
   "balancerTokenAdminStartBlock": 14456738,
   "usesBalancerTokenAdmin": true,
 
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "QmRD5cEyRossPmz2AdYjeoa1KPLgS7wu5v5oF9uGDd81HC",
   "graftStartBlock": "16637574"
 }


### PR DESCRIPTION
**Context:**
Arbitrum on the decentralized network is now live!  We want to begin migrating our subgraphs from being deployed on Ethereum to Arbitrum.