### PR TITLE
fix(#schema); Uniswap V3 Forks; Make DEX schema compatible with old schema, and add corresponding changes to Uniswap Forks

### DIFF
--- a/schema-dex-amm-extended.graphql
+++ b/schema-dex-amm-extended.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: DEX AMM (Extended)
-# Version: 3.0.4
+# Version: 3.0.5
 # See https://github.com/messari/subgraphs/blob/master/docs/Schema.md for details
 
 enum Network {
@@ -531,10 +531,10 @@ type LiquidityPool @entity @regularPolling {
   cumulativeTotalRevenueUSD: BigDecimal!
 
   " All trade volume occurred for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumeTokenAmounts: [BigInt!]!
+  cumulativeVolumeByTokenAmount: [BigInt!]!
 
   " All trade volume occurred for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumesUSD: [BigDecimal!]!
+  cumulativeVolumeByTokenUSD: [BigDecimal!]!
 
   " All historical trade volume occurred in this pool, in USD "
   cumulativeVolumeUSD: BigDecimal!
@@ -683,19 +683,19 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) @dailySnapshot {
   cumulativeVolumeUSD: BigDecimal!
 
   " All trade volume occurred in a given day, in USD "
-  dailyTotalVolumeUSD: BigDecimal!
+  dailyVolumeUSD: BigDecimal!
 
   " All trade volume , in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumeTokenAmounts: [BigInt!]!
+  cumulativeVolumeByTokenAmount: [BigInt!]!
 
   " All trade volume occurred in a given day for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  dailyVolumeTokenAmounts: [BigInt!]!
+  dailyVolumeByTokenAmount: [BigInt!]!
 
   " All trade volume, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumesUSD: [BigDecimal!]!
+  cumulativeVolumeByTokenUSD: [BigDecimal!]!
 
   " All trade volume occurred in a given day for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  dailyVolumesUSD: [BigDecimal!]!
+  dailyVolumeByTokenUSD: [BigDecimal!]!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
   inputTokenBalances: [BigInt!]!
@@ -817,20 +817,20 @@ type LiquidityPoolHourlySnapshot @entity(immutable: true) @hourlySnapshot {
   " All historical trade volume occurred in this pool, in USD "
   cumulativeVolumeUSD: BigDecimal!
 
-  " All trade volume occurred in a given day, in USD "
-  hourlyTotalVolumeUSD: BigDecimal!
+  " All trade volume occurred in a given hour, in USD "
+  hourlyVolumeUSD: BigDecimal!
 
-  " All trade volume , in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumeTokenAmounts: [BigInt!]!
+  " All trade volume, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
+  cumulativeVolumeByTokenAmount: [BigInt!]!
 
-  " All trade volume occurred in a given day for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  hourlyVolumeTokenAmounts: [BigInt!]!
+  " All trade volume occurred in a given hour for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
+  hourlyVolumeByTokenAmount: [BigInt!]!
 
   " All trade volume, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumesUSD: [BigDecimal!]!
+  cumulativeVolumeByTokenUSD: [BigDecimal!]!
 
-  " All trade volume occurred in a given day for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  hourlyVolumesUSD: [BigDecimal!]!
+  " All trade volume occurred in a given hour for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
+  hourlyVolumeByTokenUSD: [BigDecimal!]!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
   inputTokenBalances: [BigInt!]!

--- a/subgraphs/uniswap-v3-forks/schema2.graphql
+++ b/subgraphs/uniswap-v3-forks/schema2.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: DEX AMM (Extended)
-# Version: 3.0.5
+# Version: 3.0.4
 # See https://github.com/messari/subgraphs/blob/master/docs/Schema.md for details
 
 enum Network {
@@ -47,7 +47,7 @@ enum TokenType {
   # Will add more
 }
 
-type Token @entity @regularPolling {
+type Token @entity {
   " Smart contract address of the token "
   id: Bytes!
 
@@ -75,6 +75,8 @@ type Token @entity @regularPolling {
   _largePriceChangeBuffer: Int!
 
   _largeTVLImpactBuffer: Int!
+
+  _lastPricedPool: LiquidityPool
 }
 
 enum RewardTokenType {
@@ -85,7 +87,7 @@ enum RewardTokenType {
   BORROW
 }
 
-type RewardToken @entity(immutable: true) @regularPolling {
+type RewardToken @entity(immutable: true) {
   " { Reward token type }-{ Smart contract address of the reward token } "
   id: Bytes!
 
@@ -129,7 +131,7 @@ enum LiquidityPoolFeeType {
   WITHDRAWAL_FEE
 }
 
-type LiquidityPoolFee @entity @regularPolling {
+type LiquidityPoolFee @entity {
   " { Fee type }-{ Pool address } "
   id: Bytes!
 
@@ -206,7 +208,7 @@ interface Protocol {
   financialMetrics: [FinancialsDailySnapshot!]! @derivedFrom(field: "protocol")
 }
 
-type DexAmmProtocol implements Protocol @entity @regularPolling {
+type DexAmmProtocol implements Protocol @entity {
   " Smart contract address of the protocol's main contract (Factory, Registry, etc) "
   id: Bytes!
 
@@ -316,7 +318,7 @@ type DexAmmProtocol implements Protocol @entity @regularPolling {
 ##### Protocol Timeseries #####
 ###############################
 
-type UsageMetricsDailySnapshot @entity @dailySnapshot {
+type UsageMetricsDailySnapshot @entity {
   " ID is # of days since Unix epoch time "
   id: Bytes!
 
@@ -354,7 +356,7 @@ type UsageMetricsDailySnapshot @entity @dailySnapshot {
   blockNumber: BigInt!
 }
 
-type UsageMetricsHourlySnapshot @entity @hourlySnapshot {
+type UsageMetricsHourlySnapshot @entity {
   " { # of hours since Unix epoch time } "
   id: Bytes!
 
@@ -389,7 +391,7 @@ type UsageMetricsHourlySnapshot @entity @hourlySnapshot {
   blockNumber: BigInt!
 }
 
-type FinancialsDailySnapshot @entity(immutable: true) @dailySnapshot {
+type FinancialsDailySnapshot @entity(immutable: true) {
   " ID is # of days since Unix epoch time "
   id: Bytes!
 
@@ -452,7 +454,7 @@ type FinancialsDailySnapshot @entity(immutable: true) @dailySnapshot {
 ##### Pool-Level Metadata #####
 ###############################
 
-type LiquidityPool @entity @regularPolling {
+type LiquidityPool @entity {
   " Smart contract address of the pool "
   id: Bytes!
 
@@ -531,10 +533,10 @@ type LiquidityPool @entity @regularPolling {
   cumulativeTotalRevenueUSD: BigDecimal!
 
   " All trade volume occurred for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumeByTokenAmount: [BigInt!]!
+  cumulativeVolumeTokenAmounts: [BigInt!]!
 
   " All trade volume occurred for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumeByTokenUSD: [BigDecimal!]!
+  cumulativeVolumesUSD: [BigDecimal!]!
 
   " All historical trade volume occurred in this pool, in USD "
   cumulativeVolumeUSD: BigDecimal!
@@ -616,7 +618,7 @@ type LiquidityPool @entity @regularPolling {
 ##### Pool-Level Timeseries #####
 #################################
 
-type LiquidityPoolDailySnapshot @entity(immutable: true) @dailySnapshot {
+type LiquidityPoolDailySnapshot @entity(immutable: true) {
   " { Smart contract address of the pool }-{ # of days since Unix epoch time } "
   id: Bytes!
 
@@ -683,19 +685,19 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) @dailySnapshot {
   cumulativeVolumeUSD: BigDecimal!
 
   " All trade volume occurred in a given day, in USD "
-  dailyVolumeUSD: BigDecimal!
+  dailyTotalVolumeUSD: BigDecimal!
 
   " All trade volume , in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumeByTokenAmount: [BigInt!]!
+  cumulativeVolumeTokenAmounts: [BigInt!]!
 
   " All trade volume occurred in a given day for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  dailyVolumeByTokenAmount: [BigInt!]!
+  dailyVolumeTokenAmounts: [BigInt!]!
 
   " All trade volume, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumeByTokenUSD: [BigDecimal!]!
+  cumulativeVolumesUSD: [BigDecimal!]!
 
   " All trade volume occurred in a given day for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  dailyVolumeByTokenUSD: [BigDecimal!]!
+  dailyVolumesUSD: [BigDecimal!]!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
   inputTokenBalances: [BigInt!]!
@@ -751,7 +753,7 @@ type LiquidityPoolDailySnapshot @entity(immutable: true) @dailySnapshot {
   blockNumber: BigInt!
 }
 
-type LiquidityPoolHourlySnapshot @entity(immutable: true) @hourlySnapshot {
+type LiquidityPoolHourlySnapshot @entity(immutable: true) {
   " { Smart contract address of the pool }-{ # of hours since Unix epoch time } "
   id: Bytes!
 
@@ -817,20 +819,20 @@ type LiquidityPoolHourlySnapshot @entity(immutable: true) @hourlySnapshot {
   " All historical trade volume occurred in this pool, in USD "
   cumulativeVolumeUSD: BigDecimal!
 
-  " All trade volume occurred in a given hour, in USD "
-  hourlyVolumeUSD: BigDecimal!
+  " All trade volume occurred in a given day, in USD "
+  hourlyTotalVolumeUSD: BigDecimal!
 
-  " All trade volume, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumeByTokenAmount: [BigInt!]!
+  " All trade volume , in native amount. The ordering should be the same as the pool's `inputTokens` field. "
+  cumulativeVolumeTokenAmounts: [BigInt!]!
 
-  " All trade volume occurred in a given hour for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
-  hourlyVolumeByTokenAmount: [BigInt!]!
+  " All trade volume occurred in a given day for a specific input token, in native amount. The ordering should be the same as the pool's `inputTokens` field. "
+  hourlyVolumeTokenAmounts: [BigInt!]!
 
   " All trade volume, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  cumulativeVolumeByTokenUSD: [BigDecimal!]!
+  cumulativeVolumesUSD: [BigDecimal!]!
 
-  " All trade volume occurred in a given hour for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
-  hourlyVolumeByTokenUSD: [BigDecimal!]!
+  " All trade volume occurred in a given day for a specific input token, in USD. The ordering should be the same as the pool's `inputTokens` field. "
+  hourlyVolumesUSD: [BigDecimal!]!
 
   " Amount of input tokens in the pool. The ordering should be the same as the pool's `inputTokens` field. "
   inputTokenBalances: [BigInt!]!
@@ -890,7 +892,7 @@ type LiquidityPoolHourlySnapshot @entity(immutable: true) @hourlySnapshot {
 ##### Pool Tick-Level Metadata #####
 ####################################
 
-type Tick @entity @regularPolling {
+type Tick @entity {
   " { pool address }-{ tick index } "
   id: Bytes!
 
@@ -938,7 +940,7 @@ type Tick @entity @regularPolling {
 ##### Pool Tick-Level Time Series #####
 #######################################
 
-type TickDailySnapshot @entity(immutable: true) @dailySnapshot {
+type TickDailySnapshot @entity(immutable: true) {
   " { pool address }-{ tick index }-{ day ID } "
   id: Bytes!
 
@@ -970,7 +972,7 @@ type TickDailySnapshot @entity(immutable: true) @dailySnapshot {
   blockNumber: BigInt!
 }
 
-type TickHourlySnapshot @entity(immutable: true) @hourlySnapshot {
+type TickHourlySnapshot @entity(immutable: true) {
   " { pool address }-{ tick index }-{ hour ID } "
   id: Bytes!
 
@@ -1006,7 +1008,7 @@ type TickHourlySnapshot @entity(immutable: true) @hourlySnapshot {
 ##### Account-Level Data #####
 ##############################
 
-type Account @entity @regularPolling {
+type Account @entity {
   " { Account address } "
   id: Bytes!
 
@@ -1041,7 +1043,7 @@ type Account @entity @regularPolling {
   swaps: [Swap!]! @derivedFrom(field: "account")
 }
 
-type Position @entity @regularPolling {
+type Position @entity {
   " { Account address }-{ Market address }-{ Count } "
   id: Bytes!
 
@@ -1124,7 +1126,7 @@ type Position @entity @regularPolling {
 # for positions that are not moving. As we are only recording the balance
 # in token amounts instead of in USD, this will work well.
 # Note that we only take snapshot for open positions
-type PositionSnapshot @entity(immutable: true) @regularPolling {
+type PositionSnapshot @entity(immutable: true) {
   " { Position ID }-{ Transaction hash }-{ Log index } "
   id: Bytes!
 
@@ -1192,7 +1194,7 @@ the deposit and withdraw functions in Yearn do not emit any events. In our subgr
 store them as events, although they are not technically Ethereum events emitted by smart
 contracts.
 """
-type Deposit @entity(immutable: true) @transaction {
+type Deposit @entity(immutable: true) {
   " { Transaction hash }-{ Log index } "
   id: Bytes!
 
@@ -1254,7 +1256,7 @@ type Deposit @entity(immutable: true) @transaction {
   amountUSD: BigDecimal!
 }
 
-type Withdraw @entity(immutable: true) @transaction {
+type Withdraw @entity(immutable: true) {
   " { Transaction hash }-{ Log index }"
   id: Bytes!
 
@@ -1316,7 +1318,7 @@ type Withdraw @entity(immutable: true) @transaction {
   amountUSD: BigDecimal!
 }
 
-type Swap @entity(immutable: true) @transaction {
+type Swap @entity(immutable: true) {
   " { Transaction hash }-{ Log index } "
   id: Bytes!
 
@@ -1385,6 +1387,7 @@ type ActiveAccount @entity(immutable: true) {
 }
 
 #Added Entities
+
 type _LiquidityPoolAmount @entity {
   " Smart contract address of the pool "
   id: Bytes!

--- a/subgraphs/uniswap-v3-forks/src/common/dexEventHandler.ts
+++ b/subgraphs/uniswap-v3-forks/src/common/dexEventHandler.ts
@@ -563,12 +563,12 @@ export class DexEventHandler {
     this.pool.cumulativeVolumeUSD = this.pool.cumulativeVolumeUSD.plus(
       this.trackedVolumeUSD
     );
-    this.pool.cumulativeVolumesUSD = sumBigDecimalListByIndex([
-      this.pool.cumulativeVolumesUSD,
+    this.pool.cumulativeVolumeByTokenUSD = sumBigDecimalListByIndex([
+      this.pool.cumulativeVolumeByTokenUSD,
       this.trackedInputTokenBalanceDeltasUSD,
     ]);
-    this.pool.cumulativeVolumeTokenAmounts = sumBigIntListByIndex([
-      this.pool.cumulativeVolumeTokenAmounts,
+    this.pool.cumulativeVolumeByTokenAmount = sumBigIntListByIndex([
+      this.pool.cumulativeVolumeByTokenAmount,
       absBigIntList(this.inputTokenBalanceDeltas),
     ]);
 
@@ -701,10 +701,10 @@ export class DexEventHandler {
     );
 
     let prevCumulativeVolumeUSD = BIGDECIMAL_ZERO;
-    let prevCumulativeVolumesUSD = new Array<BigDecimal>(
+    let prevCumulativeVolumeByTokenUSD = new Array<BigDecimal>(
       this.pool.inputTokens.length
     ).fill(BIGDECIMAL_ZERO);
-    let prevCumulativeVolumeTokenAmounts = new Array<BigInt>(
+    let prevCumulativeVolumeByTokenAmount = new Array<BigInt>(
       this.pool.inputTokens.length
     ).fill(BIGINT_ZERO);
     let prevCumulativeSupplySideRevenueUSD = BIGDECIMAL_ZERO;
@@ -716,9 +716,10 @@ export class DexEventHandler {
 
     if (prevPoolMetrics != null) {
       prevCumulativeVolumeUSD = prevPoolMetrics.cumulativeVolumeUSD;
-      prevCumulativeVolumesUSD = prevPoolMetrics.cumulativeVolumesUSD;
-      prevCumulativeVolumeTokenAmounts =
-        prevPoolMetrics.cumulativeVolumeTokenAmounts;
+      prevCumulativeVolumeByTokenUSD =
+        prevPoolMetrics.cumulativeVolumeByTokenUSD;
+      prevCumulativeVolumeByTokenAmount =
+        prevPoolMetrics.cumulativeVolumeByTokenAmount;
       prevCumulativeSupplySideRevenueUSD =
         prevPoolMetrics.cumulativeSupplySideRevenueUSD;
       prevCumulativeProtocolSideRevenueUSD =
@@ -756,19 +757,20 @@ export class DexEventHandler {
       this.pool.uncollectedSupplySideValuesUSD;
 
     poolMetrics.cumulativeVolumeUSD = this.pool.cumulativeVolumeUSD;
-    poolMetrics.dailyTotalVolumeUSD = this.pool.cumulativeVolumeUSD.minus(
+    poolMetrics.dailyVolumeUSD = this.pool.cumulativeVolumeUSD.minus(
       prevCumulativeVolumeUSD
     );
-    poolMetrics.cumulativeVolumesUSD = this.pool.cumulativeVolumesUSD;
-    poolMetrics.dailyVolumesUSD = subtractBigDecimalLists(
-      this.pool.cumulativeVolumesUSD,
-      prevCumulativeVolumesUSD
+    poolMetrics.cumulativeVolumeByTokenUSD =
+      this.pool.cumulativeVolumeByTokenUSD;
+    poolMetrics.dailyVolumeByTokenUSD = subtractBigDecimalLists(
+      this.pool.cumulativeVolumeByTokenUSD,
+      prevCumulativeVolumeByTokenUSD
     );
-    poolMetrics.cumulativeVolumeTokenAmounts =
-      this.pool.cumulativeVolumeTokenAmounts;
-    poolMetrics.dailyVolumeTokenAmounts = subtractBigIntLists(
-      this.pool.cumulativeVolumeTokenAmounts,
-      prevCumulativeVolumeTokenAmounts
+    poolMetrics.cumulativeVolumeByTokenAmount =
+      this.pool.cumulativeVolumeByTokenAmount;
+    poolMetrics.dailyVolumeByTokenAmount = subtractBigIntLists(
+      this.pool.cumulativeVolumeByTokenAmount,
+      prevCumulativeVolumeByTokenAmount
     );
 
     poolMetrics.inputTokenBalances = this.pool.inputTokenBalances;
@@ -820,10 +822,10 @@ export class DexEventHandler {
     );
 
     let prevCumulativeVolumeUSD = BIGDECIMAL_ZERO;
-    let prevCumulativeVolumesUSD = new Array<BigDecimal>(
+    let prevCumulativeVolumeByTokenUSD = new Array<BigDecimal>(
       this.pool.inputTokens.length
     ).fill(BIGDECIMAL_ZERO);
-    let prevCumulativeVolumeTokenAmounts = new Array<BigInt>(
+    let prevCumulativeVolumeByTokenAmount = new Array<BigInt>(
       this.pool.inputTokens.length
     ).fill(BIGINT_ZERO);
     let prevCumulativeSupplySideRevenueUSD = BIGDECIMAL_ZERO;
@@ -835,9 +837,10 @@ export class DexEventHandler {
 
     if (prevPoolMetrics != null) {
       prevCumulativeVolumeUSD = prevPoolMetrics.cumulativeVolumeUSD;
-      prevCumulativeVolumesUSD = prevPoolMetrics.cumulativeVolumesUSD;
-      prevCumulativeVolumeTokenAmounts =
-        prevPoolMetrics.cumulativeVolumeTokenAmounts;
+      prevCumulativeVolumeByTokenUSD =
+        prevPoolMetrics.cumulativeVolumeByTokenUSD;
+      prevCumulativeVolumeByTokenAmount =
+        prevPoolMetrics.cumulativeVolumeByTokenAmount;
       prevCumulativeSupplySideRevenueUSD =
         prevPoolMetrics.cumulativeSupplySideRevenueUSD;
       prevCumulativeProtocolSideRevenueUSD =
@@ -875,19 +878,20 @@ export class DexEventHandler {
       this.pool.uncollectedSupplySideValuesUSD;
 
     poolMetrics.cumulativeVolumeUSD = this.pool.cumulativeVolumeUSD;
-    poolMetrics.hourlyTotalVolumeUSD = this.pool.cumulativeVolumeUSD.minus(
+    poolMetrics.hourlyVolumeUSD = this.pool.cumulativeVolumeUSD.minus(
       prevCumulativeVolumeUSD
     );
-    poolMetrics.cumulativeVolumesUSD = this.pool.cumulativeVolumesUSD;
-    poolMetrics.hourlyVolumesUSD = subtractBigDecimalLists(
-      this.pool.cumulativeVolumesUSD,
-      prevCumulativeVolumesUSD
+    poolMetrics.cumulativeVolumeByTokenUSD =
+      this.pool.cumulativeVolumeByTokenUSD;
+    poolMetrics.hourlyVolumeByTokenUSD = subtractBigDecimalLists(
+      this.pool.cumulativeVolumeByTokenUSD,
+      prevCumulativeVolumeByTokenUSD
     );
-    poolMetrics.cumulativeVolumeTokenAmounts =
-      this.pool.cumulativeVolumeTokenAmounts;
-    poolMetrics.hourlyVolumeTokenAmounts = subtractBigIntLists(
-      this.pool.cumulativeVolumeTokenAmounts,
-      prevCumulativeVolumeTokenAmounts
+    poolMetrics.cumulativeVolumeByTokenAmount =
+      this.pool.cumulativeVolumeByTokenAmount;
+    poolMetrics.hourlyVolumeByTokenAmount = subtractBigIntLists(
+      this.pool.cumulativeVolumeByTokenAmount,
+      prevCumulativeVolumeByTokenAmount
     );
 
     poolMetrics.inputTokenBalances = this.pool.inputTokenBalances;

--- a/subgraphs/uniswap-v3-forks/src/common/entities/pool.ts
+++ b/subgraphs/uniswap-v3-forks/src/common/entities/pool.ts
@@ -80,8 +80,8 @@ export function createLiquidityPool(
   pool.inputTokenBalancesUSD = [BIGDECIMAL_ZERO, BIGDECIMAL_ZERO];
 
   pool.cumulativeVolumeUSD = BIGDECIMAL_ZERO;
-  pool.cumulativeVolumeTokenAmounts = [BIGINT_ZERO, BIGINT_ZERO];
-  pool.cumulativeVolumesUSD = [BIGDECIMAL_ZERO, BIGDECIMAL_ZERO];
+  pool.cumulativeVolumeByTokenAmount = [BIGINT_ZERO, BIGINT_ZERO];
+  pool.cumulativeVolumeByTokenUSD = [BIGDECIMAL_ZERO, BIGDECIMAL_ZERO];
 
   pool.cumulativeSupplySideRevenueUSD = BIGDECIMAL_ZERO;
   pool.cumulativeProtocolSideRevenueUSD = BIGDECIMAL_ZERO;


### PR DESCRIPTION
**Context:** 
The DEX schemas from version 1.3.~ and the new extended schema were not compatible in the naming of certain volume fields on the LiquidityPool and LiquidityPoolSnapshot entities. This PR updates these problematic fields to be consistent between the schemas and applies the necessary changes to the Uniswap Forks code. 