### PR TITLE
fix (#minor); euler-finance; fix liquidation profit, updated rewards

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2424,8 +2424,8 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.3.2",
-          "methodology": "1.2.2"
+          "subgraph": "1.4.0",
+          "methodology": "1.2.3"
         },
         "files": {
           "template": "euler.template.yaml"

--- a/subgraphs/euler-finance/README.md
+++ b/subgraphs/euler-finance/README.md
@@ -6,7 +6,7 @@ Lending protocols are the life-blood of Decentralized Finance (DeFi) and provide
 
 Euler follows in the footsteps of lending protocols like AAVE and Compound but focuses on the permissionless aspect i.e. it allows users to create their own markets for any Ethereum ERC20 token. This blog from the Euler team provides much more detailed info on the benefits provided by Euler — [https://blog.euler.finance/introducing-euler-8f4422f13848](https://blog.euler.finance/introducing-euler-8f4422f13848).
 
-## Calculation Methodology v1.2.2
+## Calculation Methodology v1.2.3
 
 ### Total Value Locked (TVL) USD
 
@@ -63,13 +63,24 @@ Euler Finance distributes EUL tokens by epoch (=every 100,000 blocks) to borrowe
 3. Distribute the total EUL amount for the epoch among the top 10 markets proportional to square root of block weighted EUL amount staked;
 4. If epoch > 96, exit, else go back to 1.
 
-#### Epoch 18 - 23
+#### [Epoch 18 - 23](https://snapshot.org/#/eulerdao.eth/proposal/0x7e65ffa930507d9116ebc83663000ade6ff93fc452f437a3e95d755ccc324f93)
 
 1. At the start of a new epoch, cumulate EUL amount users staked for each market weighted by number of blocks (approximating time) the EUL is staked;
 2. At the end of the epoch, calcuate the sqrt of sum weighted EUL amount staked for all markets using the Chainlink Oracle and wstETH;
-3. The EUL amount each market receives is proportional to the sqrt of sum weighted EUL amount staked for the market.
+3. Total 8,000 EUL is distributed to markets proportional to the sqrt of sum weighted EUL amount staked for the market.
 4. 8000 EUL awarded to borrowers in the USDC, USDT, WETH, and wstETH market;
 5. 5000 EUL awarded to lenders staking their output token from USDC, USDT, and WETH market.
+
+#### [Epoch 24](https://snapshot.org/#/eulerdao.eth/proposal/0x551f9e6f3fba50a0fc2c69e361f7a81979189aa7f0ed923a1873bd578896942b)
+
+1. At the start of a new epoch, cumulate EUL amount users staked for each market weighted by number of blocks (approximating time) the EUL is staked;
+2. At the end of the epoch, calcuate the sqrt of sum weighted EUL amount staked for all markets using the Chainlink Oracle and wstETH;
+3. Total 8,000 EUL is distributed to markets proportional to the sqrt of sum weighted EUL amount staked for the market.
+4. 8000 EUL awarded to borrowers in the USDC, WETH, and wstETH market;
+5. EUL awarded to lenders staking their output token from these markets
+   - WETH market: 9,000
+   - USDC market: 5,000
+   - USDT market: 1,000
 
 ### Protocol Controlled Value
 

--- a/subgraphs/euler-finance/protocols/euler-finance/config/deployments/euler-finance-ethereum/configurations.json
+++ b/subgraphs/euler-finance/protocols/euler-finance/config/deployments/euler-finance-ethereum/configurations.json
@@ -1,7 +1,13 @@
 {
-  "factoryContract": "0x27182842E098f60e3D576794A5bFFb0777E025d3",
-  "startBlock": 13711759,
+  "factory": {
+    "address": "0x27182842E098f60e3D576794A5bFFb0777E025d3",
+    "startBlock": 13711759
+  },
+  "EulStakes": {
+    "address": "0xc697BB6625D9f7AdcF0fbf0cbd4DcF50D8716cd3",
+    "startBlock": 14975091
+  },
   "graftEnabled": false,
-  "subgraphId": "QmSZz3RPd2kekhBrpFkg6anaMP6WYPAEeqAQwRFdL1dCmm",
-  "graftStartBlock": 16817995
+  "subgraphId": "QmcvgkX4XYsCjfTZAgjJFociduZyR1D9WkmS7xjx3jDwGs",
+  "graftStartBlock": 15144100
 }

--- a/subgraphs/euler-finance/protocols/euler-finance/config/templates/euler.template.yaml
+++ b/subgraphs/euler-finance/protocols/euler-finance/config/templates/euler.template.yaml
@@ -14,9 +14,9 @@ dataSources:
     name: euler
     network: mainnet
     source:
-      address: "{{ factoryContract }}"
+      address: "{{ factory.address }}"
       abi: Euler
-      startBlock: {{ startBlock }} # this is when the first market was deployed
+      startBlock: {{ factory.startBlock }}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -73,9 +73,9 @@ dataSources:
     name: EulStakes
     network: mainnet
     source:
-      address: "0xc697BB6625D9f7AdcF0fbf0cbd4DcF50D8716cd3"
+      address: "{{ EulStakes.address }}"
       abi: EulStakes
-      startBlock: 14975091
+      startBlock: {{ EulStakes.startBlock }}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7

--- a/subgraphs/euler-finance/src/common/constants.ts
+++ b/subgraphs/euler-finance/src/common/constants.ts
@@ -119,7 +119,7 @@ export const VIEW_V2_START_BLOCK_NUMBER = BigInt.fromI32(14482429);
 export const WETH_ADDRESS = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
 export const USDC_ADDRESS = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 export const USDT_ADDRESS = "0xdac17f958d2ee523a2206206994597c13d831ec7";
-export const WSETH_ADDRESS = "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0";
+export const WStETH_ADDRESS = "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0";
 
 ////////////////////////
 ///// Type Helpers /////

--- a/subgraphs/euler-finance/src/mappings/handlers.ts
+++ b/subgraphs/euler-finance/src/mappings/handlers.ts
@@ -37,6 +37,7 @@ import {
   updateWeightedStakedAmount,
   processRewardEpoch6_17,
   processRewardEpoch18_23,
+  processRewardEpoch24Onward,
 } from "./helpers";
 import {
   createBorrow,
@@ -430,6 +431,8 @@ export function handleStake(event: Stake): void {
       processRewardEpoch6_17(epoch, epochStartBlock, event);
     } else if (epoch.epoch <= 23) {
       processRewardEpoch18_23(epoch, epochStartBlock, event);
+    } else {
+      processRewardEpoch24Onward(epoch, epochStartBlock, event);
     }
   }
 

--- a/subgraphs/euler-finance/src/mappings/helpers.ts
+++ b/subgraphs/euler-finance/src/mappings/helpers.ts
@@ -52,7 +52,7 @@ import {
   WETH_ADDRESS,
   USDC_ADDRESS,
   USDT_ADDRESS,
-  WSETH_ADDRESS,
+  WStETH_ADDRESS,
 } from "../common/constants";
 import { BigDecimalTruncateToBigInt, bigIntChangeDecimals, bigIntToBDUseDecimals } from "../common/conversions";
 import { LendingProtocol, Market, _AssetStatus, _Epoch } from "../../generated/schema";
@@ -897,7 +897,7 @@ export function processRewardEpoch18_23(epoch: _Epoch, epochStartBlock: BigInt, 
       const rewardTokenAmount = [BIGINT_ZERO, BIGINT_ZERO];
       const rewardTokenUSD = [BIGDECIMAL_ZERO, BIGDECIMAL_ZERO];
       // eIP24: 8000 EUL borrower rewards each for USDC, USDT, WETH, and WstETH
-      if ([USDC_ADDRESS, USDT_ADDRESS, WETH_ADDRESS, WSETH_ADDRESS].includes(mkt.inputToken)) {
+      if ([USDC_ADDRESS, USDT_ADDRESS, WETH_ADDRESS, WStETH_ADDRESS].includes(mkt.inputToken)) {
         rewardTokens.push(borrowerRewardToken.id);
         rewardTokenAmount[0] = BigDecimalTruncateToBigInt(
           BigDecimal.fromString("8000").times(EUL_DECIMALS_BD).times(dailyScaler),
@@ -933,6 +933,138 @@ export function processRewardEpoch18_23(epoch: _Epoch, epochStartBlock: BigInt, 
         mkt.rewardTokenEmissionsUSD = rewardTokenUSD;
 
         log.info("[processRewardEpoch18_23]mkt {} rewarded {} EUL tokens ${} for epoch {}", [
+          mkt.name!,
+          rewardTokenAmount.toString(),
+          rewardTokenUSD.toString(),
+          epoch.id,
+        ]);
+      }
+
+      // reset mkt._weightedStakedAmount for the new epoch
+      mkt._weightedStakedAmount = BIGINT_ZERO;
+      // EUL staked remains staked for the market until unstaked
+      // so not reset mkt._stakedAmount
+      mkt.save();
+    }
+  }
+}
+
+export function processRewardEpoch24Onward(epoch: _Epoch, epochStartBlock: BigInt, event: ethereum.Event): void {
+  // eIP51 changes the reward distribution from epoch 24 onward
+  // https://snapshot.org/#/eulerdao.eth/proposal/0x551f9e6f3fba50a0fc2c69e361f7a81979189aa7f0ed923a1873bd578896942b
+  const epochID = epoch.epoch;
+  const prevEpochID = epochID - 1;
+  const prevEpoch = _Epoch.load(prevEpochID.toString());
+  if (prevEpoch) {
+    const protocol = getOrCreateLendingProtocol();
+    let sumAccumulator = BIGDECIMAL_ZERO;
+    for (let i = 0; i < protocol._marketIDs!.length; i++) {
+      const mktID = protocol._marketIDs![i];
+      const mkt = Market.load(mktID);
+      if (!mkt) {
+        log.error("[processRewardEpoch24Onward]market {} doesn't exist, but this should not happen at tx ={}", [
+          mktID,
+          event.transaction.hash.toHexString(),
+        ]);
+        continue;
+      }
+
+      // eIP28 blacklist FTT market from EUL distribution
+      // https://snapshot.org/#/eulerdao.eth/proposal/0x40874e40bc18ff33a9504a770d5aadfa4ea8241a64bf24a36777cb5acc3b59a7
+      if (epochID >= 16 && mkt.inputToken == FTT_ADDRESS) {
+        mkt._stakedAmount = BIGINT_ZERO;
+        mkt._weightedStakedAmount = BIGINT_ZERO;
+      }
+
+      const stakedAmount = mkt._stakedAmount;
+      let mktWeightedStakedAmount = BIGINT_ZERO;
+      if (isMarketEligible(mkt) && stakedAmount.gt(BIGINT_ZERO)) {
+        // finalized mkt._weightedStakedAmount for the epoch just ended
+        // epochStartBlock.minus(BIGINT_ONE) is the end block of prev epoch
+        updateWeightedStakedAmount(mkt, epochStartBlock.minus(BIGINT_ONE));
+        mktWeightedStakedAmount = mkt._weightedStakedAmount!;
+      }
+      mkt.save();
+
+      sumAccumulator = sumAccumulator.plus(mktWeightedStakedAmount.sqrt().toBigDecimal());
+    }
+
+    const EULPriceUSD = getEULPriceUSD(event);
+    const borrowerRewardToken = getOrCreateRewardToken(Address.fromString(EUL_ADDRESS), RewardTokenType.BORROW);
+    const lenderRewardToken = getOrCreateRewardToken(Address.fromString(EUL_ADDRESS), RewardTokenType.DEPOSIT);
+    const GAUGE_REWARD_AMOUNT = BigDecimal.fromString("8000");
+
+    // scale to daily emission amount
+    const dailyScaler = BigDecimal.fromString((BLOCKS_PER_DAY / (BLOCKS_PER_EPOCH as f64)).toString());
+    const EUL_DECIMALS_BD = BigDecimal.fromString(EUL_DECIMALS.toString());
+    for (let i = 0; i < protocol._marketIDs!.length; i++) {
+      const mktID = protocol._marketIDs![i];
+      const mkt = Market.load(mktID);
+      if (!mkt) {
+        log.error("[processRewardEpoch24Onward]market {} doesn't exist, but this should not happen | tx ={}", [
+          mktID,
+          event.transaction.hash.toHexString(),
+        ]);
+        continue;
+      }
+      if (mkt.rewardTokens && mkt.rewardTokens!.length > 0) {
+        // reset reward emissions for the epoch
+        mkt.rewardTokenEmissionsAmount = [BIGINT_ZERO, BIGINT_ZERO];
+        mkt.rewardTokenEmissionsUSD = [BIGDECIMAL_ZERO, BIGDECIMAL_ZERO];
+      }
+
+      const rewardTokens: string[] = [];
+      const rewardTokenAmount = [BIGINT_ZERO, BIGINT_ZERO];
+      const rewardTokenUSD = [BIGDECIMAL_ZERO, BIGDECIMAL_ZERO];
+      // eIP51: 8000 EUL borrower rewards each for USDC, WETH, and WstETH
+      if ([USDC_ADDRESS, WETH_ADDRESS, WStETH_ADDRESS].includes(mkt.inputToken)) {
+        const BORROWER_REWARD_AMOUNT = BigDecimal.fromString("8000");
+        rewardTokens.push(borrowerRewardToken.id);
+        rewardTokenAmount[0] = BigDecimalTruncateToBigInt(
+          BORROWER_REWARD_AMOUNT.times(EUL_DECIMALS_BD).times(dailyScaler),
+        );
+        rewardTokenUSD[0] = rewardTokenAmount[0].divDecimal(EUL_DECIMALS_BD).times(EULPriceUSD);
+      }
+
+      // eIP51: 5000 EUL lender staking rewards each for USDC,
+      //        1000 for USDT, 9000 for WETH
+      let STAKING_REWARD_AMOUNT = BIGDECIMAL_ZERO;
+      if (mkt.inputToken === USDC_ADDRESS) {
+        STAKING_REWARD_AMOUNT = BigDecimal.fromString("5000");
+      } else if (mkt.inputToken === USDT_ADDRESS) {
+        STAKING_REWARD_AMOUNT = BigDecimal.fromString("1000");
+      } else if (mkt.inputToken === WETH_ADDRESS) {
+        STAKING_REWARD_AMOUNT = BigDecimal.fromString("9000");
+      }
+
+      if (STAKING_REWARD_AMOUNT.gt(BIGDECIMAL_ZERO)) {
+        rewardTokens.push(lenderRewardToken.id);
+        rewardTokenAmount[1] = BigDecimalTruncateToBigInt(
+          STAKING_REWARD_AMOUNT.times(EUL_DECIMALS_BD).times(dailyScaler),
+        );
+        rewardTokenUSD[1] = rewardTokenAmount[1].divDecimal(EUL_DECIMALS_BD).times(EULPriceUSD);
+      }
+
+      // distribute the 8000 rewards proportinally among eligible markets
+      // "8,000 EUL per epoch shared proportionally among assets with Chainlink oracle"
+      const _weightedStakedAmount = mkt._weightedStakedAmount;
+      if (isMarketEligible(mkt) && _weightedStakedAmount) {
+        if (rewardTokens.length == 0) {
+          rewardTokens.push(borrowerRewardToken.id);
+        }
+        mkt.rewardTokens = rewardTokens;
+        rewardTokenAmount[0] = rewardTokenAmount[0].plus(
+          BigDecimalTruncateToBigInt(
+            _weightedStakedAmount.sqrt().divDecimal(sumAccumulator).times(GAUGE_REWARD_AMOUNT).times(dailyScaler),
+          ),
+        );
+        rewardTokenUSD[0] = rewardTokenAmount[0]
+          .divDecimal(BigDecimal.fromString(EUL_DECIMALS.toString()))
+          .times(EULPriceUSD);
+        mkt.rewardTokenEmissionsAmount = rewardTokenAmount;
+        mkt.rewardTokenEmissionsUSD = rewardTokenUSD;
+
+        log.info("[processRewardEpoch24Onward]mkt {} rewarded {} EUL tokens ${} for epoch {}", [
           mkt.name!,
           rewardTokenAmount.toString(),
           rewardTokenUSD.toString(),

--- a/subgraphs/euler-finance/src/mappings/helpers.ts
+++ b/subgraphs/euler-finance/src/mappings/helpers.ts
@@ -209,6 +209,7 @@ export function createLiquidation(event: Liquidation): BigDecimal {
   liquidation.save();
 
   collateralMarket.cumulativeLiquidateUSD = collateralMarket.cumulativeLiquidateUSD.plus(liquidation.amountUSD);
+  collateralMarket.liquidationPenalty = liquidation.profitUSD.div(liquidation.amountUSD).times(BIGDECIMAL_HUNDRED);
   collateralMarket.save();
 
   const protocol = getOrCreateLendingProtocol();

--- a/subgraphs/euler-finance/src/mappings/helpers.ts
+++ b/subgraphs/euler-finance/src/mappings/helpers.ts
@@ -204,9 +204,7 @@ export function createLiquidation(event: Liquidation): BigDecimal {
     seizedToken.lastPriceUSD!,
   );
 
-  const repayUSD = bigIntToBDUseDecimals(event.params.repay, underlyingToken.decimals).times(
-    underlyingToken.lastPriceUSD!,
-  );
+  const repayUSD = bigIntToBDUseDecimals(event.params.repay, DEFAULT_DECIMALS).times(underlyingToken.lastPriceUSD!);
   liquidation.profitUSD = liquidation.amountUSD.minus(repayUSD);
   liquidation.save();
 


### PR DESCRIPTION
This PR fixes a bug in Euler liquidation profit (#2037) and updates the reward emission (#1488). Since the euler contract is still paused as of April 27th, tvl is not updated.

- test deployment (indexing in progress): https://thegraph.com/hosted-service/subgraph/tnkrxyz/euler-finance-ethereum?version=pending
- dashboard: https://subgraphs.messari.io/subgraph?endpoint=https://thegraph.com/hosted-service/subgraph/tnkrxyz/euler-finance-ethereum%3Fversion%3Dpending&tab=protocol

Note that the messari Euler subgraph ([hosted](https://subgraphs.messari.io/subgraph?endpoint=messari/euler-finance-ethereum&tab=protocol) and [decentralized](https://subgraphs.messari.io/subgraph?endpoint=https://gateway.thegraph.com/api/2b7eeacb471d383c093a79133a0a17a4/subgraphs/id/8cLf29KxAedWLVaEqjV8qKomdwwXQxjptBZFrqWNH5u2&tab=protocol)) needs to be re-deployed to fix the tvl due to the hack.

TODO: removed .prettierrc.json inside euler-finance and re-format ts files once reviewed.