### PR TITLE
fix(#patch); level-finance; remove unnecessary getOrCreatePool call

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -9080,7 +9080,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.1",
-          "subgraph": "1.0.0",
+          "subgraph": "1.0.1",
           "methodology": "1.0.0"
         },
         "services": {
@@ -9102,7 +9102,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.1",
-          "subgraph": "1.0.0",
+          "subgraph": "1.0.1",
           "methodology": "1.0.0"
         },
         "services": {

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/poolSnapshot.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/poolSnapshot.ts
@@ -39,7 +39,13 @@ export class PoolSnapshot {
   }
 
   private takeSnapshots(): void {
-    if (!this.isInitialized()) return;
+    if (!this.isInitialized()) {
+      log.error(
+        "[isInitialized] cannot create snapshots, pool: {} not initialized",
+        [this.pool.id.toHexString()]
+      );
+      return
+    };
 
     const snapshotDayID =
       this.pool._lastUpdateTimestamp!.toI32() / constants.SECONDS_PER_DAY;
@@ -60,11 +66,6 @@ export class PoolSnapshot {
   }
 
   private isInitialized(): boolean {
-    log.error(
-      "[isInitialized] cannot create snapshots, pool: {} not initialized",
-      [this.pool.id.toHexString()]
-    );
-
     return this.pool._lastSnapshotDayID &&
       this.pool._lastSnapshotHourID &&
       this.pool._lastUpdateTimestamp

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/poolSnapshot.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/poolSnapshot.ts
@@ -44,8 +44,8 @@ export class PoolSnapshot {
         "[isInitialized] cannot create snapshots, pool: {} not initialized",
         [this.pool.id.toHexString()]
       );
-      return
-    };
+      return;
+    }
 
     const snapshotDayID =
       this.pool._lastUpdateTimestamp!.toI32() / constants.SECONDS_PER_DAY;

--- a/subgraphs/level-finance/src/common/initializers.ts
+++ b/subgraphs/level-finance/src/common/initializers.ts
@@ -91,9 +91,8 @@ export function createMasterChefStakingPool(
   masterChefPool.multiplier = constants.BIGINT_ONE;
   masterChefPool.poolAllocPoint = constants.BIGINT_ZERO;
   masterChefPool.lastRewardBlock = event.block.number;
-  const sdk = initializeSDK(event);
-  getOrCreatePool(sdk);
 
+  const sdk = initializeSDK(event);
   const rewardToken = sdk.Tokens.getOrCreateToken(
     constants.LEVEL_TOKEN_ADDRESS
   );

--- a/subgraphs/level-finance/src/sdk/protocols/perpfutures/poolSnapshot.ts
+++ b/subgraphs/level-finance/src/sdk/protocols/perpfutures/poolSnapshot.ts
@@ -39,7 +39,13 @@ export class PoolSnapshot {
   }
 
   private takeSnapshots(): void {
-    if (!this.isInitialized()) return;
+    if (!this.isInitialized()) {
+      log.error(
+        "[isInitialized] cannot create snapshots, pool: {} not initialized",
+        [this.pool.id.toHexString()]
+      );
+      return;
+    }
 
     const snapshotDayID =
       this.pool._lastUpdateTimestamp!.toI32() / constants.SECONDS_PER_DAY;
@@ -60,11 +66,6 @@ export class PoolSnapshot {
   }
 
   private isInitialized(): boolean {
-    log.error(
-      "[isInitialized] cannot create snapshots, pool: {} not initialized",
-      [this.pool.id.toHexString()]
-    );
-
     return this.pool._lastSnapshotDayID &&
       this.pool._lastSnapshotHourID &&
       this.pool._lastUpdateTimestamp


### PR DESCRIPTION
- Error: Trying to overwrite immutable `LiquidityPoolHourlySnapshot` due to duplicate ids
- Cause: 
  - `PoolHourlySnapshot`'s id is created using `pool._lastUpdateTimestamp`, which is internally updated everytime there is an update on pool entity's fields
  - In the current implementation, `getOrCreatePool` is called inside handler `handleLogPoolAddition`, but no field of the pool is updated. This creates a `LiquidityPoolHourlySnapshot` object, but does not update `pool._lastUpdateTimestamp`, which causes indexer to fail in the following iteration.
- Fix: This unnecessary `getOrCreatePool` call can be removed with no impact
- Deployments:
  - https://okgraph.xyz/?q=dhruv-chauhan%2Flevel-finance-bsc
  - https://okgraph.xyz/?q=dhruv-chauhan%2Flevel-finance-arbitrum