### PR TITLE
fix(#minor); Uniswap Forks; Fix issues for Uniswap Forks from issues 2145 and 2168

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -4698,7 +4698,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.14",
+          "subgraph": "1.2.0",
           "methodology": "1.0.0"
         },
         "files": {

--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1360,7 +1360,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.4",
+          "subgraph": "1.0.5",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4290,7 +4290,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.2.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4312,7 +4312,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.1.13",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4342,7 +4342,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.7",
+          "subgraph": "1.0.8",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4364,7 +4364,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.4",
+          "subgraph": "1.0.5",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4394,7 +4394,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.8",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4424,7 +4424,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.10",
+          "subgraph": "1.1.11",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4454,7 +4454,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.8",
+          "subgraph": "1.1.9",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4484,7 +4484,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.10",
+          "subgraph": "1.1.11",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4514,7 +4514,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.2.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4536,7 +4536,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.2.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4558,7 +4558,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.1.13",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4580,7 +4580,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.1.13",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4606,7 +4606,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.1.13",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4628,7 +4628,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.1.13",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4650,7 +4650,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.2.2",
+          "subgraph": "1.2.3",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4676,7 +4676,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.13",
+          "subgraph": "1.1.14",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4698,7 +4698,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.13",
+          "subgraph": "1.1.14",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4720,7 +4720,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.1.13",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4742,7 +4742,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.1.13",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4764,7 +4764,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.13",
+          "subgraph": "1.1.14",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4798,7 +4798,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.2.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4828,7 +4828,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.7",
+          "subgraph": "1.0.8",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4858,7 +4858,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.1.13",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4892,7 +4892,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.8",
+          "subgraph": "1.1.9",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4922,7 +4922,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.12",
+          "subgraph": "1.1.13",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4952,7 +4952,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.10",
+          "subgraph": "1.1.0",
           "methodology": "1.0.1"
         },
         "files": {
@@ -4978,7 +4978,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.8",
+          "subgraph": "1.0.9",
           "methodology": "1.0.1"
         },
         "files": {
@@ -6718,7 +6718,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.6",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {

--- a/subgraphs/uniswap-forks/protocols/apeswap/config/deployments/apeswap-bsc/configurations.ts
+++ b/subgraphs/uniswap-forks/protocols/apeswap/config/deployments/apeswap-bsc/configurations.ts
@@ -113,7 +113,10 @@ export class ApeswapBscConfigurations implements Configurations {
     return [];
   }
   getUntrackedTokens(): string[] {
-    return [];
+    return [
+      "0x87bade473ea0513d4aa7085484aeaa6cb6ebe7e3", // Mor Stablecoin
+      "0x7e7d3556310830581815b1aa1bbbc9e5d7097580", // NFTGirl
+    ];
   }
   getBrokenERC20Tokens(): string[] {
     return [];

--- a/subgraphs/uniswap-forks/protocols/honeyswap/config/deployments/honeyswap-gnosis/configurations.ts
+++ b/subgraphs/uniswap-forks/protocols/honeyswap/config/deployments/honeyswap-gnosis/configurations.ts
@@ -110,7 +110,11 @@ export class HoneyswapGnosisConfigurations implements Configurations {
     return [];
   }
   getUntrackedTokens(): string[] {
-    return [];
+    return [
+      "0x2f26b15dd4d27d9811a08389a0171a3c8750890e", //Honey/hiveWATER Token LP
+      "0x5d32a9baf31a793dba7275f77856a47a0f5d09b3", // Giveth Test GIV Token
+      "0x69f79c9ea174d4659b18c7993c7efbbbb58cf068", // Test HNY Token
+    ];
   }
   getBrokenERC20Tokens(): string[] {
     return [];

--- a/subgraphs/uniswap-forks/protocols/pangolin/config/templates/pangolin.template.yaml
+++ b/subgraphs/uniswap-forks/protocols/pangolin/config/templates/pangolin.template.yaml
@@ -44,6 +44,8 @@ dataSources:
       abis:
         - name: MiniChefV2
           file: ./abis/pangolin/MiniChefV2.json
+        - name: Factory
+          file: ./abis/pangolin/Factory.json
         - name: TokenABI
           file: ./abis/pangolin/ERC20.json
       eventHandlers:

--- a/subgraphs/uniswap-forks/protocols/quickswap/config/deployments/quickswap-polygon/configurations.ts
+++ b/subgraphs/uniswap-forks/protocols/quickswap/config/deployments/quickswap-polygon/configurations.ts
@@ -108,7 +108,10 @@ export class QuickswapMaticConfigurations implements Configurations {
     return toLowerCaseList([]);
   }
   getUntrackedTokens(): string[] {
-    return [];
+    return [
+      "0x1518820879bc87d4dfea5664bb1b6c240d20d4f2", // Drop
+      "0x26d41380012d698e0a65c0f268cfa8ed0148f6f3", // Flamingo
+    ];
   }
   getBrokenERC20Tokens(): string[] {
     return ["0x5d76fa95c308fce88d347556785dd1dd44416272"];

--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/deployments/sushiswap-arbitrum/configurations.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/deployments/sushiswap-arbitrum/configurations.ts
@@ -109,7 +109,13 @@ export class SushiswapArbitrumConfigurations implements Configurations {
     return toLowerCaseList([]);
   }
   getUntrackedTokens(): string[] {
-    return [];
+    return [
+      "0x3010eadefaba5756226c0543ab4ea1f975018c65", // HonorWorld
+      "0x5204ca6252643b1cfc6bbac05698c45e70f2cb1c", // Pi Network
+      "0x15e32be99b3af4b7517639b3ac608c93f73e42de", // Bluefin APP
+      "0xf5520364a2e2ff1cb2e007df7cbe01c8b2cd7e0d", // ReadON
+      "0x014a029338d7953e0df6dc5ea351ade9743c98ed", // Sushiswap AI Card Render
+    ];
   }
   getBrokenERC20Tokens(): string[] {
     return [];

--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/deployments/sushiswap-avalanche/configurations.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/deployments/sushiswap-avalanche/configurations.ts
@@ -116,7 +116,9 @@ export class SushiswapAvalancheConfigurations implements Configurations {
     return toLowerCaseList([]);
   }
   getUntrackedTokens(): string[] {
-    return [];
+    return [
+      "0x0da67235dd5787d67955420c84ca1cecd4e5bb3b", // wMEMO
+    ];
   }
   getMinimumLiquidityThresholdTrackVolume(): BigDecimal {
     return MINIMUM_LIQUIDITY_TEN_THOUSAND;

--- a/subgraphs/uniswap-forks/protocols/sushiswap/config/deployments/sushiswap-polygon/configurations.ts
+++ b/subgraphs/uniswap-forks/protocols/sushiswap/config/deployments/sushiswap-polygon/configurations.ts
@@ -90,8 +90,6 @@ export class SushiswapMaticConfigurations implements Configurations {
       "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063", // DAI
       "0xc2132d05d31c914a87c6611c10748aeb04b58e8f", // USDT
       "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6", // wBTC
-      "0x4e78011ce80ee02d2c3e649fb657e45898257815", // Klima
-      "0x2f800db0fdb5223b3c3f354886d907a671414a7f", // BCT
     ]);
   }
   getStableCoins(): string[] {

--- a/subgraphs/uniswap-forks/protocols/trader-joe/src/common/handlers/handleRewarder.ts
+++ b/subgraphs/uniswap-forks/protocols/trader-joe/src/common/handlers/handleRewarder.ts
@@ -255,6 +255,7 @@ function getOrCreateRewarder(
     rewarder.hasFundsAt = BIGINT_ZERO;
     rewarder.tokenPerSec = BIGINT_ZERO;
     rewarder.rateCalculatedAt = BIGINT_ZERO;
+    rewarder._rewardRateCalculationInProgress = false;
 
     const tokenPerSec = RewarderCalculator.attemptToRetrieveRewardRate(c);
     if (tokenPerSec) {

--- a/subgraphs/uniswap-forks/src/price/price.ts
+++ b/subgraphs/uniswap-forks/src/price/price.ts
@@ -116,7 +116,7 @@ export function findUSDPricePerToken(
             poolAmounts.inputTokenBalances[priceTokenIndex]
           ).times(whitelistToken.lastPriceUSD! as BigDecimal);
 
-          if (isValidTVL(pool, token, whitelistToken.lastPriceUSD!)) {
+          if (isValidTVL(pool, token, newPrice)) {
             priceSoFar = newPrice;
           }
         }


### PR DESCRIPTION
**Context:**
There are 2 issues out for subgraphs within the Uniswap Forks directory. These are #2145 and #2168. This PR addresses the issues covered here for the Uniswap Forks subgraphs. Below are the changes implemented:

**Changes:**
- Apeswap BSC: Blacklisted Mor StableCoin and NFTGirl tokens
- Quickswap Polygon: Blacklisted Drop and Flamingo tokens
- Trader Joe Avalanche - Fixed null value for creation of the _MasterChefRewarder that caused run-time error.
- Honeyswap Gnosis - Blacklisted Honey/hiveWATER Token LP, Giveth Test Giv, and Test HNY tokens.
- Added factory contract abi to subgraph template. 
- Sushiswap Arbitrum - Blacklist 5 tokens. 
- Sushiswap Avalanche - Blacklist Wrapped Memo
- Sushiswap Polygon - Remove blacklist for klima dao and toucan protocol token
- Fixed pricing mechanism for maximum token TVL checks as it was using the whitelist token price to check TVL of the token to be priced. Was not causing any noticeable issues, but needed to be corrected. 