### PR TITLE
docs(); Bytes as IDs perf; Performance test for bytes as IDs updated in response to issue being resolved by Edge and Node

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -211,7 +211,9 @@ The purpose of this test is to compare the performance of 2 price oracles in the
 - The results after a a roughly 5 hour test across about 284,000 is a nearly identical indexing speed. This test tells me that adding hourly metrics will not severely impact the indexing speed of a subgraph.
 - An additional insight that I believe can be extracted from this test is that event and call handlers are by far the greatest bottleneck in the indexing speed using The Graph.
 
-### Bytes and Immutables Test 1.0
+### Bytes and Immutables Test (Deprecated)
+
+**NOTE:** The results from this test have been addressed by Edge and Node. The results are no longer indicative of the performance of the subgraph using Bytes verse ID for the entity IDs. The results are still included for reference. The issue on the graph-node repo has been tracked [here](https://github.com/graphprotocol/graph-node/issues/3534). It has closed with the performance issues being resolved.
 
 - The purpose of this test is to check how much changing the id values of entities to Bytes and adding immutable entities where relevant affects indexing performance
 - The entities which I added the immutable quality to are the RewardToken, Deposit, Withdraw, Swap, Account, and ActiveAccount
@@ -275,3 +277,5 @@ https://github.com/steegecs/subgraphs/tree/steegecs/uniswap-forks-bytes
 - The results of this test indicate that having neither bytes as IDs or immutable entities is the fasted case. This is against our expectations. It was expected to see that adding both immutables and bytes as IDs would improve indexing speed.
 - The results are quite strange upon analysis. Adding bytes as IDs only slows down the indexing process quite a lot (-23%) and adding immutables only slows the indexing process by a moderate amount (-6.8%). However when we combine both the addition of immutables and bytes, it only slightly slows down the indexing process (-1.2%).
 - These results are far from the expectation of how the addition of immutables and bytes as IDs would impact the speed of indexing in isolation and combination. The results of this test warrant investigation into how the graph handles immutables and bytes as IDs behind the scenes so that we can get results more in line with our expectation and achieve the desired performance improvements.
+
+** Note: ** Edge and Node has


### PR DESCRIPTION
**Context:**
We ran a performance test using bytes as IDs in April 2022. The results from the test indicated that using bytes as IDs and immutable entities did not have the expected benefits on indexing speed as was expected. This issue has been addressed by Lutter as Edge and Node, and the performance is now improved with Bytes and immutable IDs. The issue on the graph-node can be viewed here: https://github.com/graphprotocol/graph-node/issues/3534.