### PR TITLE
Add directives to Generic Protocols

### DIFF
--- a/subgraphs/lido/schema.graphql
+++ b/subgraphs/lido/schema.graphql
@@ -35,7 +35,7 @@ enum ProtocolType {
   # Will add more
 }
 
-type Token @entity {
+type Token @entity @regularPolling {
   " Smart contract address of the token "
   id: ID!
 
@@ -63,7 +63,7 @@ enum RewardTokenType {
   BORROW
 }
 
-type RewardToken @entity {
+type RewardToken @entity @regularPolling {
   " { Reward token type }-{ Smart contract address of the reward token } "
   id: ID!
 
@@ -78,7 +78,7 @@ type RewardToken @entity {
 ##### Protocol Metadata #####
 #############################
 
-type Protocol @entity {
+type Protocol @entity @regularPolling {
   " Smart contract address of the protocol's main contract (Factory, Registry, etc) "
   id: ID!
 
@@ -149,7 +149,7 @@ type Protocol @entity {
 ##### Protocol Timeseries #####
 ###############################
 
-type UsageMetricsDailySnapshot @entity {
+type UsageMetricsDailySnapshot @entity @dailySnapshot {
   " ID is # of days since Unix epoch time "
   id: ID!
 
@@ -175,7 +175,7 @@ type UsageMetricsDailySnapshot @entity {
   timestamp: BigInt!
 }
 
-type UsageMetricsHourlySnapshot @entity {
+type UsageMetricsHourlySnapshot @entity @hourlySnapshot {
   " { # of hours since Unix epoch time } "
   id: ID!
 
@@ -198,7 +198,7 @@ type UsageMetricsHourlySnapshot @entity {
   timestamp: BigInt!
 }
 
-type FinancialsDailySnapshot @entity {
+type FinancialsDailySnapshot @entity @dailySnapshot {
   " ID is # of days since Unix epoch time "
   id: ID!
 
@@ -240,7 +240,7 @@ type FinancialsDailySnapshot @entity {
 ##### Pool-Level Data #####
 ###########################
 
-type Pool @entity {
+type Pool @entity @regularPolling {
   " Smart contract address of the pool "
   id: ID!
 
@@ -315,7 +315,7 @@ type Pool @entity {
   hourlySnapshots: [PoolHourlySnapshot!]! @derivedFrom(field: "pool")
 }
 
-type PoolDailySnapshot @entity {
+type PoolDailySnapshot @entity @dailySnapshot {
   " { Smart contract address of the pool }-{ # of days since Unix epoch time } "
   id: ID!
 
@@ -376,7 +376,7 @@ type PoolDailySnapshot @entity {
   rewardTokenEmissionsUSD: [BigDecimal!]
 }
 
-type PoolHourlySnapshot @entity {
+type PoolHourlySnapshot @entity @hourlySnapshot {
   " { Smart contract address of the pool }-{ # of hours since Unix epoch time } "
   id: ID!
 
@@ -439,13 +439,13 @@ type PoolHourlySnapshot @entity {
 
 # An account is a unique Ethereum address
 # Helps to accumulate total unique users
-type Account @entity {
+type Account @entity @regularPolling {
   " Address of the account "
   id: ID!
 }
 
 # Helper entity for calculating daily/hourly active users
-type ActiveAccount @entity {
+type ActiveAccount @entity @regularPolling {
   " { daily/hourly }-{ Address of the account }-{ Days/hours since Unix epoch } "
   id: ID!
 }

--- a/subgraphs/rocket-pool/schema.graphql
+++ b/subgraphs/rocket-pool/schema.graphql
@@ -35,7 +35,7 @@ enum ProtocolType {
   # Will add more
 }
 
-type Token @entity {
+type Token @entity @regularPolling {
   " Smart contract address of the token "
   id: ID!
 
@@ -63,7 +63,7 @@ enum RewardTokenType {
   BORROW
 }
 
-type RewardToken @entity {
+type RewardToken @entity @regularPolling {
   " { Reward token type }-{ Smart contract address of the reward token } "
   id: ID!
 
@@ -78,7 +78,7 @@ type RewardToken @entity {
 ##### Protocol Metadata #####
 #############################
 
-type Protocol @entity {
+type Protocol @entity @regularPolling {
   " Smart contract address of the protocol's main contract (Factory, Registry, etc) "
   id: ID!
 
@@ -149,7 +149,7 @@ type Protocol @entity {
 ##### Protocol Timeseries #####
 ###############################
 
-type UsageMetricsDailySnapshot @entity {
+type UsageMetricsDailySnapshot @entity @dailySnapshot {
   " ID is # of days since Unix epoch time "
   id: ID!
 
@@ -175,7 +175,7 @@ type UsageMetricsDailySnapshot @entity {
   timestamp: BigInt!
 }
 
-type UsageMetricsHourlySnapshot @entity {
+type UsageMetricsHourlySnapshot @entity @hourlySnapshot {
   " { # of hours since Unix epoch time } "
   id: ID!
 
@@ -198,7 +198,7 @@ type UsageMetricsHourlySnapshot @entity {
   timestamp: BigInt!
 }
 
-type FinancialsDailySnapshot @entity {
+type FinancialsDailySnapshot @entity @dailySnapshot {
   " ID is # of days since Unix epoch time "
   id: ID!
 
@@ -240,7 +240,7 @@ type FinancialsDailySnapshot @entity {
 ##### Pool-Level Data #####
 ###########################
 
-type Pool @entity {
+type Pool @entity @regularPolling {
   " Smart contract address of the pool "
   id: ID!
 
@@ -315,7 +315,7 @@ type Pool @entity {
   hourlySnapshots: [PoolHourlySnapshot!]! @derivedFrom(field: "pool")
 }
 
-type PoolDailySnapshot @entity {
+type PoolDailySnapshot @entity @dailySnapshot {
   " { Smart contract address of the pool }-{ # of days since Unix epoch time } "
   id: ID!
 
@@ -376,7 +376,7 @@ type PoolDailySnapshot @entity {
   rewardTokenEmissionsUSD: [BigDecimal!]
 }
 
-type PoolHourlySnapshot @entity {
+type PoolHourlySnapshot @entity @hourlySnapshot {
   " { Smart contract address of the pool }-{ # of hours since Unix epoch time } "
   id: ID!
 
@@ -443,19 +443,19 @@ type PoolHourlySnapshot @entity {
 
 # An account is a unique Ethereum address
 # Helps to accumulate total unique users
-type Account @entity {
+type Account @entity @regularPolling {
   " Address of the account "
   id: ID!
 }
 
 # Helper entity for calculating daily/hourly active users
-type ActiveAccount @entity {
+type ActiveAccount @entity @regularPolling {
   " { daily/hourly }-{ Address of the account }-{ Days/hours since Unix epoch } "
   id: ID!
 }
 
 # Entity that represents the RocketPool protocol.
-type RocketPoolProtocol @entity {
+type RocketPoolProtocol @entity @regularPolling {
   # The name of the RocketPool protocol.
   id: ID!
 
@@ -488,7 +488,7 @@ type RocketPoolProtocol @entity {
 }
 
 # An address that is/was associated with an rETH balance.
-type Staker @entity {
+type Staker @entity @regularPolling {
   # Address that holds rETH.
   id: ID!
 
@@ -515,7 +515,7 @@ type Staker @entity {
 }
 
 # Tracks the mint, burn and transfers of rETH.
-type RocketETHTransaction @entity(immutable: true) {
+type RocketETHTransaction @entity(immutable: true) @transaction {
   # Composite key based on transaction hash of the triggered event and its log index.
   id: ID!
 
@@ -614,7 +614,7 @@ type StakerBalanceCheckpoint @entity {
 }
 
 # A node address that was registered by a node operator.
-type Node @entity {
+type Node @entity @regularPolling {
   # Address that is associated with a node on RocketPool.
   id: ID!
 
@@ -702,7 +702,7 @@ enum NodeRPLStakeTransactionType {
 }
 
 # Keeps track of the RPL staking transactions for a node.
-type NodeRPLStakeTransaction @entity {
+type NodeRPLStakeTransaction @entity @transaction {
   # Composite key based on transaction hash of the triggered event and its log index.
   id: ID!
 

--- a/subgraphs/rocket-pool/schema.graphql
+++ b/subgraphs/rocket-pool/schema.graphql
@@ -488,7 +488,7 @@ type RocketPoolProtocol @entity @regularPolling {
 }
 
 # An address that is/was associated with an rETH balance.
-type Staker @entity @regularPolling {
+type Staker @entity {
   # Address that holds rETH.
   id: ID!
 
@@ -515,7 +515,7 @@ type Staker @entity @regularPolling {
 }
 
 # Tracks the mint, burn and transfers of rETH.
-type RocketETHTransaction @entity(immutable: true) @transaction {
+type RocketETHTransaction @entity(immutable: true) {
   # Composite key based on transaction hash of the triggered event and its log index.
   id: ID!
 
@@ -1021,7 +1021,7 @@ type NodeBalanceCheckpoint @entity {
 }
 
 # Represents a minipool for a node.
-type Minipool @entity {
+type Minipool @entity @regularPolling {
   # Address of the minipool.
   id: ID!
 

--- a/subgraphs/tornado-cash/schema.graphql
+++ b/subgraphs/tornado-cash/schema.graphql
@@ -35,7 +35,7 @@ enum ProtocolType {
   # Will add more
 }
 
-type Token @entity {
+type Token @entity @regularPolling {
   " Smart contract address of the token "
   id: ID!
 
@@ -63,7 +63,7 @@ enum RewardTokenType {
   BORROW
 }
 
-type RewardToken @entity {
+type RewardToken @entity @regularPolling {
   " { Reward token type }-{ Smart contract address of the reward token } "
   id: ID!
 
@@ -78,7 +78,7 @@ type RewardToken @entity {
 ##### Protocol Metadata #####
 #############################
 
-type Protocol @entity {
+type Protocol @entity @regularPolling {
   " Smart contract address of the protocol's main contract (Factory, Registry, etc) "
   id: ID!
 
@@ -149,7 +149,7 @@ type Protocol @entity {
 ##### Protocol Timeseries #####
 ###############################
 
-type UsageMetricsDailySnapshot @entity {
+type UsageMetricsDailySnapshot @entity @dailySnapshot {
   " ID is # of days since Unix epoch time "
   id: ID!
 
@@ -175,7 +175,7 @@ type UsageMetricsDailySnapshot @entity {
   timestamp: BigInt!
 }
 
-type UsageMetricsHourlySnapshot @entity {
+type UsageMetricsHourlySnapshot @entity @hourlySnapshot {
   " { # of hours since Unix epoch time } "
   id: ID!
 
@@ -198,7 +198,7 @@ type UsageMetricsHourlySnapshot @entity {
   timestamp: BigInt!
 }
 
-type FinancialsDailySnapshot @entity {
+type FinancialsDailySnapshot @entity @dailySnapshot {
   " ID is # of days since Unix epoch time "
   id: ID!
 
@@ -240,7 +240,7 @@ type FinancialsDailySnapshot @entity {
 ##### Pool-Level Data #####
 ###########################
 
-type Pool @entity {
+type Pool @entity @regularPolling {
   " Smart contract address of the pool "
   id: ID!
 
@@ -385,7 +385,7 @@ type PoolDailySnapshot @entity {
   rewardTokenEmissionsUSD: [BigDecimal!]
 }
 
-type PoolHourlySnapshot @entity {
+type PoolHourlySnapshot @entity @hourlySnapshot {
   " { Smart contract address of the pool }-{ # of hours since Unix epoch time } "
   id: ID!
 
@@ -448,13 +448,13 @@ type PoolHourlySnapshot @entity {
 
 # An account is a unique Ethereum address
 # Helps to accumulate total unique users
-type Account @entity {
+type Account @entity @regularPolling {
   " Address of the account "
   id: ID!
 }
 
 # Helper entity for calculating daily/hourly active users
-type ActiveAccount @entity {
+type ActiveAccount @entity @regularPolling {
   " { daily/hourly }-{ Address of the account }-{ Days/hours since Unix epoch } "
   id: ID!
 }


### PR DESCRIPTION
# Description
- Add additional GraphQL directives to various Generic Protocols subgraph schemas. These directives will be helpful to Messari's internal data ingestion. It also helps in identifying the type and nature of the affected entities.

Affected subgraphs: Lido, RocketPool, TornadoCash