### PR TITLE
fix: force nullability check on `this.position`

### DIFF
--- a/subgraphs/_reference_/src/sdk/protocols/lending/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/lending/account.ts
@@ -11,7 +11,7 @@ import { INT_ONE, INT_ZERO } from "./constants";
  *  - Making position snapshots
  *
  * Schema Version:  3.1.0
- * SDK Version:     1.0.5
+ * SDK Version:     1.0.6
  * Author(s):
  *  - @dmelotik
  *  - @dhruv-chauhan

--- a/subgraphs/_reference_/src/sdk/protocols/lending/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/lending/account.ts
@@ -11,7 +11,7 @@ import { INT_ONE, INT_ZERO } from "./constants";
  *  - Making position snapshots
  *
  * Schema Version:  3.1.0
- * SDK Version:     1.0.4
+ * SDK Version:     1.0.5
  * Author(s):
  *  - @dmelotik
  */

--- a/subgraphs/_reference_/src/sdk/protocols/lending/manager.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/lending/manager.ts
@@ -52,7 +52,7 @@ import { PositionManager } from "./position";
  * need to think about all of the detailed storage changes that occur.
  *
  * Schema Version:  3.1.0
- * SDK Version:     1.0.5
+ * SDK Version:     1.0.6
  * Author(s):
  *  - @dmelotik
  *  - @dhruv-chauhan

--- a/subgraphs/_reference_/src/sdk/protocols/lending/manager.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/lending/manager.ts
@@ -52,7 +52,7 @@ import { PositionManager } from "./position";
  * need to think about all of the detailed storage changes that occur.
  *
  * Schema Version:  3.1.0
- * SDK Version:     1.0.4
+ * SDK Version:     1.0.5
  * Author(s):
  *  - @dmelotik
  */

--- a/subgraphs/_reference_/src/sdk/protocols/lending/position.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/lending/position.ts
@@ -30,7 +30,7 @@ import { PositionSide } from "./constants";
  * make changes to a given position.
  *
  * Schema Version:  3.1.0
- * SDK Version:     1.0.5
+ * SDK Version:     1.0.6
  * Author(s):
  *  - @dmelotik
  *  - @dhruv-chauhan

--- a/subgraphs/_reference_/src/sdk/protocols/lending/position.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/lending/position.ts
@@ -30,7 +30,7 @@ import { PositionSide } from "./constants";
  * make changes to a given position.
  *
  * Schema Version:  3.1.0
- * SDK Version:     1.0.4
+ * SDK Version:     1.0.5
  * Author(s):
  *  - @dmelotik
  */
@@ -81,15 +81,15 @@ export class PositionManager {
 
   setCollateral(isCollateral: boolean): void {
     if (this.position) {
-      this.position.isCollateral = isCollateral;
-      this.position.save();
+      this.position!.isCollateral = isCollateral;
+      this.position!.save();
     }
   }
 
   setIsolation(isIsolated: boolean): void {
     if (this.position) {
-      this.position.isIsolated = isIsolated;
-      this.position.save();
+      this.position!.isIsolated = isIsolated;
+      this.position!.save();
     }
   }
 

--- a/subgraphs/_reference_/src/sdk/protocols/lending/snapshots.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/lending/snapshots.ts
@@ -36,7 +36,7 @@ import {
  * need to think about all of the detailed storage changes that occur.
  *
  * Schema Version:  3.1.0
- * SDK Version:     1.0.5
+ * SDK Version:     1.0.6
  * Author(s):
  *  - @dmelotik
  *  - @dhruv-chauhan

--- a/subgraphs/_reference_/src/sdk/protocols/lending/snapshots.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/lending/snapshots.ts
@@ -36,7 +36,7 @@ import {
  * need to think about all of the detailed storage changes that occur.
  *
  * Schema Version:  3.1.0
- * SDK Version:     1.0.4
+ * SDK Version:     1.0.5
  * Author(s):
  *  - @dmelotik
  */

--- a/subgraphs/_reference_/src/sdk/protocols/lending/token.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/lending/token.ts
@@ -17,7 +17,7 @@ import {
  * use in mappings and get info about the token.
  *
  * Schema Version:  3.1.0
- * SDK Version:     1.0.5
+ * SDK Version:     1.0.6
  * Author(s):
  *  - @dmelotik
  *  - @dhruv-chauhan

--- a/subgraphs/_reference_/src/sdk/protocols/lending/token.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/lending/token.ts
@@ -17,7 +17,7 @@ import {
  * use in mappings and get info about the token.
  *
  * Schema Version:  3.1.0
- * SDK Version:     1.0.4
+ * SDK Version:     1.0.5
  * Author(s):
  *  - @dmelotik
  */


### PR DESCRIPTION
without this, i run into the following error during compilation:
```
stdout: ERROR TS2322: Type 'generated/schema/Position | null' is not assignable to type 'generated/schema/Position'.

       this.position.isCollateral = isCollateral;
       ~~~~~~~~~~~~~
 in src/sdk/position.ts(84,7)

ERROR TS2322: Type 'generated/schema/Position | null' is not assignable to type 'generated/schema/Position'.

       this.position.save();
       ~~~~~~~~~~~~~
 in src/sdk/position.ts(85,7)

ERROR TS2322: Type 'generated/schema/Position | null' is not assignable to type 'generated/schema/Position'.

       this.position.isIsolated = isIsolated;
       ~~~~~~~~~~~~~
 in src/sdk/position.ts(91,7)

ERROR TS2322: Type 'generated/schema/Position | null' is not assignable to type 'generated/schema/Position'.

       this.position.save();
       ~~~~~~~~~~~~~
 in src/sdk/position.ts(92,7)
```