### PR TITLE
fix(#patch); gmx-forks; update subtractArrays method to handle uneven arrays

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -8380,7 +8380,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.3",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "services": {
@@ -8402,7 +8402,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.3",
-          "subgraph": "1.1.3",
+          "subgraph": "1.1.4",
           "methodology": "1.0.0"
         },
         "services": {

--- a/subgraphs/_reference_/src/sdk/util/arrays.ts
+++ b/subgraphs/_reference_/src/sdk/util/arrays.ts
@@ -72,24 +72,32 @@ export function addToArrayAtIndex<T>(x: T[], item: T, index: i32 = -1): T[] {
 
 export function addArrays<T>(a: T[], b: T[]): T[] {
   const retval = new Array<T>();
-  if (a.length == b.length) {
-    let i = 0;
-    while (i < a.length) {
-      retval.push(a[i].plus(b[i]));
-      i += 1;
-    }
+  const arraysByLength = a.length <= b.length ? [a, b] : [b, a];
+
+  let i = 0;
+  while (i < arraysByLength[0].length) {
+    retval.push(a[i].plus(b[i]));
+    i += 1;
+  }
+  while (i < arraysByLength[1].length) {
+    retval.push(arraysByLength[1][i]);
+    i += 1;
   }
   return retval;
 }
 
 export function subtractArrays<T>(a: T[], b: T[]): T[] {
   const retval = new Array<T>();
-  if (a.length == b.length) {
-    let i = 0;
-    while (i < a.length) {
-      retval.push(a[i].minus(b[i]));
-      i += 1;
-    }
+  const arraysByLength = a.length <= b.length ? [a, b] : [b, a];
+
+  let i = 0;
+  while (i < arraysByLength[0].length) {
+    retval.push(a[i].minus(b[i]));
+    i += 1;
+  }
+  while (i < arraysByLength[1].length) {
+    retval.push(arraysByLength[1][i]);
+    i += 1;
   }
   return retval;
 }

--- a/subgraphs/gmx-forks/protocols/gmx/config/deployments/gmx-arbitrum/configurations.json
+++ b/subgraphs/gmx-forks/protocols/gmx/config/deployments/gmx-arbitrum/configurations.json
@@ -29,5 +29,8 @@
       "address": "0x3963ffc9dff443c2a94f21b129d429891e32ec18",
       "startBlock": 40559781
     }
-  ]
+  ],
+  "graftEnabled": false,
+  "subgraphId": "",
+  "graftStartBlock": 0
 }

--- a/subgraphs/gmx-forks/protocols/gmx/config/deployments/gmx-avalanche/configurations.json
+++ b/subgraphs/gmx-forks/protocols/gmx/config/deployments/gmx-avalanche/configurations.json
@@ -29,5 +29,8 @@
       "address": "0xd152c7f25db7f4b95b7658323c5f33d176818ee4",
       "startBlock": 22742389
     }
-  ]
+  ],
+  "graftEnabled": false,
+  "subgraphId": "",
+  "graftStartBlock": 0
 }

--- a/subgraphs/gmx-forks/protocols/gmx/config/templates/gmx.template.yaml
+++ b/subgraphs/gmx-forks/protocols/gmx/config/templates/gmx.template.yaml
@@ -1,6 +1,13 @@
 specVersion: 0.0.5
 schema:
   file: ./schema.graphql
+{{#graftEnabled}}
+features:
+  - grafting
+graft:
+  base: {{subgraphId}} # Subgraph ID of base subgraph
+  block: {{graftStartBlock}} # Block number
+{{/graftEnabled}}
 dataSources:
   - kind: ethereum
     name: Vault

--- a/subgraphs/gmx-forks/src/sdk/protocols/perpfutures/pool.ts
+++ b/subgraphs/gmx-forks/src/sdk/protocols/perpfutures/pool.ts
@@ -10,7 +10,11 @@ import { Perpetual } from "./protocol";
 import { TokenManager } from "./tokens";
 import { PoolSnapshot } from "./poolSnapshot";
 import * as constants from "../../util/constants";
-import { exponentToBigDecimal, safeDivide } from "../../util/numbers";
+import {
+  exponentToBigDecimal,
+  poolArraySort,
+  safeDivide,
+} from "../../util/numbers";
 
 import {
   LiquidityPoolFee,
@@ -765,6 +769,20 @@ export class Pool {
     cumulativeClosedInflowVolumeByTokenUSD.push(constants.BIGDECIMAL_ZERO);
     cumulativeOutflowVolumeByTokenAmount.push(constants.BIGINT_ZERO);
     cumulativeOutflowVolumeByTokenUSD.push(constants.BIGDECIMAL_ZERO);
+
+    poolArraySort(
+      inputTokens,
+      inputTokenBalances,
+      fundingrates,
+      cumulativeVolumeByTokenAmount,
+      cumulativeVolumeByTokenUSD,
+      cumulativeInflowVolumeByTokenAmount,
+      cumulativeInflowVolumeByTokenUSD,
+      cumulativeClosedInflowVolumeByTokenAmount,
+      cumulativeClosedInflowVolumeByTokenUSD,
+      cumulativeOutflowVolumeByTokenAmount,
+      cumulativeOutflowVolumeByTokenUSD
+    );
 
     this.pool.inputTokens = inputTokens;
     this.pool.fundingrate = fundingrates;

--- a/subgraphs/gmx-forks/src/sdk/protocols/perpfutures/pool.ts
+++ b/subgraphs/gmx-forks/src/sdk/protocols/perpfutures/pool.ts
@@ -770,20 +770,6 @@ export class Pool {
     cumulativeOutflowVolumeByTokenAmount.push(constants.BIGINT_ZERO);
     cumulativeOutflowVolumeByTokenUSD.push(constants.BIGDECIMAL_ZERO);
 
-    poolArraySort(
-      inputTokens,
-      inputTokenBalances,
-      fundingrates,
-      cumulativeVolumeByTokenAmount,
-      cumulativeVolumeByTokenUSD,
-      cumulativeInflowVolumeByTokenAmount,
-      cumulativeInflowVolumeByTokenUSD,
-      cumulativeClosedInflowVolumeByTokenAmount,
-      cumulativeClosedInflowVolumeByTokenUSD,
-      cumulativeOutflowVolumeByTokenAmount,
-      cumulativeOutflowVolumeByTokenUSD
-    );
-
     this.pool.inputTokens = inputTokens;
     this.pool.fundingrate = fundingrates;
     this.pool.cumulativeVolumeByTokenAmount = cumulativeVolumeByTokenAmount;

--- a/subgraphs/gmx-forks/src/sdk/protocols/perpfutures/pool.ts
+++ b/subgraphs/gmx-forks/src/sdk/protocols/perpfutures/pool.ts
@@ -10,11 +10,7 @@ import { Perpetual } from "./protocol";
 import { TokenManager } from "./tokens";
 import { PoolSnapshot } from "./poolSnapshot";
 import * as constants from "../../util/constants";
-import {
-  exponentToBigDecimal,
-  poolArraySort,
-  safeDivide,
-} from "../../util/numbers";
+import { exponentToBigDecimal, safeDivide } from "../../util/numbers";
 
 import {
   LiquidityPoolFee,

--- a/subgraphs/gmx-forks/src/sdk/util/arrays.ts
+++ b/subgraphs/gmx-forks/src/sdk/util/arrays.ts
@@ -72,24 +72,32 @@ export function addToArrayAtIndex<T>(x: T[], item: T, index: i32 = -1): T[] {
 
 export function addArrays<T>(a: T[], b: T[]): T[] {
   const retval = new Array<T>();
-  if (a.length == b.length) {
-    let i = 0;
-    while (i < a.length) {
-      retval.push(a[i].plus(b[i]));
-      i += 1;
-    }
+  const arraysByLength = a.length <= b.length ? [a, b] : [b, a];
+
+  let i = 0;
+  while (i < arraysByLength[0].length) {
+    retval.push(a[i].plus(b[i]));
+    i += 1;
+  }
+  while (i < arraysByLength[1].length) {
+    retval.push(arraysByLength[1][i]);
+    i += 1;
   }
   return retval;
 }
 
 export function subtractArrays<T>(a: T[], b: T[]): T[] {
   const retval = new Array<T>();
-  if (a.length == b.length) {
-    let i = 0;
-    while (i < a.length) {
-      retval.push(a[i].minus(b[i]));
-      i += 1;
-    }
+  const arraysByLength = a.length <= b.length ? [a, b] : [b, a];
+
+  let i = 0;
+  while (i < arraysByLength[0].length) {
+    retval.push(a[i].minus(b[i]));
+    i += 1;
+  }
+  while (i < arraysByLength[1].length) {
+    retval.push(arraysByLength[1][i]);
+    i += 1;
   }
   return retval;
 }


### PR DESCRIPTION
Deployments,

- gmx-arbitrum-graft (graft, block: 104485000): https://okgraph.xyz/?q=dhruv-chauhan%2Fgmx-arbitrum-graft
- gmx-arbitrum (complete): https://okgraph.xyz/?q=dhruv-chauhan%2Fgmx-arbitrum

Query,

https://api.thegraph.com/subgraphs/id/QmfYbKE9pBpXii8CYemccw9XdsDc2Hd3hDiFahpB1JBiit/graphql?query=%7B%0A++liquidityPoolDailySnapshots%28%0A++++first%3A5%2C%0A++++orderBy%3Adays%2C%0A++++orderDirection%3Adesc%2C%0A++++where%3A+%7B%0A++++++days_in%3A+%5B19533%2C19534%2C19535%5D%0A++++%7D%0A++%29%7B%0A++++days%0A++++inputTokens+%7B%0A++++++id%0A++++%7D%0A++++dailyVolumeByTokenUSD%0A++%7D%0A%7D