### PR TITLE
chore(); morpho; fix deployment structure

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3057,10 +3057,10 @@
       }
     }
   },
-  "morpho": {
+  "morpho-aave-v2": {
     "schema": "lending",
     "base": "morpho",
-    "protocol": "morpho",
+    "protocol": "morpho-aave-v2",
     "project": "morpho",
     "deployments": {
       "morpho-aave-v2-ethereum": {
@@ -3072,7 +3072,7 @@
           "methodology": "1.0.0"
         },
         "files": {
-          "template": "morpho.template.yaml"
+          "template": "morpho.aave.v2.template.yaml"
         },
         "options": {
           "prepare:yaml": true,
@@ -3084,7 +3084,15 @@
             "query-id": "morpho-aave-v2-ethereum"
           }
         }
-      },
+      }
+    }
+  },
+  "morpho-compound": {
+    "schema": "lending",
+    "base": "morpho",
+    "protocol": "morpho-compound",
+    "project": "morpho",
+    "deployments": {
       "morpho-compound-ethereum": {
         "network": "ethereum",
         "status": "prod",
@@ -3094,7 +3102,7 @@
           "methodology": "1.0.0"
         },
         "files": {
-          "template": "morpho.template.yaml"
+          "template": "morpho.compound.template.yaml"
         },
         "options": {
           "prepare:yaml": true,

--- a/subgraphs/morpho/protocols/morpho-aave-v2/config/deployments/morpho-aave-v2-ethereum/configurations.json
+++ b/subgraphs/morpho/protocols/morpho-aave-v2/config/deployments/morpho-aave-v2-ethereum/configurations.json
@@ -1,6 +1,5 @@
 {
   "network": "mainnet",
-  "isAaveV2": true,
   "factory": {
     "startBlock": 15383036,
     "address": "0x777777c9898d384f785ee44acfe945efdff5f3e0"

--- a/subgraphs/morpho/protocols/morpho-aave-v2/config/templates/morpho.aave.v2.template.yaml
+++ b/subgraphs/morpho/protocols/morpho-aave-v2/config/templates/morpho.aave.v2.template.yaml
@@ -1,0 +1,148 @@
+specVersion: 0.0.5
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum
+    name: Morpho
+    network: mainnet
+    source:
+      address: "{{ factory.address }}"
+      abi: MorphoAaveV2
+      startBlock: { { factory.startBlock } }
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities: []
+      abis:
+        - name: MorphoAaveV2
+          file: ./abis/MorphoAaveV2.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: AToken
+          file: ./abis/aave/AToken.json
+        - name: DebtToken
+          file: ./abis/aave/DebtToken.json
+        - name: LendingPool
+          file: ./abis/aave/LendingPool.json
+        - name: LendingPoolAddressesProvider
+          file: ./abis/aave/LendingPoolAddressesProvider.json
+        - name: LendingPoolConfigurator
+          file: ./abis/aave/LendingPoolConfigurator.json
+        - name: PriceOracle
+          file: ./abis/aave/PriceOracle.json
+        - name: ProtocolDataProvider
+          file: ./abis/aave/ProtocolDataProvider.json
+        - name: ChainlinkPriceFeed
+          file: ./abis/chainlink/PriceFeed.json
+      eventHandlers:
+        - event: Borrowed(indexed address,indexed address,uint256,uint256,uint256)
+          handler: handleBorrowed
+        - event: P2PAmountsUpdated(indexed address,uint256,uint256)
+          handler: handleP2PAmountsUpdated
+        - event: P2PBorrowDeltaUpdated(indexed address,uint256)
+          handler: handleP2PBorrowDeltaUpdated
+        - event: P2PSupplyDeltaUpdated(indexed address,uint256)
+          handler: handleP2PSupplyDeltaUpdated
+        - event: Supplied(indexed address,indexed address,indexed address,uint256,uint256,uint256)
+          handler: handleSupplied
+        - event: BorrowerPositionUpdated(indexed address,indexed address,uint256,uint256)
+          handler: handleBorrowerPositionUpdated
+        - event: SupplierPositionUpdated(indexed address,indexed address,uint256,uint256)
+          handler: handleSupplierPositionUpdated
+        - event: P2PIndexesUpdated(indexed address,uint256,uint256,uint256,uint256)
+          handler: handleP2PIndexesUpdated
+        - event: Liquidated(address,indexed address,indexed address,uint256,indexed address,uint256)
+          handler: handleLiquidated
+        - event: Withdrawn(indexed address,indexed address,indexed address,uint256,uint256,uint256)
+          handler: handleWithdrawn
+        - event: Repaid(indexed address,indexed address,indexed address,uint256,uint256,uint256)
+          handler: handleRepaid
+        - event: DefaultMaxGasForMatchingSet((uint64,uint64,uint64,uint64))
+          handler: handleDefaultMaxGasForMatchingSet
+        - event: IsBorrowPausedSet(indexed address,bool)
+          handler: handleIsBorrowPausedSet
+        - event: IsDeprecatedSet(indexed address,bool)
+          handler: handleIsDeprecatedSet
+        - event: IsLiquidateBorrowPausedSet(indexed address,bool)
+          handler: handleIsLiquidateBorrowPausedSet
+        - event: IsLiquidateCollateralPausedSet(indexed address,bool)
+          handler: handleIsLiquidateCollateralPausedSet
+        - event: IsRepayPausedSet(indexed address,bool)
+          handler: handleIsRepayPausedSet
+        - event: IsSupplyPausedSet(indexed address,bool)
+          handler: handleIsSupplyPausedSet
+        - event: IsWithdrawPausedSet(indexed address,bool)
+          handler: handleIsWithdrawPausedSet
+        - event: MarketCreated(indexed address,uint16,uint16)
+          handler: handleMarketCreated
+        - event: MaxSortedUsersSet(uint256)
+          handler: handleMaxSortedUsersSet
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleOwnershipTransferred
+        - event: P2PIndexCursorSet(indexed address,uint16)
+          handler: handleP2PIndexCursorSet
+        - event: P2PStatusSet(indexed address,bool)
+          handler: handleP2PStatusSet
+        - event: PartialPauseStatusSet(indexed address,bool)
+          handler: handlePartialPauseStatusSet
+        - event: PauseStatusSet(indexed address,bool)
+          handler: handlePauseStatusSet
+        - event: ReserveFactorSet(indexed address,uint16)
+          handler: handleReserveFactorSet
+        - event: ReserveFeeClaimed(indexed address,uint256)
+          handler: handleReserveFeeClaimed
+      file: ./src/mapping/morpho-aave-v2/morphoAaveV2.ts
+templates:
+  - kind: ethereum
+    name: LendingPool
+    network: mainnet
+    source:
+      abi: LendingPool
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities: []
+      abis:
+        - name: MorphoAaveV2
+          file: ./abis/MorphoAaveV2.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: AToken
+          file: ./abis/aave/AToken.json
+        - name: DebtToken
+          file: ./abis/aave/DebtToken.json
+        - name: LendingPool
+          file: ./abis/aave/LendingPool.json
+        - name: LendingPoolAddressesProvider
+          file: ./abis/aave/LendingPoolAddressesProvider.json
+        - name: LendingPoolConfigurator
+          file: ./abis/aave/LendingPoolConfigurator.json
+        - name: PriceOracle
+          file: ./abis/aave/PriceOracle.json
+        - name: ProtocolDataProvider
+          file: ./abis/aave/ProtocolDataProvider.json
+        - name: ChainlinkPriceFeed
+          file: ./abis/chainlink/PriceFeed.json
+      eventHandlers:
+        - event: ReserveDataUpdated(indexed address,uint256,uint256,uint256,uint256,uint256)
+          handler: handleReserveDataUpdated
+      file: ./src/mapping/morpho-aave-v2/lendingPool.ts
+  - kind: ethereum
+    name: LendingPoolConfigurator
+    network: mainnet
+    source:
+      abi: LendingPoolConfigurator
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities: []
+      abis:
+        - name: LendingPoolConfigurator
+          file: ./abis/aave/LendingPoolConfigurator.json
+      eventHandlers:
+        - event: CollateralConfigurationChanged(indexed address,uint256,uint256,uint256)
+          handler: handleCollateralConfigurationChanged
+      file: ./src/mapping/morpho-aave-v2/lendingPoolConfigurator.ts

--- a/subgraphs/morpho/protocols/morpho-aave-v2/config/templates/morpho.aave.v2.template.yaml
+++ b/subgraphs/morpho/protocols/morpho-aave-v2/config/templates/morpho.aave.v2.template.yaml
@@ -8,7 +8,7 @@ dataSources:
     source:
       address: "{{ factory.address }}"
       abi: MorphoAaveV2
-      startBlock: { { factory.startBlock } }
+      startBlock: {{ factory.startBlock }}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7

--- a/subgraphs/morpho/protocols/morpho-compound/config/deployments/morpho-compound-ethereum/configurations.json
+++ b/subgraphs/morpho/protocols/morpho-compound/config/deployments/morpho-compound-ethereum/configurations.json
@@ -1,6 +1,5 @@
 {
   "network": "mainnet",
-  "isCompound": true,
   "factory": {
     "startBlock": 14860866,
     "address": "0x8888882f8f843896699869179fb6e4f7e3b58888"

--- a/subgraphs/morpho/protocols/morpho-compound/config/templates/morpho.compound.template.yaml
+++ b/subgraphs/morpho/protocols/morpho-compound/config/templates/morpho.compound.template.yaml
@@ -8,7 +8,7 @@ dataSources:
     source:
       address: "{{ factory.address }}"
       abi: MorphoCompound
-      startBlock: { { factory.startBlock } }
+      startBlock: {{ factory.startBlock }}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7

--- a/subgraphs/morpho/protocols/morpho-compound/config/templates/morpho.compound.template.yaml
+++ b/subgraphs/morpho/protocols/morpho-compound/config/templates/morpho.compound.template.yaml
@@ -2,107 +2,13 @@ specVersion: 0.0.5
 schema:
   file: ./schema.graphql
 dataSources:
-{{#isAaveV2}}
-  - kind: ethereum
-    name: Morpho
-    network: mainnet
-    source:
-      address: "{{ factory.address }}"
-      abi: MorphoAaveV2
-      startBlock: {{ factory.startBlock }}
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      entities: []
-      abis:
-        - name: MorphoAaveV2
-          file: ./abis/MorphoAaveV2.json
-        - name: ERC20
-          file: ./abis/ERC20.json
-        - name: AToken
-          file: ./abis/aave/AToken.json
-        - name: DebtToken
-          file: ./abis/aave/DebtToken.json
-        - name: LendingPool
-          file: ./abis/aave/LendingPool.json
-        - name: LendingPoolAddressesProvider
-          file: ./abis/aave/LendingPoolAddressesProvider.json
-        - name: LendingPoolConfigurator
-          file: ./abis/aave/LendingPoolConfigurator.json
-        - name: PriceOracle
-          file: ./abis/aave/PriceOracle.json
-        - name: ProtocolDataProvider
-          file: ./abis/aave/ProtocolDataProvider.json
-        - name: ChainlinkPriceFeed
-          file: ./abis/chainlink/PriceFeed.json
-      eventHandlers:
-        - event: Borrowed(indexed address,indexed address,uint256,uint256,uint256)
-          handler: handleBorrowed
-        - event: P2PAmountsUpdated(indexed address,uint256,uint256)
-          handler: handleP2PAmountsUpdated
-        - event: P2PBorrowDeltaUpdated(indexed address,uint256)
-          handler: handleP2PBorrowDeltaUpdated
-        - event: P2PSupplyDeltaUpdated(indexed address,uint256)
-          handler: handleP2PSupplyDeltaUpdated
-        - event: Supplied(indexed address,indexed address,indexed address,uint256,uint256,uint256)
-          handler: handleSupplied
-        - event: BorrowerPositionUpdated(indexed address,indexed address,uint256,uint256)
-          handler: handleBorrowerPositionUpdated
-        - event: SupplierPositionUpdated(indexed address,indexed address,uint256,uint256)
-          handler: handleSupplierPositionUpdated
-        - event: P2PIndexesUpdated(indexed address,uint256,uint256,uint256,uint256)
-          handler: handleP2PIndexesUpdated
-        - event: Liquidated(address,indexed address,indexed address,uint256,indexed address,uint256)
-          handler: handleLiquidated
-        - event: Withdrawn(indexed address,indexed address,indexed address,uint256,uint256,uint256)
-          handler: handleWithdrawn
-        - event: Repaid(indexed address,indexed address,indexed address,uint256,uint256,uint256)
-          handler: handleRepaid
-        - event: DefaultMaxGasForMatchingSet((uint64,uint64,uint64,uint64))
-          handler: handleDefaultMaxGasForMatchingSet
-        - event: IsBorrowPausedSet(indexed address,bool)
-          handler: handleIsBorrowPausedSet
-        - event: IsDeprecatedSet(indexed address,bool)
-          handler: handleIsDeprecatedSet
-        - event: IsLiquidateBorrowPausedSet(indexed address,bool)
-          handler: handleIsLiquidateBorrowPausedSet
-        - event: IsLiquidateCollateralPausedSet(indexed address,bool)
-          handler: handleIsLiquidateCollateralPausedSet
-        - event: IsRepayPausedSet(indexed address,bool)
-          handler: handleIsRepayPausedSet
-        - event: IsSupplyPausedSet(indexed address,bool)
-          handler: handleIsSupplyPausedSet
-        - event: IsWithdrawPausedSet(indexed address,bool)
-          handler: handleIsWithdrawPausedSet
-        - event: MarketCreated(indexed address,uint16,uint16)
-          handler: handleMarketCreated
-        - event: MaxSortedUsersSet(uint256)
-          handler: handleMaxSortedUsersSet
-        - event: OwnershipTransferred(indexed address,indexed address)
-          handler: handleOwnershipTransferred
-        - event: P2PIndexCursorSet(indexed address,uint16)
-          handler: handleP2PIndexCursorSet
-        - event: P2PStatusSet(indexed address,bool)
-          handler: handleP2PStatusSet
-        - event: PartialPauseStatusSet(indexed address,bool)
-          handler: handlePartialPauseStatusSet
-        - event: PauseStatusSet(indexed address,bool)
-          handler: handlePauseStatusSet
-        - event: ReserveFactorSet(indexed address,uint16)
-          handler: handleReserveFactorSet
-        - event: ReserveFeeClaimed(indexed address,uint256)
-          handler: handleReserveFeeClaimed
-      file: ./src/mapping/morpho-aave-v2/morphoAaveV2.ts
-{{/isAaveV2}}
-{{#isCompound}}
   - kind: ethereum
     name: Morpho
     network: mainnet
     source:
       address: "{{ factory.address }}"
       abi: MorphoCompound
-      startBlock: {{ factory.startBlock }}
+      startBlock: { { factory.startBlock } }
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -177,63 +83,7 @@ dataSources:
         - event: ReserveFeeClaimed(indexed address,uint256)
           handler: handleReserveFeeClaimed
       file: ./src/mapping/morpho-compound/morphoCompound.ts
-{{/isCompound}}
 templates:
-{{#isAaveV2}}
-  - kind: ethereum
-    name: LendingPool
-    network: mainnet
-    source:
-      abi: LendingPool
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      entities: []
-      abis:
-        - name: MorphoAaveV2
-          file: ./abis/MorphoAaveV2.json
-        - name: ERC20
-          file: ./abis/ERC20.json
-        - name: AToken
-          file: ./abis/aave/AToken.json
-        - name: DebtToken
-          file: ./abis/aave/DebtToken.json
-        - name: LendingPool
-          file: ./abis/aave/LendingPool.json
-        - name: LendingPoolAddressesProvider
-          file: ./abis/aave/LendingPoolAddressesProvider.json
-        - name: LendingPoolConfigurator
-          file: ./abis/aave/LendingPoolConfigurator.json
-        - name: PriceOracle
-          file: ./abis/aave/PriceOracle.json
-        - name: ProtocolDataProvider
-          file: ./abis/aave/ProtocolDataProvider.json
-        - name: ChainlinkPriceFeed
-          file: ./abis/chainlink/PriceFeed.json
-      eventHandlers:
-        - event: ReserveDataUpdated(indexed address,uint256,uint256,uint256,uint256,uint256)
-          handler: handleReserveDataUpdated
-      file: ./src/mapping/morpho-aave-v2/lendingPool.ts
-  - kind: ethereum
-    name: LendingPoolConfigurator
-    network: mainnet
-    source:
-      abi: LendingPoolConfigurator
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      entities: []
-      abis:
-        - name: LendingPoolConfigurator
-          file: ./abis/aave/LendingPoolConfigurator.json
-      eventHandlers:
-        - event: CollateralConfigurationChanged(indexed address,uint256,uint256,uint256)
-          handler: handleCollateralConfigurationChanged
-      file: ./src/mapping/morpho-aave-v2/lendingPoolConfigurator.ts
-{{/isAaveV2}}
-{{#isCompound}}
   - kind: ethereum
     name: CToken
     network: mainnet
@@ -309,4 +159,3 @@ templates:
         - event: PriceUpdated(indexed bytes32,uint256)
           handler: handlePriceUpdated
       file: ./src/mapping/morpho-compound/oracle.ts
-{{/isCompound}}


### PR DESCRIPTION
Morpho deployments needed to be separated to ensure our BE assumptions were met.

We assume that each protocol has only 1 deployment of each network.

Fix: separate into 2 separate protocols in the `deployment.json`