### PR TITLE
fix (#patch); axelar; fixed revenue and non-evm address

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -8518,8 +8518,8 @@
         "status": "dev",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.0.0",
-          "methodology": "1.0.0"
+          "subgraph": "1.0.1",
+          "methodology": "1.0.1"
         },
         "files": {
           "template": "axelar.template.yaml"
@@ -8540,8 +8540,8 @@
         "status": "dev",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.0.0",
-          "methodology": "1.0.0"
+          "subgraph": "1.0.1",
+          "methodology": "1.0.1"
         },
         "files": {
           "template": "axelar.template.yaml"
@@ -8562,8 +8562,8 @@
         "status": "dev",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.0.0",
-          "methodology": "1.0.0"
+          "subgraph": "1.0.1",
+          "methodology": "1.0.1"
         },
         "files": {
           "template": "axelar.template.yaml"
@@ -8584,8 +8584,8 @@
         "status": "dev",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.0.0",
-          "methodology": "1.0.0"
+          "subgraph": "1.0.1",
+          "methodology": "1.0.1"
         },
         "files": {
           "template": "axelar.template.yaml"
@@ -8606,8 +8606,8 @@
         "status": "dev",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.0.0",
-          "methodology": "1.0.0"
+          "subgraph": "1.0.1",
+          "methodology": "1.0.1"
         },
         "files": {
           "template": "axelar.template.yaml"
@@ -8628,8 +8628,8 @@
         "status": "dev",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.0.0",
-          "methodology": "1.0.0"
+          "subgraph": "1.0.1",
+          "methodology": "1.0.1"
         },
         "files": {
           "template": "axelar.template.yaml"
@@ -8650,8 +8650,8 @@
         "status": "dev",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.0.0",
-          "methodology": "1.0.0"
+          "subgraph": "1.0.1",
+          "methodology": "1.0.1"
         },
         "files": {
           "template": "axelar.template.yaml"
@@ -8672,8 +8672,8 @@
         "status": "dev",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.0.0",
-          "methodology": "1.0.0"
+          "subgraph": "1.0.1",
+          "methodology": "1.0.1"
         },
         "files": {
           "template": "axelar.template.yaml"

--- a/subgraphs/axelar/README.md
+++ b/subgraphs/axelar/README.md
@@ -2,7 +2,7 @@
 
 Axelar network support cross-chain communication and token transfers.
 
-## Methodology Version 1.0.0
+## Methodology Version 1.0.1
 
 ### Usage Metrics
 
@@ -26,11 +26,7 @@ Not applicable.
 
 ### Total Revenue USD
 
-Total revenue is a measure of the fees paid by the traders over a specific period.
-
-Total Revenue = `ProtocolSideRevenue`
-
-Note: Gas fees varying by chain and token, and the information is only available via Axelar CLI or Satellite frontend and not available on-chain. The current subgraph implementation tracks fee payment by users to the Gas Service contract, which include prepaid actual gas fee and fees to the protocol (maybe set to 0). Overpaid gas fees are refunded to the user, which may lead to negative revenue for certain days in the snapshot when the refund happened in a day/hour different than the payment.
+The Axelar bridge currently charges only gas fees and no bridge fees. Gas fees paid by users are used for transfers, relays and contract calls, and not collected as protocol side revenue. The total revenue is 0 as of April 2023.
 
 #### Supply Side Revenue USD
 
@@ -38,11 +34,7 @@ None
 
 #### Protocol Side Revenue USD
 
-The protocol receive 100% of the protocol fees from the xAsset model of bridging.
-
-Protocol Side Revenue = Sum `gas fee paid by users of the bridge`
-
-Part of the paid gas fees may be used for token mint or contract call, but the amount is unknown (e.g. in the destination chain).
+None
 
 ### Pool-Level Metrics
 

--- a/subgraphs/axelar/protocols/axelar/config/deployments/axelar-arbitrum/configurations.json
+++ b/subgraphs/axelar/protocols/axelar/config/deployments/axelar-arbitrum/configurations.json
@@ -5,7 +5,7 @@
     "startBlock": 42018673
   },
   "AxelarGasService": {
-    "address": "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    "address": "0x0000000000000000000000000000000000000000",
     "startBlock": 43982851
   },
   "supportCallHandlers": false,

--- a/subgraphs/axelar/protocols/axelar/config/deployments/axelar-avalanche/configurations.json
+++ b/subgraphs/axelar/protocols/axelar/config/deployments/axelar-avalanche/configurations.json
@@ -5,7 +5,7 @@
     "startBlock": 8590881
   },
   "AxelarGasService": {
-    "address": "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    "address": "0x0000000000000000000000000000000000000000",
     "startBlock": 19369414
   },
   "supportCallHandlers": false,

--- a/subgraphs/axelar/protocols/axelar/config/deployments/axelar-bsc/configurations.json
+++ b/subgraphs/axelar/protocols/axelar/config/deployments/axelar-bsc/configurations.json
@@ -5,7 +5,7 @@
     "startBlock": 19151651
   },
   "AxelarGasService": {
-    "address": "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    "address": "0x0000000000000000000000000000000000000000",
     "startBlock": 20931507
   },
   "supportCallHandlers": false,

--- a/subgraphs/axelar/protocols/axelar/config/deployments/axelar-celo/configurations.json
+++ b/subgraphs/axelar/protocols/axelar/config/deployments/axelar-celo/configurations.json
@@ -5,7 +5,7 @@
     "startBlock": 2750407
   },
   "AxelarGasService": {
-    "address": "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    "address": "0x0000000000000000000000000000000000000000",
     "startBlock": 2750690
   },
   "supportCallHandlers": false,

--- a/subgraphs/axelar/protocols/axelar/config/deployments/axelar-ethereum/configurations.json
+++ b/subgraphs/axelar/protocols/axelar/config/deployments/axelar-ethereum/configurations.json
@@ -5,11 +5,11 @@
     "startBlock": 13857570
   },
   "AxelarGasService": {
-    "address": "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    "address": "0x0000000000000000000000000000000000000000",
     "startBlock": 15448318
   },
   "supportCallHandlers": true,
   "graftEnabled": false,
-  "subgraphId": "QmcUEtkUvCJtsYhdq4t7mrxe9fnybXxJPnNAbCsjwXZ9uQ",
-  "graftStartBlock": 15484661
+  "subgraphId": "QmUxhg6r5uJ4o8jvWRwwhSwmw9iDBnZ4NTBvSBaYfmnzbg",
+  "graftStartBlock": 17074656
 }

--- a/subgraphs/axelar/protocols/axelar/config/deployments/axelar-fantom/configurations.json
+++ b/subgraphs/axelar/protocols/axelar/config/deployments/axelar-fantom/configurations.json
@@ -5,7 +5,7 @@
     "startBlock": 25758453
   },
   "AxelarGasService": {
-    "address": "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    "address": "0x0000000000000000000000000000000000000000",
     "startBlock": 46087791
   },
   "supportCallHandlers": true,

--- a/subgraphs/axelar/protocols/axelar/config/deployments/axelar-moonbeam/configurations.json
+++ b/subgraphs/axelar/protocols/axelar/config/deployments/axelar-moonbeam/configurations.json
@@ -5,7 +5,7 @@
     "startBlock": 229400
   },
   "AxelarGasService": {
-    "address": "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    "address": "0x0000000000000000000000000000000000000000",
     "startBlock": 1771141
   },
   "supportCallHandlers": false,

--- a/subgraphs/axelar/protocols/axelar/config/deployments/axelar-polygon/configurations.json
+++ b/subgraphs/axelar/protocols/axelar/config/deployments/axelar-polygon/configurations.json
@@ -5,7 +5,7 @@
     "startBlock": 22850070
   },
   "AxelarGasService": {
-    "address": "0x2d5d7d31F671F86C782533cc367F14109a082712",
+    "address": "0x0000000000000000000000000000000000000000",
     "startBlock": 32528856
   },
   "supportCallHandlers": false,

--- a/subgraphs/axelar/src/mappings.ts
+++ b/subgraphs/axelar/src/mappings.ts
@@ -300,7 +300,10 @@ export function handleContractCall(event: ContractCall): void {
 export function handleContractCallApproved(event: ContractCallApproved): void {
   // contract call
   const srcChainId = networkToChainID(event.params.sourceChain.toUpperCase());
-  const srcAccount = Address.fromString(event.params.sourceAddress);
+  const srcStr = event.params.sourceAddress;
+  const srcAccount = isValidEVMAddress(srcStr)
+    ? Address.fromString(srcStr)
+    : Bytes.fromUTF8(srcStr);
   const customEvent = _createCustomEvent(event)!;
   _handleMessageIn(
     srcChainId,


### PR DESCRIPTION
This PR fixes the revenue issue found in the axelar QA (#2007 ), and the handle of non-evm src addresses in `handleContractCallApproved`.

- Test deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/axelar-ethereum?version=pending&selected=logs
- Dashboard: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/id/QmYqtQzyWSc5LPevXUesaw4bP5VzmK6QXVH98s1H9PeNaK&tab=protocol