### PR TITLE
chore(); allowed string literal in ethereum.decode call

### DIFF
--- a/subgraphs/_eslint-rules/no-string-literals.js
+++ b/subgraphs/_eslint-rules/no-string-literals.js
@@ -20,6 +20,7 @@ module.exports = {
       // e.g. Bytes.fromHexString("0x123456789abcdef")
       // BigInt.fromString("1")
       const ALLOWED_METHODS = [
+        "decode", // in ethereum.decode()
         "fromString",
         "fromHexString",
         "replace",


### PR DESCRIPTION
Allowing usage of string literal in `ethereum.decode()` e.g. `ethereum.decode("address", log.data)`. Otherwise, we have to go through
```
const ADDRESS = "address";
ethereum.decode(ADDRESS, log.data);
```
and adds no more readability.