### PR TITLE
fix(#patch); lido; skip aragon voting in counting protocol revenue

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2570,7 +2570,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.4.0",
-          "subgraph": "1.0.5",
+          "subgraph": "1.0.6",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/lido/README.md
+++ b/subgraphs/lido/README.md
@@ -387,12 +387,15 @@ SUM(`Staking Rewards (ETH)`) OVER `time`
 
 ### Treasury Revenue (ETH):
 
-FOR every tx WITH triggered the evt `lido."LidoOracle_evt_PostTotalShares"`:
+FOR every** tx WITH triggered the evt `lido."LidoOracle_evt_PostTotalShares"`:
 
     SUM(`value`/1e18) FROM `stETH erc20."ERC20_evt_Transfer"`
     WHERE `to` = '\x3e40d73eb977dc6a537af587d48316fee66e9c8c'
 
 _Note_:0x3e40d73eb977dc6a537af587d48316fee66e9c8c Treasury address
+
+> ** [Treasury contract](https://etherscan.io/address/0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb#readProxyContract#F13) doubles as [Aragon Agent contract](https://docs.lido.fi/deployed-contracts/#lido-v2-dao-contracts). To not count DAO treasury transfers into protocol's revenue, we ignore transactions which execute voting. </br>
+> Example of such a transaction: https://etherscan.io/tx/0x673804d1c993c21f50f019cefb4c4cfb5e0a9e0ca2d78d6a59c33b321887a277
 
 **Contract:** stETH erc20 0xae7ab96520de3a18e5e111b5eaab095312d7fe84
 

--- a/subgraphs/lido/protocols/lido/config/templates/lido.template.yaml
+++ b/subgraphs/lido/protocols/lido/config/templates/lido.template.yaml
@@ -18,7 +18,7 @@ dataSources:
       startBlock: 11473216
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Token
@@ -79,6 +79,7 @@ dataSources:
           handler: handleSubmit
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+          receipt: true
         - event: ETHDistributed(indexed uint256,uint256,uint256,uint256,uint256,uint256)
           handler: handleETHDistributed
       file: ./src/mappings/Lido.ts
@@ -91,7 +92,7 @@ dataSources:
       startBlock: 11473216
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Token

--- a/subgraphs/lido/src/utils/constants.ts
+++ b/subgraphs/lido/src/utils/constants.ts
@@ -127,6 +127,7 @@ export const INT_NEGATIVE_ONE = -1 as i32;
 export const INT_ZERO = 0 as i32;
 export const INT_ONE = 1 as i32;
 export const INT_TWO = 2 as i32;
+export const INT_THREE = 3 as i32;
 export const INT_FOUR = 4 as i32;
 
 export const BIGDECIMAL_ZERO = new BigDecimal(BIGINT_ZERO);


### PR DESCRIPTION
Deployments,

- lido-ethereum (graft, block: 17590000): https://okgraph.xyz/?q=QmYVWJKizmhAFf9hi3t5qD1n36fJGwpd8ng57y7Zfs1ZBi
- lido-ethereum (complete): https://okgraph.xyz/?q=QmVRX9S5VCzovKdffLdP24LxXVCPe2THF9QTauc4EDc7JB