### PR TITLE
chore(); rpl; remove transaction tag

### DIFF
--- a/subgraphs/rocket-pool/schema.graphql
+++ b/subgraphs/rocket-pool/schema.graphql
@@ -702,7 +702,7 @@ enum NodeRPLStakeTransactionType {
 }
 
 # Keeps track of the RPL staking transactions for a node.
-type NodeRPLStakeTransaction @entity @transaction {
+type NodeRPLStakeTransaction @entity {
   # Composite key based on transaction hash of the triggered event and its log index.
   id: ID!
 


### PR DESCRIPTION
This entitiy should not have the `@transaction` tag bc it does not have a timestamp entity.

Alt: We can update `blockTime` to `timestamp` and fix the ingestion that way instead.