### PR TITLE
feat(#minor); dashboard; add blocknumber to snapshot tables

### DIFF
--- a/dashboard/src/common/DashboardVersion.tsx
+++ b/dashboard/src/common/DashboardVersion.tsx
@@ -11,7 +11,7 @@ const DashboardTag = styled("div")`
   z-index: 2;
 `;
 
-export const dashboardVersion = "v2.2.18";
+export const dashboardVersion = "v2.2.19";
 
 export const DashboardVersion = () => {
   return <DashboardTag>{dashboardVersion}</DashboardTag>;

--- a/dashboard/src/common/chartComponents/TableChart.tsx
+++ b/dashboard/src/common/chartComponents/TableChart.tsx
@@ -60,7 +60,8 @@ export const TableChart = ({
         xHeaderName = "Days";
       }
     }
-    const columns = [
+
+    let columns = [
       { field: "date", headerName: xHeaderName, width: 120 },
       {
         field: "value",
@@ -71,6 +72,16 @@ export const TableChart = ({
         align: "left" as GridAlignment,
       },
     ];
+    if (dataTable[0]["blockNumber"]) {
+      columns.push({
+        field: "blockNumber",
+        headerName: "Block",
+        flex: 0,
+        type: "number",
+        headerAlign: "left" as GridAlignment,
+        align: "left" as GridAlignment,
+      });
+    }
     let suffix = "";
     if (isPercentageField) {
       suffix = "%";
@@ -97,6 +108,14 @@ export const TableChart = ({
         returnVal = dataPoint.value;
       }
 
+      if (dataPoint.blockNumber) {
+        return {
+          id: idx,
+          date: dateColumn,
+          value: returnVal,
+          blockNumber: dataPoint.blockNumber,
+        };
+      }
       return {
         id: idx,
         date: dateColumn,

--- a/dashboard/src/queries/bridge/schema.ts
+++ b/dashboard/src/queries/bridge/schema.ts
@@ -46,6 +46,7 @@ export const schema100 = (): Schema => {
       dailyVolumeOutUSD: "BigDecimal!",
       cumulativeNetVolumeUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -80,6 +81,7 @@ export const schema100 = (): Schema => {
       totalCanonicalRouteCount: "Int!",
       totalWrappedRouteCount: "Int!",
       totalSupportedTokenCount: "Int!",
+      blockNumber: "BigInt!",
     },
     poolDailySnapshots: {
       id: "ID!",
@@ -111,6 +113,7 @@ export const schema100 = (): Schema => {
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       mintSupply: "BigInt",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -140,6 +143,7 @@ export const schema100 = (): Schema => {
       cumulativeMessageReceivedCount: "Int!",
       hourlyMessageReceivedCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     poolHourlySnapshots: {
       id: "ID!",
@@ -171,6 +175,7 @@ export const schema100 = (): Schema => {
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       mintSupply: "BigInt",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 
@@ -437,6 +442,7 @@ export const schema110 = (): Schema => {
       dailyVolumeOutUSD: "BigDecimal!",
       cumulativeNetVolumeUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -471,6 +477,7 @@ export const schema110 = (): Schema => {
       totalCanonicalRouteCount: "Int!",
       totalWrappedRouteCount: "Int!",
       totalSupportedTokenCount: "Int!",
+      blockNumber: "BigInt!",
     },
     poolDailySnapshots: {
       id: "ID!",
@@ -502,6 +509,7 @@ export const schema110 = (): Schema => {
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       mintSupply: "BigInt",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -531,6 +539,7 @@ export const schema110 = (): Schema => {
       cumulativeMessageReceivedCount: "Int!",
       hourlyMessageReceivedCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     poolHourlySnapshots: {
       id: "ID!",
@@ -562,6 +571,7 @@ export const schema110 = (): Schema => {
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       mintSupply: "BigInt",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 
@@ -839,6 +849,7 @@ export const schema120 = (): Schema => {
       dailyVolumeOutUSD: "BigDecimal!",
       cumulativeNetVolumeUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -873,6 +884,7 @@ export const schema120 = (): Schema => {
       totalCanonicalRouteCount: "Int!",
       totalWrappedRouteCount: "Int!",
       totalSupportedTokenCount: "Int!",
+      blockNumber: "BigInt!",
     },
     poolDailySnapshots: {
       id: "ID!",
@@ -905,6 +917,7 @@ export const schema120 = (): Schema => {
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       mintSupply: "BigInt",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -934,6 +947,7 @@ export const schema120 = (): Schema => {
       cumulativeMessageReceivedCount: "Int!",
       hourlyMessageReceivedCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     poolHourlySnapshots: {
       id: "ID!",
@@ -966,6 +980,7 @@ export const schema120 = (): Schema => {
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       mintSupply: "BigInt",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 

--- a/dashboard/src/queries/dex/schema.ts
+++ b/dashboard/src/queries/dex/schema.ts
@@ -49,6 +49,7 @@ export const schema130 = (): Schema => {
       dailyTotalRevenueUSD: "BigDecimal!",
       cumulativeTotalRevenueUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -60,6 +61,7 @@ export const schema130 = (): Schema => {
       dailySwapCount: "Int!",
       timestamp: "BigInt!",
       totalPoolCount: "Int!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolDailySnapshots: {
       id: "ID!",
@@ -82,6 +84,7 @@ export const schema130 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -92,6 +95,7 @@ export const schema130 = (): Schema => {
       hourlyWithdrawCount: "Int!",
       hourlySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolHourlySnapshots: {
       id: "ID!",
@@ -114,6 +118,7 @@ export const schema130 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 
@@ -344,6 +349,7 @@ export const schema132 = (): Schema => {
       dailyTotalRevenueUSD: "BigDecimal!",
       cumulativeTotalRevenueUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -355,6 +361,7 @@ export const schema132 = (): Schema => {
       dailySwapCount: "Int!",
       timestamp: "BigInt!",
       totalPoolCount: "Int!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolDailySnapshots: {
       id: "ID!",
@@ -377,6 +384,7 @@ export const schema132 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -387,6 +395,7 @@ export const schema132 = (): Schema => {
       hourlyWithdrawCount: "Int!",
       hourlySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolHourlySnapshots: {
       id: "ID!",
@@ -409,6 +418,7 @@ export const schema132 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 
@@ -640,6 +650,7 @@ export const schema200 = (): Schema => {
       dailyTotalRevenueUSD: "BigDecimal!",
       cumulativeTotalRevenueUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -648,6 +659,7 @@ export const schema200 = (): Schema => {
       dailyTransactionCount: "Int!",
       timestamp: "BigInt!",
       totalPoolCount: "Int!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolDailySnapshots: {
       id: "ID!",
@@ -670,6 +682,7 @@ export const schema200 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -677,6 +690,7 @@ export const schema200 = (): Schema => {
       hourlyActiveUsers: "Int!",
       hourlyTransactionCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolHourlySnapshots: {
       id: "ID!",
@@ -699,6 +713,7 @@ export const schema200 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 
@@ -970,6 +985,7 @@ export const schema303 = (): Schema => {
       dailyTotalRevenueUSD: "BigDecimal!",
       cumulativeTotalRevenueUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -982,6 +998,7 @@ export const schema303 = (): Schema => {
       dailySwapCount: "Int"!,
       totalPoolCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolDailySnapshots: {
       id: "ID!",
@@ -1024,6 +1041,7 @@ export const schema303 = (): Schema => {
       cumulativeSwapCount: "Int!",
       dailySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -1035,6 +1053,7 @@ export const schema303 = (): Schema => {
       hourlyWithdrawCount: "Int!",
       hourlySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolHourlySnapshots: {
       id: "ID!",
@@ -1077,6 +1096,7 @@ export const schema303 = (): Schema => {
       cumulativeSwapCount: "Int!",
       hourlySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 
@@ -1391,6 +1411,7 @@ export const schema304 = (): Schema => {
       dailyTotalRevenueUSD: "BigDecimal!",
       cumulativeTotalRevenueUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -1403,6 +1424,7 @@ export const schema304 = (): Schema => {
       dailySwapCount: "Int"!,
       totalPoolCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolDailySnapshots: {
       id: "ID!",
@@ -1445,6 +1467,7 @@ export const schema304 = (): Schema => {
       cumulativeSwapCount: "Int!",
       dailySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -1456,6 +1479,7 @@ export const schema304 = (): Schema => {
       hourlyWithdrawCount: "Int!",
       hourlySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolHourlySnapshots: {
       id: "ID!",
@@ -1498,6 +1522,7 @@ export const schema304 = (): Schema => {
       cumulativeSwapCount: "Int!",
       hourlySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 
@@ -1813,6 +1838,7 @@ export const schema400 = (): Schema => {
       dailyTotalRevenueUSD: "BigDecimal!",
       cumulativeTotalRevenueUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -1825,6 +1851,7 @@ export const schema400 = (): Schema => {
       dailySwapCount: "Int"!,
       totalPoolCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolDailySnapshots: {
       id: "ID!",
@@ -1867,6 +1894,7 @@ export const schema400 = (): Schema => {
       cumulativeSwapCount: "Int!",
       dailySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -1878,6 +1906,7 @@ export const schema400 = (): Schema => {
       hourlyWithdrawCount: "Int!",
       hourlySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     liquidityPoolHourlySnapshots: {
       id: "ID!",
@@ -1920,6 +1949,7 @@ export const schema400 = (): Schema => {
       cumulativeSwapCount: "Int!",
       hourlySwapCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 

--- a/dashboard/src/queries/generic/schema.ts
+++ b/dashboard/src/queries/generic/schema.ts
@@ -37,6 +37,7 @@ export const schema120 = (): Schema => {
       dailyTotalRevenueUSD: "BigDecimal!",
       cumulativeTotalRevenueUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -44,6 +45,7 @@ export const schema120 = (): Schema => {
       dailyActiveUsers: "Int!",
       dailyTransactionCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     poolDailySnapshots: {
       id: "ID!",
@@ -55,6 +57,7 @@ export const schema120 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -62,6 +65,7 @@ export const schema120 = (): Schema => {
       hourlyActiveUsers: "Int!",
       hourlyTransactionCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     poolHourlySnapshots: {
       id: "ID!",
@@ -73,6 +77,7 @@ export const schema120 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 
@@ -256,6 +261,7 @@ export const schema130 = (): Schema => {
       dailyTotalRevenueUSD: "BigDecimal!",
       cumulativeTotalRevenueUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -264,6 +270,7 @@ export const schema130 = (): Schema => {
       dailyTransactionCount: "Int!",
       timestamp: "BigInt!",
       totalPoolCount: "Int!",
+      blockNumber: "BigInt!",
     },
     poolDailySnapshots: {
       id: "ID!",
@@ -281,6 +288,7 @@ export const schema130 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -288,6 +296,7 @@ export const schema130 = (): Schema => {
       hourlyActiveUsers: "Int!",
       hourlyTransactionCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     poolHourlySnapshots: {
       id: "ID!",
@@ -305,6 +314,7 @@ export const schema130 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 

--- a/dashboard/src/queries/lending/schema.ts
+++ b/dashboard/src/queries/lending/schema.ts
@@ -50,6 +50,7 @@ export const schema130 = (): Schema => {
       cumulativeLiquidateUSD: "BigDecimal!",
       mintedTokenSupplies: "[BigInt!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -63,6 +64,7 @@ export const schema130 = (): Schema => {
       dailyLiquidateCount: "Int!",
       totalPoolCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     marketDailySnapshots: {
       id: "ID!",
@@ -90,6 +92,7 @@ export const schema130 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -102,6 +105,7 @@ export const schema130 = (): Schema => {
       hourlyRepayCount: "Int!",
       hourlyLiquidateCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     marketHourlySnapshots: {
       id: "ID!",
@@ -129,6 +133,7 @@ export const schema130 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 

--- a/dashboard/src/queries/yield/schema.ts
+++ b/dashboard/src/queries/yield/schema.ts
@@ -37,6 +37,7 @@ export const schema120 = (): Schema => {
       dailyTotalRevenueUSD: "BigDecimal!",
       cumulativeTotalRevenueUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -46,6 +47,7 @@ export const schema120 = (): Schema => {
       dailyDepositCount: "Int!",
       dailyWithdrawCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     vaultDailySnapshots: {
       id: "ID!",
@@ -58,6 +60,7 @@ export const schema120 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -67,6 +70,7 @@ export const schema120 = (): Schema => {
       hourlyDepositCount: "Int!",
       hourlyWithdrawCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     vaultHourlySnapshots: {
       id: "ID!",
@@ -79,6 +83,7 @@ export const schema120 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 
@@ -291,6 +296,7 @@ export const schema130 = (): Schema => {
       dailyTotalRevenueUSD: "BigDecimal!",
       cumulativeTotalRevenueUSD: "BigDecimal!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsDailySnapshots: {
       id: "ID!",
@@ -301,6 +307,7 @@ export const schema130 = (): Schema => {
       dailyWithdrawCount: "Int!",
       timestamp: "BigInt!",
       totalPoolCount: "Int!",
+      blockNumber: "BigInt!",
     },
     vaultDailySnapshots: {
       id: "ID!",
@@ -319,6 +326,7 @@ export const schema130 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     usageMetricsHourlySnapshots: {
       id: "ID!",
@@ -328,6 +336,7 @@ export const schema130 = (): Schema => {
       hourlyDepositCount: "Int!",
       hourlyWithdrawCount: "Int!",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
     vaultHourlySnapshots: {
       id: "ID!",
@@ -346,6 +355,7 @@ export const schema130 = (): Schema => {
       rewardTokenEmissionsAmount: "[BigInt!]",
       rewardTokenEmissionsUSD: "[BigDecimal!]",
       timestamp: "BigInt!",
+      blockNumber: "BigInt!",
     },
   };
 


### PR DESCRIPTION
> Note: schemas for options and perp subgraphs do not have field `blockNumber` in their snapshot entities, hence block column will not show in their tables.

![Screenshot from 2023-06-22 17-38-10](https://github.com/messari/subgraphs/assets/32761670/3625444f-403f-4c15-86ee-2333680abb70)