### PR TITLE
fix(#minor); Aave Governance; Parse non-json proposal data 

### DIFF
--- a/subgraphs/aave-governance/src/handlers.ts
+++ b/subgraphs/aave-governance/src/handlers.ts
@@ -31,10 +31,13 @@ import {
   DelegateChange,
 } from "../generated/schema";
 
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
 export const SECONDS_PER_DAY = 60 * 60 * 24;
 
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
 export function toDecimal(value: BigInt, decimals: number = 18): BigDecimal {
   return value.divDecimal(
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     BigInt.fromI32(10)
       .pow(<u8>decimals)
       .toBigDecimal()

--- a/subgraphs/aave-governance/src/handlers.ts
+++ b/subgraphs/aave-governance/src/handlers.ts
@@ -272,13 +272,20 @@ export function _handleProposalCreated(
     "1220" + ipfsHash.toHexString().slice(2)
   ).toBase58();
   const data = ipfs.cat(hash);
-  const proposalData = json.try_fromBytes(data as Bytes);
-  let descriptionJSON: JSONValue | null = null;
-  if (proposalData.isOk && proposalData.value.kind == JSONValueKind.OBJECT) {
-    const jsonData = proposalData.value.toObject();
-    descriptionJSON = jsonData.get("description");
-    if (descriptionJSON) {
-      description = descriptionJSON.toString();
+  if (data) {
+    const proposalData = json.try_fromBytes(data as Bytes);
+    let descriptionJSON: JSONValue | null = null;
+    if (proposalData.isOk) {
+      // proposalData is either a JSON object or a raw string
+      if (proposalData.value.kind == JSONValueKind.OBJECT) {
+        const jsonData = proposalData.value.toObject();
+        descriptionJSON = jsonData.get("description");
+        if (descriptionJSON) {
+          description = descriptionJSON.toString();
+        }
+      }
+    } else {
+      description = data.toString();
     }
   }
   proposal.description = description;


### PR DESCRIPTION
### Description

More Aave proposal data from ipfs are no longer consistently json, but a mix of json and markdown (string). Currently if the retrieved data isnt json we leave it blank. This changes falls back to saving it as a string.


<img width="600" alt="image" src="https://github.com/messari/subgraphs/assets/4507317/87920600-1b35-4036-8fff-78e76eb6f737">
