### PR TITLE
fix (#patch) aave-v2 bug incorrect argument in handleReserveDataUpdated

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -242,7 +242,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.1.0",
-          "subgraph": "2.0.2",
+          "subgraph": "2.0.3",
           "methodology": "1.1.0"
         },
         "files": {
@@ -268,7 +268,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.1.0",
-          "subgraph": "2.0.2",
+          "subgraph": "2.0.3",
           "methodology": "1.1.0"
         },
         "files": {
@@ -294,7 +294,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.1.0",
-          "subgraph": "2.0.2",
+          "subgraph": "2.0.3",
           "methodology": "1.1.0"
         },
         "files": {

--- a/subgraphs/aave-forks/protocols/aave-v2/src/mapping.ts
+++ b/subgraphs/aave-forks/protocols/aave-v2/src/mapping.ts
@@ -216,7 +216,7 @@ export function handleReserveDataUpdated(event: ReserveDataUpdated): void {
     event,
     event.params.liquidityRate,
     event.params.liquidityIndex,
-    event.params.variableBorrowRate,
+    event.params.variableBorrowIndex,
     event.params.variableBorrowRate,
     event.params.stableBorrowRate,
     protocolData,


### PR DESCRIPTION
This PR fixes a bug for aave-v2 in handleReserveDataUpdated. When calling _handleReserveDataUpdated, the 4th argument should be `variableBorrowIndex`, but it was set to `variableBorrowRate`.