### PR TITLE
fix(#minor); Uniswap V3 Etheruem; Blacklist X token

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3732,7 +3732,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.0",
-          "subgraph": "1.5.0",
+          "subgraph": "1.6.0",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-ethereum/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-ethereum/configurations.ts
@@ -97,7 +97,9 @@ export class UniswapV3MainnetConfigurations implements Configurations {
     return stringToBytesList([]);
   }
   getUntrackedTokens(): Bytes[] {
-    return stringToBytesList([]);
+    return stringToBytesList([
+      "0x0df66b8644771fae9400d93e74a509a3546cd13e", // X token
+    ]);
   }
   getMinimumLiquidityThreshold(): BigDecimal {
     return BigDecimal.fromString("200000");


### PR DESCRIPTION
**Context:** 

X token is causing the TVL on Uniswap V3 Ethereum to be in the trillions. The purpose of this PR is to blacklist this token so that it can be grafted and fixed. 

Connect to issue #2299

https://api.thegraph.com/subgraphs/name/messari/uniswap-v3-ethereum/graphql?query=%7B%0A++liquidityPool+%28id%3A+%220x8e002692a1604fdde5cb21cdce4002dda9833496%22%29+%7B%0A++++name%0A++++id%0A++++totalValueLockedUSD%0A++++inputTokens+%7B%0A++++++id%0A++++++name%0A++++++lastPriceUSD%0A++++%7D%0A++%7D%0A%7D++