### PR TITLE
fix (#patch); arrakis-finance; fixed reward emissions #1408

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -576,7 +576,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.0",
+          "subgraph": "1.1.1",
           "methodology": "1.0.0"
         },
         "files": {
@@ -598,7 +598,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.0",
+          "subgraph": "1.1.1",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/arrakis-finance/src/mappings/handlers/liquidityGauge.ts
+++ b/subgraphs/arrakis-finance/src/mappings/handlers/liquidityGauge.ts
@@ -56,12 +56,8 @@ export function handleAddGauge(event: AddGauge): void {
     return;
   }
   const rewardToken = getOrCreateToken(spiceResult.value);
-  log.info("[handleAddGauge]{} rewardToken.symbol {} startsWith('FAKE') {}", [
-    rewardToken.id,
-    rewardToken.symbol,
-    rewardToken.symbol.startsWith("FAKE").toString(),
-  ]);
-  if (rewardToken.symbol.startsWith("FAKE")) {
+  const FAKE = "FAKE";
+  if (rewardToken.symbol.startsWith(FAKE)) {
     log.info("[handleAddGauge]Fake reward token {} for gauge {} skipped", [
       rewardToken.symbol,
       gaugeAddress.toHexString(),
@@ -77,7 +73,8 @@ export function handleRemoveGauge(event: RemoveGauge): void {
   const gaugeAddress = event.params.gauge;
   const vaultAddress = event.params.vault;
   const gauge = getOrCreateLiquidityGauge(gaugeAddress);
-  store.remove("_LiquidityGauge", gauge.id);
+  const LIQUIDITY_GAUGE = "_LiquidityGauge";
+  store.remove(LIQUIDITY_GAUGE, gauge.id);
   gauge.save();
 
   const vault = Vault.load(vaultAddress.toHexString());
@@ -122,7 +119,8 @@ export function handleRemoveGauge(event: RemoveGauge): void {
       continue;
     }
     const token = getOrCreateToken(rewardTokenResult.value);
-    if (token.symbol.startsWith("FAKE")) {
+    const FAKE = "FAKE";
+    if (token.symbol.startsWith(FAKE)) {
       continue;
     }
 
@@ -170,15 +168,8 @@ export function handleRewardDataUpdate(event: RewardDataUpdate): void {
   const rewardTokenAddress = event.params._token;
 
   const rewardToken = getOrCreateToken(rewardTokenAddress);
-  log.info(
-    "[handleRewardDataUpdate]{} rewardToken.symbol {} startsWith('FAKE') {}",
-    [
-      rewardToken.id,
-      rewardToken.symbol,
-      rewardToken.symbol.startsWith("FAKE").toString(),
-    ]
-  );
-  if (rewardToken.symbol.startsWith("FAKE")) {
+  const FAKE = "FAKE";
+  if (rewardToken.symbol.startsWith(FAKE)) {
     log.info(
       "[handleRewardDataUpdate]Fake reward token {} for gauge {} skipped",
       [rewardToken.symbol, gaugeAddress.toHexString()]

--- a/subgraphs/arrakis-finance/src/mappings/helpers/liquidityGauge.ts
+++ b/subgraphs/arrakis-finance/src/mappings/helpers/liquidityGauge.ts
@@ -154,11 +154,14 @@ function updateRewardEmission(
 ): void {
   const rewardToken = RewardToken.load(rewardTokenId);
   if (!rewardToken) {
-    log.error("[]no RewardToken found for reward token {} tx {}-{}", [
-      rewardTokenId,
-      event.transaction.hash.toHexString(),
-      event.transactionLogIndex.toString(),
-    ]);
+    log.error(
+      "[updateRewardEmission]no RewardToken found for reward token {} tx {}-{}",
+      [
+        rewardTokenId,
+        event.transaction.hash.toHexString(),
+        event.transactionLogIndex.toString(),
+      ]
+    );
     return;
   }
 


### PR DESCRIPTION
This PR fixes the issue with [reward emission with Arrakis-finance-polygon](https://github.com/messari/subgraphs/issues/1408#issuecomment-1530814542):
- added missing updateRewardData() call
- removed FAKE reward tokens (FAKECRV, FAKEWMATIC) - likely used for testing

### deployment and dashboard
- polygon deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/arrakis-finance-polygon?version=pending
- polygon dashboard: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/id/QmZwBbRLX1EgzutSmuRgrnyqUPjGb1uqNv6quPQJwYfjS7&tab=pool&poolId=
- optimism deployment: https://thegraph.com/hosted-service/subgraph/tnkrxyz/arrakis-finance-optimism?version=pending
- optimism dashboard: https://subgraphs.messari.io/subgraph?endpoint=https://api.thegraph.com/subgraphs/id/QmauJTJPRJPUKUrbVYbddbkCpJp5RDeZt2fpNWsdBQAAsC&tab=protocol