### PR TITLE
fix(#patch); pricelib; fix UniswapForksRouter.getLpTokenLiquidityUsdc decimals; add DPR override

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2596,7 +2596,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.4.0",
-          "subgraph": "1.0.6",
+          "subgraph": "1.0.7",
           "methodology": "1.0.0"
         },
         "files": {
@@ -8142,7 +8142,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.2",
           "methodology": "1.0.0"
         },
         "services": {
@@ -8163,7 +8163,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.2",
           "methodology": "1.0.0"
         },
         "services": {

--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1330,7 +1330,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.2",
           "methodology": "1.0.0"
         },
         "files": {
@@ -1352,7 +1352,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.2.0",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.2",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/_reference_/src/prices/common/constants.ts
+++ b/subgraphs/_reference_/src/prices/common/constants.ts
@@ -23,7 +23,7 @@ export const CHAIN_LINK_USD_ADDRESS = Address.fromString(
   "0x0000000000000000000000000000000000000348"
 );
 
-export const PRICE_LIB_VERSION = "1.3.1";
+export const PRICE_LIB_VERSION = "1.3.2";
 
 export const INT_ZERO = 0 as i32;
 export const INT_ONE = 1 as i32;

--- a/subgraphs/_reference_/src/prices/common/utils.ts
+++ b/subgraphs/_reference_/src/prices/common/utils.ts
@@ -29,6 +29,15 @@ export function isNullAddress(tokenAddr: Address): boolean {
   return tokenAddr.equals(constants.NULL.TYPE_ADDRESS);
 }
 
+export function bigIntToBigDecimal(
+  quantity: BigInt,
+  decimals: i32 = constants.DEFAULT_DECIMALS.toI32()
+): BigDecimal {
+  return quantity.divDecimal(
+    constants.BIGINT_TEN.pow(decimals as u8).toBigDecimal()
+  );
+}
+
 export function readValue<T>(
   callResult: ethereum.CallResult<T>,
   defaultValue: T

--- a/subgraphs/_reference_/src/prices/config/mainnet.ts
+++ b/subgraphs/_reference_/src/prices/config/mainnet.ts
@@ -102,7 +102,7 @@ export const HARDCODED_STABLES: Address[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 // https://github.com/messari/subgraphs/issues/2090
-class spellOverride implements OracleConfig {
+class SpellOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -119,7 +119,7 @@ class spellOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/726
-class stETHOverride implements OracleConfig {
+class StETHOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -136,7 +136,7 @@ class stETHOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/2097
-class baxaOverride implements OracleConfig {
+class BaxaOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -153,7 +153,7 @@ class baxaOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/2329
-class delperOverride implements OracleConfig {
+class DelperOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -257,7 +257,7 @@ export class config implements Configurations {
           Address.fromString("0x090185f2135308bad17527004364ebcc2d37e5f6"), // SPELL
         ].includes(tokenAddr)
       ) {
-        return new spellOverride();
+        return new SpellOverride();
       }
       if (
         tokenAddr &&
@@ -268,7 +268,7 @@ export class config implements Configurations {
         block.number.gt(BigInt.fromString("14019699")) &&
         block.number.lt(BigInt.fromString("14941265"))
       ) {
-        return new stETHOverride();
+        return new StETHOverride();
       }
       if (
         tokenAddr &&
@@ -276,7 +276,7 @@ export class config implements Configurations {
           Address.fromString("0x91b08f4a7c1251dfccf5440f8894f8daa10c8de5"), // BAXA
         ].includes(tokenAddr)
       ) {
-        return new baxaOverride();
+        return new BaxaOverride();
       }
       if (
         tokenAddr &&
@@ -284,7 +284,7 @@ export class config implements Configurations {
           Address.fromString("0x077416cc6242b3a7d8e42652b8a6a2599fda4a92"), // DPR
         ].includes(tokenAddr)
       ) {
-        return new delperOverride();
+        return new DelperOverride();
       }
     }
 

--- a/subgraphs/_reference_/src/prices/config/mainnet.ts
+++ b/subgraphs/_reference_/src/prices/config/mainnet.ts
@@ -152,6 +152,23 @@ class baxaOverride implements OracleConfig {
   }
 }
 
+// https://github.com/messari/subgraphs/issues/2329
+class delperOverride implements OracleConfig {
+  oracleCount(): number {
+    return constants.INT_ONE;
+  }
+  oracleOrder(): string[] {
+    return [
+      constants.OracleType.UNISWAP_FORKS_ROUTER,
+      constants.OracleType.YEARN_LENS_ORACLE,
+      constants.OracleType.CHAINLINK_FEED,
+      constants.OracleType.CURVE_CALCULATIONS,
+      constants.OracleType.CURVE_ROUTER,
+      constants.OracleType.SUSHI_CALCULATIONS,
+    ];
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 ///////////////////////////////// HELPERS /////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////
@@ -260,6 +277,14 @@ export class config implements Configurations {
         ].includes(tokenAddr)
       ) {
         return new baxaOverride();
+      }
+      if (
+        tokenAddr &&
+        [
+          Address.fromString("0x077416cc6242b3a7d8e42652b8a6a2599fda4a92"), // DPR
+        ].includes(tokenAddr)
+      ) {
+        return new delperOverride();
       }
     }
 

--- a/subgraphs/_reference_/src/prices/config/template.ts
+++ b/subgraphs/_reference_/src/prices/config/template.ts
@@ -46,7 +46,7 @@ export const HARDCODED_STABLES: Address[] = [];
 ///////////////////////// ORACLE CONFIG OVERRIDES /////////////////////////
 ///////////////////////////////////////////////////////////////////////////
 
-class someOverride implements OracleConfig {
+class SomeOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -137,6 +137,6 @@ export class config implements Configurations {
     tokenAddr: Address | null,
     block: ethereum.Block | null
   ): OracleConfig | null {
-    return new someOverride();
+    return new SomeOverride();
   }
 }

--- a/subgraphs/_reference_/src/prices/index.ts
+++ b/subgraphs/_reference_/src/prices/index.ts
@@ -116,13 +116,13 @@ export function getLiquidityBoundPrice(
       .div(amount);
 
     log.warning(
-      "[getLiquidityBoundPrice] reported (token price * amount): ({} * {}) bound to: {} for token: {} due to insufficient liquidity: {}",
+      "[getLiquidityBoundPrice] token: {} (reported price * amount): ({} * {}) bound to available liquidity: {}; new price: {}",
       [
+        tokenAddress.toHexString(),
         tokenPrice.usdPrice.toString(),
         amount.toString(),
-        liquidityBoundPriceUSD.toString(),
-        tokenAddress.toHexString(),
         liquidity.toString(),
+        liquidityBoundPriceUSD.toString(),
       ]
     );
   }

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/README.md
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/README.md
@@ -1,4 +1,4 @@
-# Bridge SDK
+# Bridge SDK `1.0.1`
 
 ## Setup
 

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/account.ts
@@ -16,6 +16,19 @@ import { BridgePoolType, TransactionType, TransferType } from "./enums";
 import { getUnixDays, getUnixHours } from "../../util/events";
 import { CustomEventType } from "../../util/events";
 
+/**
+ * This file contains the AccountClass, which does
+ * the operations on the Account entity. This includes:
+ *  - Creating a new Account
+ *  - Updating an existing Account
+ *
+ * Schema Version:  1.2.0
+ * SDK Version:     1.0.1
+ * Author(s):
+ *  - @jaimehgb
+ *  - @dhruv-chauhan
+ */
+
 export class AccountManager {
   protocol: Bridge;
   tokens: TokenManager;

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/chainIds.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/chainIds.ts
@@ -2,6 +2,16 @@
 import { BigInt, TypedMap } from "@graphprotocol/graph-ts";
 import { Network } from "../../util/constants";
 
+/**
+ * This file contains the network to chainId mapping
+ *
+ * Schema Version:  1.2.0
+ * SDK Version:     1.0.1
+ * Author(s):
+ *  - @jaimehgb
+ *  - @dhruv-chauhan
+ */
+
 export function chainIDToNetwork(chainID: BigInt): Network {
   const network = chainIDs.get(chainID.toU64());
   if (network) {
@@ -100,3 +110,4 @@ setChainID(1313161554, Network.AURORA);
 setChainID(1666600000, Network.HARMONY);
 setChainID(11297108109, Network.PALM);
 setChainID(836542336838601, Network.CURIO);
+setChainID(8453, Network.BASE);

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/pool.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/pool.ts
@@ -23,7 +23,6 @@ import {
   BIGINT_ZERO,
   RewardTokenType,
 } from "../../util/constants";
-import { bigIntToBigDecimal } from "../../util/numbers";
 import {
   sortArrayByReference,
   sortBytesArray,

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/poolSnapshot.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/poolSnapshot.ts
@@ -9,6 +9,17 @@ import {
 } from "../../../../generated/schema";
 import { SECONDS_PER_DAY_BI, SECONDS_PER_HOUR_BI } from "../../util/constants";
 
+/**
+ * This file contains the PoolSnapshot, which is used to
+ * make all of the storage changes that occur in the pool daily and hourly snapshots.
+ *
+ * Schema Version:  1.2.0
+ * SDK Version:     1.0.1
+ * Author(s):
+ *  - @jaimehgb
+ *  - @dhruv-chauhan
+ */
+
 export class PoolSnapshot {
   pool: PoolSchema;
   event: CustomEventType;

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/protocol.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/protocol.ts
@@ -19,6 +19,17 @@ import { SDK } from ".";
 import { CustomEventType } from "../../util/events";
 
 /**
+ * This file contains the Bridge class, which is used to
+ * make all of the storage changes that occur in a protocol.
+ *
+ * Schema Version:  1.2.0
+ * SDK Version:     1.0.1
+ * Author(s):
+ *  - @jaimehgb
+ *  - @dhruv-chauhan
+ */
+
+/**
  * Bridge is a wrapper around the BridgeProtocolSchema entity that takes care of
  * safely and conveniently updating the entity. Updating the Bridge entity using this
  * wrapper also takes care of the Financials and Usage snapshots.

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/protocolSnapshot.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/protocolSnapshot.ts
@@ -15,6 +15,18 @@ import {
 } from "../../util/constants";
 import { CustomEventType } from "../../util/events";
 
+/**
+ * This file contains the ProtocolSnapshot, which is used to
+ * make all of the storage changes that occur in the protocol's
+ * daily and hourly snapshots.
+ *
+ * Schema Version:  1.2.0
+ * SDK Version:     1.0.1
+ * Author(s):
+ *  - @jaimehgb
+ *  - @dhruv-chauhan
+ */
+
 const SnapshotHelperID = Bytes.fromUTF8("_ProtocolSnapshotHelper");
 const ActivityHelperID = Bytes.fromUTF8("_ActivityHelper");
 

--- a/subgraphs/_reference_/src/sdk/protocols/generic/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/generic/account.ts
@@ -14,7 +14,7 @@ import { CustomEventType, getUnixDays, getUnixHours } from "../../util/events";
  *  - Updating an existing Account
  *
  * Schema Version:  2.1.1
- * SDK Version:     1.0.0
+ * SDK Version:     1.0.1
  * Author(s):
  *  - @steegecs
  *  - @shashwatS22

--- a/subgraphs/_reference_/src/sdk/protocols/generic/index.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/generic/index.ts
@@ -11,7 +11,7 @@ import { ProtocolConfigurer, TokenPricer } from "../config";
  * This file contains the SDK class, which initializes
  * all managers from event or call.
  * Schema Version:  2.1.1
- * SDK Version:     1.0.0
+ * SDK Version:     1.0.1
  * Author(s):
  *  - @steegecs
  *  - @shashwatS22

--- a/subgraphs/_reference_/src/sdk/protocols/generic/pool.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/generic/pool.ts
@@ -11,7 +11,6 @@ import {
 import { TokenManager } from "./tokens";
 import { ProtocolManager } from "./protocol";
 import { PoolSnapshot } from "./poolSnapshot";
-import { exponentToBigDecimal } from "../../util/numbers";
 import { Pool as PoolSchema, Token } from "../../../../generated/schema";
 import { Bytes, BigDecimal, BigInt, Address } from "@graphprotocol/graph-ts";
 

--- a/subgraphs/_reference_/src/sdk/protocols/generic/poolSnapshot.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/generic/poolSnapshot.ts
@@ -11,7 +11,7 @@ import { CustomEventType, getUnixDays, getUnixHours } from "../../util/events";
  * make all of the storage changes that occur in the pool daily and hourly snapshots.
  *
  * Schema Version:  2.1.1
- * SDK Version:     1.0.0
+ * SDK Version:     1.0.1
  * Author(s):
  *  - @steegecs
  *  - @shashwatS22

--- a/subgraphs/_reference_/src/sdk/protocols/generic/protocol.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/generic/protocol.ts
@@ -19,7 +19,7 @@ import { Versions } from "../../../../../../deployment/context/interface";
  * make all of the storage changes that occur in a protocol.
  *
  * Schema Version:  2.1.1
- * SDK Version:     1.0.0
+ * SDK Version:     1.0.1
  * Author(s):
  *  - @steegecs
  *  - @shashwatS22

--- a/subgraphs/_reference_/src/sdk/protocols/generic/protocolSnapshot.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/generic/protocolSnapshot.ts
@@ -18,7 +18,7 @@ const ActivityHelperID = Bytes.fromUTF8("_ActivityHelper");
  * daily and hourly snapshots.
  *
  * Schema Version:  2.1.1
- * SDK Version:     1.0.0
+ * SDK Version:     1.0.1
  * Author(s):
  *  - @steegecs
  *  - @shashwatS22

--- a/subgraphs/_reference_/src/sdk/protocols/generic/tokens.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/generic/tokens.ts
@@ -7,7 +7,7 @@ import { BIGDECIMAL_ZERO, RewardTokenType } from "../../util/constants";
  * This file contains the TokenManagerClass, which initializes
  * token entities.
  * Schema Version:  2.1.1
- * SDK Version:     1.0.0
+ * SDK Version:     1.0.1
  * Author(s):
  *  - @steegecs
  *  - @shashwatS22

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/README.md
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/README.md
@@ -1,4 +1,4 @@
-# Perpetual SDK `1.1.6`
+# Perpetual SDK `1.1.7`
 
 The perpetual SDK follows the `1.3.3` Derivatives Perpetual Futures schema.
 

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/account.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/account.ts
@@ -34,7 +34,7 @@ import {
  *  - Making position snapshots
  *
  * Schema Version:  1.3.3
- * SDK Version:     1.1.6
+ * SDK Version:     1.1.7
  * Author(s):
  *  - @harsh9200
  *  - @dhruv-chauhan

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/pool.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/pool.ts
@@ -10,7 +10,6 @@ import { Perpetual } from "./protocol";
 import { TokenManager } from "./tokens";
 import { PoolSnapshot } from "./poolSnapshot";
 import * as constants from "../../util/constants";
-import { exponentToBigDecimal } from "../../util/numbers";
 
 import {
   LiquidityPoolFee,

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/pool.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/pool.ts
@@ -23,7 +23,7 @@ import {
  * initialize new pools in the protocol.
  *
  * Schema Version:  1.3.3
- * SDK Version:     1.1.6
+ * SDK Version:     1.1.7
  * Author(s):
  *  - @harsh9200
  *  - @dhruv-chauhan
@@ -590,17 +590,35 @@ export class Pool {
   }
 
   /**
+   * Utility function to update token price.
+   *
+   * @param token
+   * @returns
+   */
+  setTokenPrice(token: TokenSchema): void {
+    if (
+      !token.lastPriceBlockNumber ||
+      (token.lastPriceBlockNumber &&
+        token.lastPriceBlockNumber! < this.protocol.event.block.number)
+    ) {
+      const pricePerToken = this.protocol.getTokenPricer().getTokenPrice(token);
+      token.lastPriceUSD = pricePerToken;
+      token.lastPriceBlockNumber = this.protocol.event.block.number;
+      token.save();
+    }
+  }
+
+  /**
    * Utility function to convert some amount of input token to USD.
    *
-   * @param amount the amount of inputTokens to convert to USD
+   * @param token
+   * @param amount the amount of inputToken to convert to USD
    * @returns The converted amount.
    */
   getInputTokenAmountPrice(token: TokenSchema, amount: BigInt): BigDecimal {
-    const price = this.protocol.getTokenPricer().getTokenPrice(token);
-    token.lastPriceUSD = price;
-    token.save();
+    this.setTokenPrice(token);
 
-    return amount.divDecimal(exponentToBigDecimal(token.decimals)).times(price);
+    return this.protocol.getTokenPricer().getAmountValueUSD(token, amount);
   }
 
   /**

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/poolSnapshot.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/poolSnapshot.ts
@@ -16,7 +16,7 @@ import {
  * make all of the storage changes that occur in the pool daily and hourly snapshots.
  *
  * Schema Version:  1.3.3
- * SDK Version:     1.1.6
+ * SDK Version:     1.1.7
  * Author(s):
  *  - @harsh9200
  *  - @dhruv-chauhan

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/position.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/position.ts
@@ -20,7 +20,7 @@ import {
  * its corresponding snapshots.
  *
  * Schema Version:  1.3.3
- * SDK Version:     1.1.6
+ * SDK Version:     1.1.7
  * Author(s):
  *  - @harsh9200
  *  - @dhruv-chauhan

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/protocol.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/protocol.ts
@@ -20,7 +20,7 @@ import { DerivPerpProtocol as PerpetualSchema } from "../../../../generated/sche
  * make all of the storage changes that occur in a protocol.
  *
  * Schema Version:  1.3.3
- * SDK Version:     1.1.6
+ * SDK Version:     1.1.7
  * Author(s):
  *  - @harsh9200
  *  - @dhruv-chauhan

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/protocolSnapshot.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/protocolSnapshot.ts
@@ -19,7 +19,7 @@ import {
  * daily and hourly snapshots.
  *
  * Schema Version:  1.3.3
- * SDK Version:     1.1.6
+ * SDK Version:     1.1.7
  * Author(s):
  *  - @harsh9200
  *  - @dhruv-chauhan

--- a/subgraphs/_reference_/src/sdk/protocols/perpfutures/tokens.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/perpfutures/tokens.ts
@@ -11,7 +11,7 @@ import { Token, RewardToken } from "../../../../generated/schema";
  * use in mappings and get info about the token.
  *
  * Schema Version:  1.3.3
- * SDK Version:     1.1.6
+ * SDK Version:     1.1.7
  * Author(s):
  *  - @harsh9200
  *  - @dhruv-chauhan

--- a/subgraphs/arbitrum-one-bridge/src/common/utils.ts
+++ b/subgraphs/arbitrum-one-bridge/src/common/utils.ts
@@ -1,7 +1,7 @@
 import { Token } from "../../generated/schema";
 import { bigIntToBigDecimal } from "../sdk/util/numbers";
 import { TokenPricer } from "../sdk/protocols/config";
-import { getUsdPrice, getUsdPricePerToken } from "../prices";
+import { getUsdPrice } from "../prices";
 import { TokenInitializer, TokenParams } from "../sdk/protocols/bridge/tokens";
 import {
   Address,
@@ -18,6 +18,7 @@ import {
 import { BridgeConfig } from "../sdk/protocols/bridge/config";
 import { Versions } from "../versions";
 import {
+  BIGDECIMAL_ONE,
   ETH_ADDRESS,
   ETH_NAME,
   ETH_SYMBOL,
@@ -37,8 +38,7 @@ export class Pricer implements TokenPricer {
       return BIGDECIMAL_ZERO;
     }
 
-    const price = getUsdPricePerToken(Address.fromBytes(token.id), this.block);
-    return price.usdPrice;
+    return getUsdPrice(Address.fromBytes(token.id), BIGDECIMAL_ONE, this.block);
   }
 
   getAmountValueUSD(token: Token, amount: BigInt): BigDecimal {

--- a/subgraphs/arbitrum-one-bridge/src/prices/common/constants.ts
+++ b/subgraphs/arbitrum-one-bridge/src/prices/common/constants.ts
@@ -23,7 +23,7 @@ export const CHAIN_LINK_USD_ADDRESS = Address.fromString(
   "0x0000000000000000000000000000000000000348"
 );
 
-export const PRICE_LIB_VERSION = "1.3.1";
+export const PRICE_LIB_VERSION = "1.3.2";
 
 export const INT_ZERO = 0 as i32;
 export const INT_ONE = 1 as i32;

--- a/subgraphs/arbitrum-one-bridge/src/prices/common/utils.ts
+++ b/subgraphs/arbitrum-one-bridge/src/prices/common/utils.ts
@@ -29,6 +29,15 @@ export function isNullAddress(tokenAddr: Address): boolean {
   return tokenAddr.equals(constants.NULL.TYPE_ADDRESS);
 }
 
+export function bigIntToBigDecimal(
+  quantity: BigInt,
+  decimals: i32 = constants.DEFAULT_DECIMALS.toI32()
+): BigDecimal {
+  return quantity.divDecimal(
+    constants.BIGINT_TEN.pow(decimals as u8).toBigDecimal()
+  );
+}
+
 export function readValue<T>(
   callResult: ethereum.CallResult<T>,
   defaultValue: T

--- a/subgraphs/arbitrum-one-bridge/src/prices/config/mainnet.ts
+++ b/subgraphs/arbitrum-one-bridge/src/prices/config/mainnet.ts
@@ -102,7 +102,7 @@ export const HARDCODED_STABLES: Address[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 // https://github.com/messari/subgraphs/issues/2090
-class spellOverride implements OracleConfig {
+class SpellOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -119,7 +119,7 @@ class spellOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/726
-class stETHOverride implements OracleConfig {
+class StETHOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -136,7 +136,7 @@ class stETHOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/2097
-class baxaOverride implements OracleConfig {
+class BaxaOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -153,7 +153,7 @@ class baxaOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/2329
-class delperOverride implements OracleConfig {
+class DelperOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -257,7 +257,7 @@ export class config implements Configurations {
           Address.fromString("0x090185f2135308bad17527004364ebcc2d37e5f6"), // SPELL
         ].includes(tokenAddr)
       ) {
-        return new spellOverride();
+        return new SpellOverride();
       }
       if (
         tokenAddr &&
@@ -268,7 +268,7 @@ export class config implements Configurations {
         block.number.gt(BigInt.fromString("14019699")) &&
         block.number.lt(BigInt.fromString("14941265"))
       ) {
-        return new stETHOverride();
+        return new StETHOverride();
       }
       if (
         tokenAddr &&
@@ -276,7 +276,7 @@ export class config implements Configurations {
           Address.fromString("0x91b08f4a7c1251dfccf5440f8894f8daa10c8de5"), // BAXA
         ].includes(tokenAddr)
       ) {
-        return new baxaOverride();
+        return new BaxaOverride();
       }
       if (
         tokenAddr &&
@@ -284,7 +284,7 @@ export class config implements Configurations {
           Address.fromString("0x077416cc6242b3a7d8e42652b8a6a2599fda4a92"), // DPR
         ].includes(tokenAddr)
       ) {
-        return new delperOverride();
+        return new DelperOverride();
       }
     }
 

--- a/subgraphs/arbitrum-one-bridge/src/prices/config/mainnet.ts
+++ b/subgraphs/arbitrum-one-bridge/src/prices/config/mainnet.ts
@@ -152,6 +152,23 @@ class baxaOverride implements OracleConfig {
   }
 }
 
+// https://github.com/messari/subgraphs/issues/2329
+class delperOverride implements OracleConfig {
+  oracleCount(): number {
+    return constants.INT_ONE;
+  }
+  oracleOrder(): string[] {
+    return [
+      constants.OracleType.UNISWAP_FORKS_ROUTER,
+      constants.OracleType.YEARN_LENS_ORACLE,
+      constants.OracleType.CHAINLINK_FEED,
+      constants.OracleType.CURVE_CALCULATIONS,
+      constants.OracleType.CURVE_ROUTER,
+      constants.OracleType.SUSHI_CALCULATIONS,
+    ];
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 ///////////////////////////////// HELPERS /////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////
@@ -260,6 +277,14 @@ export class config implements Configurations {
         ].includes(tokenAddr)
       ) {
         return new baxaOverride();
+      }
+      if (
+        tokenAddr &&
+        [
+          Address.fromString("0x077416cc6242b3a7d8e42652b8a6a2599fda4a92"), // DPR
+        ].includes(tokenAddr)
+      ) {
+        return new delperOverride();
       }
     }
 

--- a/subgraphs/arbitrum-one-bridge/src/prices/config/template.ts
+++ b/subgraphs/arbitrum-one-bridge/src/prices/config/template.ts
@@ -46,7 +46,7 @@ export const HARDCODED_STABLES: Address[] = [];
 ///////////////////////// ORACLE CONFIG OVERRIDES /////////////////////////
 ///////////////////////////////////////////////////////////////////////////
 
-class someOverride implements OracleConfig {
+class SomeOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -137,6 +137,6 @@ export class config implements Configurations {
     tokenAddr: Address | null,
     block: ethereum.Block | null
   ): OracleConfig | null {
-    return new someOverride();
+    return new SomeOverride();
   }
 }

--- a/subgraphs/arbitrum-one-bridge/src/prices/index.ts
+++ b/subgraphs/arbitrum-one-bridge/src/prices/index.ts
@@ -117,13 +117,13 @@ export function getLiquidityBoundPrice(
       .div(amount);
 
     log.warning(
-      "[getLiquidityBoundPrice] reported (token price * amount): ({} * {}) bound to: {} for token: {} due to insufficient liquidity: {}",
+      "[getLiquidityBoundPrice] token: {} (reported price * amount): ({} * {}) bound to available liquidity: {}; new price: {}",
       [
+        tokenAddress.toHexString(),
         tokenPrice.usdPrice.toString(),
         amount.toString(),
-        liquidityBoundPriceUSD.toString(),
-        tokenAddress.toHexString(),
         liquidity.toString(),
+        liquidityBoundPriceUSD.toString(),
       ]
     );
   }

--- a/subgraphs/arbitrum-one-bridge/src/sdk/protocols/bridge/pool.ts
+++ b/subgraphs/arbitrum-one-bridge/src/sdk/protocols/bridge/pool.ts
@@ -336,6 +336,25 @@ export class Pool {
   }
 
   /**
+   * Utility function to update token price.
+   *
+   * @param token
+   * @returns
+   */
+  setTokenPrice(token: Token): void {
+    if (
+      !token.lastPriceBlockNumber ||
+      (token.lastPriceBlockNumber &&
+        token.lastPriceBlockNumber! < this.protocol.event.block.number)
+    ) {
+      const pricePerToken = this.protocol.getTokenPricer().getTokenPrice(token);
+      token.lastPriceUSD = pricePerToken;
+      token.lastPriceBlockNumber = this.protocol.event.block.number;
+      token.save();
+    }
+  }
+
+  /**
    * Utility function to convert some amount of input token to USD.
    *
    * @param amount the amount of inputToken to convert to USD
@@ -343,11 +362,9 @@ export class Pool {
    */
   getInputTokenAmountPrice(amount: BigInt): BigDecimal {
     const token = this.getInputToken();
-    const price = this.protocol.getTokenPricer().getTokenPrice(token);
-    token.lastPriceUSD = price;
-    token.save();
+    this.setTokenPrice(token);
 
-    return bigIntToBigDecimal(amount, token.decimals).times(price);
+    return this.protocol.getTokenPricer().getAmountValueUSD(token, amount);
   }
 
   /**

--- a/subgraphs/arbitrum-one-bridge/src/sdk/protocols/bridge/pool.ts
+++ b/subgraphs/arbitrum-one-bridge/src/sdk/protocols/bridge/pool.ts
@@ -23,7 +23,6 @@ import {
   BIGINT_ZERO,
   RewardTokenType,
 } from "../../util/constants";
-import { bigIntToBigDecimal } from "../../util/numbers";
 import {
   sortArrayByReference,
   sortBytesArray,

--- a/subgraphs/lido/package-lock.json
+++ b/subgraphs/lido/package-lock.json
@@ -7,37 +7,102 @@
       "name": "lido",
       "license": "MIT",
       "dependencies": {
-        "@graphprotocol/graph-cli": "0.42.4",
-        "@graphprotocol/graph-ts": "0.29.3",
-        "prettier": "^2.7.1"
+        "@graphprotocol/graph-cli": "^0.56.0",
+        "@graphprotocol/graph-ts": "^0.31.0",
+        "prettier": "^3.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
+      "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.22.10",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-      "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
+      "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.5",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -81,6 +146,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -100,15 +173,15 @@
         "node": ">=4"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
-      "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=12"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -523,39 +596,39 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli": {
-      "version": "0.42.4",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.42.4.tgz",
-      "integrity": "sha512-h6/OkmLSPqP8cji6AMXtq7AWHtgl4nC8wjunHhDBlQiLzdClky3jFe50/xAM9VBs2QV+oXhCflRq26qqO3XBXA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.56.0.tgz",
+      "integrity": "sha512-bOVtYLDLJpyqjPv9RX8DwRFePOiIlzWZhQGuznb6lY7Uk+uvjc0JSBsgPOAWjwkAI+3U1Ux7GPVwgYSLIOBXoQ==",
       "dependencies": {
         "@float-capital/float-subgraph-uncrashable": "^0.0.0-alpha.4",
-        "@oclif/core": "2.0.7",
+        "@oclif/core": "2.8.6",
+        "@whatwg-node/fetch": "^0.8.4",
         "assemblyscript": "0.19.23",
         "binary-install-raw": "0.0.13",
         "chalk": "3.0.0",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
-        "docker-compose": "0.23.4",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "docker-compose": "0.23.19",
         "dockerode": "2.5.8",
-        "fs-extra": "9.0.0",
-        "glob": "7.1.6",
-        "gluegun": "git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep",
+        "fs-extra": "9.1.0",
+        "glob": "9.3.5",
+        "gluegun": "5.1.2",
         "graphql": "15.5.0",
         "immutable": "4.2.1",
-        "ipfs-http-client": "34.0.0",
-        "jayson": "3.6.6",
-        "js-yaml": "3.13.1",
-        "node-fetch": "2.6.0",
+        "ipfs-http-client": "55.0.0",
+        "jayson": "4.0.0",
+        "js-yaml": "3.14.1",
         "prettier": "1.19.1",
         "request": "2.88.2",
-        "semver": "7.3.5",
+        "semver": "7.4.0",
         "sync-request": "6.1.0",
-        "tmp-promise": "3.0.2",
+        "tmp-promise": "3.0.3",
         "web3-eth-abi": "1.7.0",
         "which": "2.0.2",
-        "yaml": "1.9.2"
+        "yaml": "1.10.2"
       },
       "bin": {
-        "graph": "dist/bin.js"
+        "graph": "bin/run"
       },
       "engines": {
         "node": ">=14"
@@ -587,20 +660,29 @@
         "wasm-opt": "bin/wasm-opt"
       }
     },
-    "node_modules/@graphprotocol/graph-cli/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+    "node_modules/@graphprotocol/graph-cli/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
-        "ms": "2.1.2"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@graphprotocol/graph-cli/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=16 || 14 >=14.17"
       },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/long": {
@@ -608,10 +690,27 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
       "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
-    "node_modules/@graphprotocol/graph-cli/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    "node_modules/@graphprotocol/graph-cli/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@graphprotocol/graph-cli/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/prettier": {
       "version": "1.19.1",
@@ -625,11 +724,59 @@
       }
     },
     "node_modules/@graphprotocol/graph-ts": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.29.3.tgz",
-      "integrity": "sha512-FXBLGlunOSwjiUXYEz1J9J/I2D/myldyib/9v0R+gn/NJaYqUkXD39UmIuRxqj9cBzB/FYojHzoHidIG5nYZDw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.31.0.tgz",
+      "integrity": "sha512-xreRVM6ho2BtolyOh2flDkNoGZximybnzUnF53zJVp0+Ed0KnAlO1/KOCUYw06euVI9tk0c9nA2Z/D5SIQV2Rg==",
       "dependencies": {
         "assemblyscript": "0.19.10"
+      }
+    },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "dependencies": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@ipld/dag-json": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
+      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
+      "dependencies": {
+        "cborg": "^1.5.4",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@ipld/dag-pb": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "dependencies": {
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -665,9 +812,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.7.tgz",
-      "integrity": "sha512-pj7hIH8SBeH3qha47fmyqdaBdNVEqesRgnKFh8Ytdb4S41/4BYOiQuyQGuvnKgvicH6DMxp4FbM9EQEW46V9xw==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.6.tgz",
+      "integrity": "sha512-1QlPaHMhOORySCXkQyzjsIsy2GYTilOw3LkjeHkCgsPJQjAT4IclVytJusWktPbYNys9O+O4V23J44yomQvnBQ==",
       "dependencies": {
         "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
@@ -675,9 +822,9 @@
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -693,7 +840,8 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -728,128 +876,120 @@
         "node": ">=8"
       }
     },
-    "node_modules/@oclif/core/node_modules/ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
+      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
       "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
       "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
+        "tslib": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=8.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
       },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
-    "node_modules/@oclif/core/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
-    "node_modules/@oclif/core/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
-    "node_modules/@oclif/core/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
-    "node_modules/@oclif/core/node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
-    },
-    "node_modules/@oclif/core/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@rescript/std": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@rescript/std/-/std-9.0.0.tgz",
       "integrity": "sha512-zGzFsgtZ44mgL4Xef2gOy1hrRVdrs9mcxCOOKZrIPsmbZW14yTkaF591GXxpQvjXiHtgZ/iA9qLyWH6oSReIxQ=="
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.0",
@@ -883,16 +1023,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.33",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
-      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
-    },
     "node_modules/@types/form-data": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
@@ -901,10 +1031,15 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "node_modules/@types/node": {
       "version": "12.20.55",
@@ -929,11 +1064,6 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
-    },
     "node_modules/@types/secp256k1": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
@@ -950,6 +1080,35 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@whatwg-node/events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
+      "integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA=="
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
+      "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "@whatwg-node/node-fetch": "^0.3.6",
+        "busboy": "^1.6.0",
+        "urlpattern-polyfill": "^8.0.0",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
+      "integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
+      "dependencies": {
+        "@whatwg-node/events": "^0.0.3",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "fast-url-parser": "^1.1.3",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -959,6 +1118,25 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -977,9 +1155,9 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "engines": {
         "node": ">=6"
       }
@@ -1025,10 +1203,19 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
     },
+    "node_modules/any-signal": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
+      "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.3"
+      }
+    },
     "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -1038,18 +1225,22 @@
       }
     },
     "node_modules/apisauce": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-1.1.5.tgz",
-      "integrity": "sha512-gKC8qb/bDJsPsnEXLZnXJ7gVx7dh87CEVNeIwv1dvaffnXoh5GHwac5pWR1P2broLiVj/fqFMQvLDDt/RhjiqA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-2.1.6.tgz",
+      "integrity": "sha512-MdxR391op/FucS2YQRfB/NMRyCnHEPDd4h17LRIuVYi0BpGmMhpxc0shbOpfs5ahABuBEffNCGal5EcsydbBWg==",
       "dependencies": {
-        "axios": "^0.21.2",
-        "ramda": "^0.25.0"
+        "axios": "^0.21.4"
       }
     },
     "node_modules/app-module-path": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
       "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ=="
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -1072,11 +1263,6 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "node_modules/asmcrypto.js": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
-      "integrity": "sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA=="
-    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -1085,15 +1271,17 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
       "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/assemblyscript": {
@@ -1122,12 +1310,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1208,14 +1393,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
-    "node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1245,82 +1422,23 @@
         "wasm-opt": "bin/wasm-opt"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/bl": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
-      "integrity": "sha512-jrCW5ZhfQ/Vt07WX1Ngs+yn9BDqPL/gw28S7s9H6QK/gupnizNzJAss5akW20ISgOrbLTlXOOCTJeNUQqruAWQ==",
-      "dependencies": {
-        "readable-stream": "^3.0.1"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
       "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
+    "node_modules/blob-to-it": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
+      "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
+      "dependencies": {
+        "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
     "node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/borc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "dependencies": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/borc/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1346,6 +1464,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+    },
+    "node_modules/browser-readablestream-to-it": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
+      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -1379,9 +1502,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -1398,7 +1521,7 @@
       ],
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-alloc": {
@@ -1430,10 +1553,16 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
     },
-    "node_modules/builtin-status-codes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -1455,14 +1584,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
@@ -1480,6 +1601,14 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
+    "node_modules/cborg": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz",
+      "integrity": "sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug==",
+      "bin": {
+        "cborg": "cli.js"
+      }
+    },
     "node_modules/chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -1492,24 +1621,41 @@
         "node": ">=8"
       }
     },
-    "node_modules/chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
-        "anymatch": "~3.1.1",
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "engines": {
         "node": ">= 8.10.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chownr": {
@@ -1518,33 +1664,6 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/cids": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "class-is": "^1.1.0",
-        "multibase": "~0.6.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/cids/node_modules/multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
       }
     },
     "node_modules/cipher-base": {
@@ -1556,11 +1675,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/class-is": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
-    },
     "node_modules/clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -1568,17 +1682,6 @@
       "dependencies": {
         "escape-string-regexp": "4.0.0"
       },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clean-stack/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
       },
@@ -1608,31 +1711,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/cli-progress/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-progress/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cli-spinners": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
-      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
       "engines": {
         "node": ">=6"
       },
@@ -1641,15 +1723,15 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dependencies": {
         "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
+        "string-width": "^4.2.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
         "colors": "^1.1.2"
@@ -1680,9 +1762,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -1728,18 +1810,18 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/create-hash": {
@@ -1766,6 +1848,11 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1812,20 +1899,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "dependencies": {
         "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delay": {
@@ -1847,15 +1929,13 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1868,10 +1948,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/dns-over-http-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^3.0.0",
+        "receptacle": "^1.3.2"
+      }
+    },
     "node_modules/docker-compose": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.4.tgz",
-      "integrity": "sha512-yWdXby9uQ8o4syOfvoSJ9ZlTnLipvUmDn59uaYY5VGIUSUAfMPPGqE1DE3pOCnfSg9Tl9UOOFO0PCSAzuIHmuA==",
+      "version": "0.23.19",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.19.tgz",
+      "integrity": "sha512-v5vNLIdUqwj4my80wxFDkNH+4S85zsRuH29SO7dCWVWPCMt/ohZBsGN6g6KXWifT0pzQ7uOxqEKCYCDPJ8Vz4g==",
+      "dependencies": {
+        "yaml": "^1.10.2"
+      },
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -1932,19 +2025,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "dependencies": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1955,12 +2035,28 @@
       }
     },
     "node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron-fetch": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
+      "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
+      "dependencies": {
+        "encoding": "^0.1.13"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/elliptic": {
@@ -1982,6 +2078,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1991,20 +2095,20 @@
       }
     },
     "node_modules/enquirer": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.4.tgz",
-      "integrity": "sha512-pkYrrDZumL2VS6VBGDhqbajCM2xpkUNLuKfGPjfKaSIBKYopQbqEFyrOkRMIb2HDR/rO1kGhEt/5twBwtzKBXw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dependencies": {
-        "ansi-colors": "^3.2.1"
+        "ansi-colors": "^4.1.1"
       },
       "engines": {
         "node": ">=8.6"
       }
     },
     "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -2028,11 +2132,14 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/esprima": {
@@ -2147,29 +2254,26 @@
       }
     },
     "node_modules/execa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
         "is-stream": "^2.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
       },
       "engines": {
-        "node": "^8.12.0 || >=9.7.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
-    },
-    "node_modules/explain-error": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
-      "integrity": "sha512-/wSgNMxFusiYRy1rd19LT2SQlIXDppHpumpWo06wxjflD1OYxDLbl6rMVw+U3bxD5Nuhex4TKqv9Aem4D0lVzQ=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2192,15 +2296,25 @@
         "node": "> 0.1.90"
       }
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2217,6 +2331,27 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "dependencies": {
+        "punycode": "^1.3.2"
+      }
+    },
+    "node_modules/fast-url-parser/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -2224,11 +2359,6 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -2267,11 +2397,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/flatmap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
-      "integrity": "sha512-OuR+o7kHVe+x9RtIujPay7Uw3bvDZBZFSBXClEphZuSDLmZTqMdclasf4vFSsogC8baDz0eaC2NdO/2dlXHBKQ=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.1",
@@ -2319,29 +2444,26 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/fs-jetpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-2.4.0.tgz",
-      "integrity": "sha512-S/o9Dd7K9A7gicVU32eT8G0kHcmSu0rCVdP79P0MWInKFb8XpTc8Syhoo66k9no+HDshtlh4pUJTws8X+8fdFQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-4.3.1.tgz",
+      "integrity": "sha512-dbeOK84F6BiQzk2yqqCVwCPWTxAvVGJ3fMQc6E2wuEohS28mR6yHngbrKuVCK1KHRx/ccByDylqu4H5PCP2urQ==",
       "dependencies": {
         "minimatch": "^3.0.2",
         "rimraf": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/fs-jetpack/node_modules/rimraf": {
@@ -2372,9 +2494,9 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -2402,6 +2524,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2419,14 +2546,11 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2490,20 +2614,20 @@
       }
     },
     "node_modules/gluegun": {
-      "version": "4.3.1",
-      "resolved": "git+ssh://git@github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a",
-      "license": "MIT",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/gluegun/-/gluegun-5.1.2.tgz",
+      "integrity": "sha512-Cwx/8S8Z4YQg07a6AFsaGnnnmd8mN17414NcPS3OoDtZRwxgsvwRNJNg69niD6fDa8oNwslCG0xH7rEpRNNE/g==",
       "dependencies": {
-        "apisauce": "^1.0.1",
+        "apisauce": "^2.1.5",
         "app-module-path": "^2.2.0",
-        "cli-table3": "~0.5.0",
-        "colors": "1.3.3",
-        "cosmiconfig": "6.0.0",
-        "cross-spawn": "^7.0.0",
-        "ejs": "^2.6.1",
-        "enquirer": "2.3.4",
-        "execa": "^3.0.0",
-        "fs-jetpack": "^2.2.2",
+        "cli-table3": "0.6.0",
+        "colors": "1.4.0",
+        "cosmiconfig": "7.0.1",
+        "cross-spawn": "7.0.3",
+        "ejs": "3.1.6",
+        "enquirer": "2.3.6",
+        "execa": "5.1.1",
+        "fs-jetpack": "4.3.1",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.lowercase": "^4.3.0",
@@ -2519,21 +2643,48 @@
         "lodash.trimstart": "^4.5.1",
         "lodash.uppercase": "^4.3.0",
         "lodash.upperfirst": "^4.3.1",
-        "ora": "^4.0.0",
+        "ora": "4.0.2",
         "pluralize": "^8.0.0",
-        "ramdasauce": "^2.1.0",
-        "semver": "^7.0.0",
-        "which": "^2.0.0",
-        "yargs-parser": "^16.1.0"
+        "semver": "7.3.5",
+        "which": "2.0.2",
+        "yargs-parser": "^21.0.0"
       },
       "bin": {
         "gluegun": "bin/gluegun"
       }
     },
+    "node_modules/gluegun/node_modules/ejs": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+      "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+      "dependencies": {
+        "jake": "^10.6.1"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gluegun/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphql": {
       "version": "15.5.0",
@@ -2637,11 +2788,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "node_modules/hi-base32": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
-      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -2694,11 +2840,11 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=10.17.0"
       }
     },
     "node_modules/hyperlinker": {
@@ -2707,6 +2853,17 @@
       "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -2778,280 +2935,143 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
-    },
-    "node_modules/ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
-      "engines": {
-        "node": ">=4"
+    "node_modules/interface-datastore": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
+      "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "dependencies": {
+        "interface-store": "^2.0.2",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
       }
     },
-    "node_modules/ipfs-block": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
-      "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
-      "dependencies": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0"
-      },
+    "node_modules/interface-store": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
       "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/ipfs-core-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.9.0.tgz",
+      "integrity": "sha512-VJ8vJSHvI1Zm7/SxsZo03T+zzpsg8pkgiIi5hfwSJlsrJ1E2v68QPlnLshGHUSYw89Oxq0IbETYl2pGTFHTWfg==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dependencies": {
+        "interface-datastore": "^6.0.2",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13"
+      }
+    },
+    "node_modules/ipfs-core-utils": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.13.0.tgz",
+      "integrity": "sha512-HP5EafxU4/dLW3U13CFsgqVO5Ika8N4sRSIb/dTg16NjLOozMH31TXV0Grtu2ZWo1T10ahTzMvrfT5f4mhioXw==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dependencies": {
+        "any-signal": "^2.1.2",
+        "blob-to-it": "^1.0.1",
+        "browser-readablestream-to-it": "^1.0.1",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.9.0",
+        "ipfs-unixfs": "^6.0.3",
+        "ipfs-utils": "^9.0.2",
+        "it-all": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-peekable": "^1.0.2",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "multiformats": "^9.4.13",
+        "nanoid": "^3.1.23",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^2.0.0",
+        "uint8arrays": "^3.0.0"
       }
     },
     "node_modules/ipfs-http-client": {
-      "version": "34.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-34.0.0.tgz",
-      "integrity": "sha512-4RCkk8ix4Dqn6sxqFVwuXWCZ1eLFPsVaj6Ijvu1fs9VYgxgVudsW9PWwarlr4mw1xUCmPWYyXnEbGgzBrfMy0Q==",
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-55.0.0.tgz",
+      "integrity": "sha512-GpvEs7C7WL9M6fN/kZbjeh4Y8YN7rY8b18tVWZnKxRsVwM25cIFrRI8CwNt3Ugin9yShieI3i9sPyzYGMrLNnQ==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
       "dependencies": {
+        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-json": "^8.0.1",
+        "@ipld/dag-pb": "^2.1.3",
         "abort-controller": "^3.0.0",
-        "async": "^2.6.1",
-        "bignumber.js": "^9.0.0",
-        "bl": "^3.0.0",
-        "bs58": "^4.0.1",
-        "buffer": "^5.4.2",
-        "cids": "~0.7.1",
-        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "end-of-stream": "^1.4.1",
-        "err-code": "^2.0.0",
-        "explain-error": "^1.0.4",
-        "flatmap": "0.0.3",
-        "glob": "^7.1.3",
-        "ipfs-block": "~0.8.1",
-        "ipfs-utils": "~0.0.3",
-        "ipld-dag-cbor": "~0.15.0",
-        "ipld-dag-pb": "~0.17.3",
-        "ipld-raw": "^4.0.0",
-        "is-ipfs": "~0.6.1",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "iso-stream-http": "~0.1.2",
-        "iso-url": "~0.4.6",
-        "iterable-ndjson": "^1.1.0",
-        "just-kebab-case": "^1.1.0",
-        "just-map-keys": "^1.1.0",
-        "kind-of": "^6.0.2",
-        "ky": "^0.11.2",
-        "ky-universal": "^0.2.2",
-        "lru-cache": "^5.1.1",
-        "multiaddr": "^6.0.6",
-        "multibase": "~0.6.0",
-        "multicodec": "~0.5.1",
-        "multihashes": "~0.4.14",
-        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.3",
-        "peer-info": "~0.15.1",
-        "promise-nodeify": "^3.0.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "pull-to-stream": "~0.1.1",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^3.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^2.0.1",
-        "through2": "^3.0.1"
+        "any-signal": "^2.1.2",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.9.0",
+        "ipfs-core-utils": "^0.13.0",
+        "ipfs-utils": "^9.0.2",
+        "it-first": "^1.0.6",
+        "it-last": "^1.0.4",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13",
+        "native-abort-controller": "^1.0.3",
+        "parse-duration": "^1.0.0",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^3.0.0"
       },
       "engines": {
-        "node": ">=8.3.0",
+        "node": ">=14.0.0",
         "npm": ">=3.0.0"
       }
     },
-    "node_modules/ipfs-http-client/node_modules/concat-stream": {
-      "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/hugomrdias/concat-stream.git#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-      "license": "MIT",
+    "node_modules/ipfs-unixfs": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
+      "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2"
+        "err-code": "^3.0.1",
+        "protobufjs": "^6.10.2"
       },
       "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ipfs-http-client/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-utils": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.0.4.tgz",
-      "integrity": "sha512-7cZf6aGj2FG3XJWhCNwn4mS93Q0GEWjtBZvEHqzgI43U2qzNDCyzfS1pei1Y5F+tw/zDJ5U4XG0G9reJxR53Ig==",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
+      "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
       "dependencies": {
-        "buffer": "^5.2.1",
-        "is-buffer": "^2.0.3",
+        "any-signal": "^3.0.0",
+        "browser-readablestream-to-it": "^1.0.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
         "is-electron": "^2.2.0",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "kind-of": "^6.0.2",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/ipfs-utils/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "iso-url": "^1.1.5",
+        "it-all": "^1.0.4",
+        "it-glob": "^1.0.1",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "^2.6.8",
+        "react-native-fetch-api": "^3.0.0",
+        "stream-to-it": "^0.2.2"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipld-dag-cbor": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.3.tgz",
-      "integrity": "sha512-m23nG7ZyoVFnkK55/bLAErc7EfiMgaEQlqHWDTGzPI+O5r6bPfp+qbL5zTVSIT8tpbHmu174dwerVtLoVgeVyA==",
-      "deprecated": "This module has been superseded by @ipld/dag-cbor and multiformats",
-      "dependencies": {
-        "borc": "^2.1.2",
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
-        "is-circular": "^1.0.2",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor/node_modules/cids": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-      "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "class-is": "^1.1.0",
-        "multibase": "^1.0.0",
-        "multicodec": "^1.0.1",
-        "multihashes": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor/node_modules/multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor/node_modules/multihashes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/ipld-dag-pb": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.17.4.tgz",
-      "integrity": "sha512-YwCxETEMuXVspOKOhjIOHJvKvB/OZfCDkpSFiYBQN2/JQjM9y/RFCYzIQGm0wg7dCFLrhvfjAZLTSaKs65jzWA==",
-      "deprecated": "This module has been superseded by @ipld/dag-pb and multiformats",
-      "dependencies": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0",
-        "multicodec": "~0.5.1",
-        "multihashing-async": "~0.7.0",
-        "protons": "^1.0.1",
-        "stable": "~0.1.8"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-dag-pb/node_modules/err-code": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-      "integrity": "sha512-CJAN+O0/yA1CKfRn9SXOGctSpEM7DCon/r/5r2eXFMY2zCCJBasFhcM5I+1kh3Ap11FsQCX+vGHceNPvpWKhoA=="
-    },
-    "node_modules/ipld-dag-pb/node_modules/multihashing-async": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.7.0.tgz",
-      "integrity": "sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "buffer": "^5.2.1",
-        "err-code": "^1.1.2",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-raw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-4.0.1.tgz",
-      "integrity": "sha512-WjIdtZ06jJEar8zh+BHB84tE6ZdbS/XNa7+XCArOYfmeJ/c01T9VQpeMwdJQYn5c3s5UvvCu7y4VIi3vk2g1bA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "cids": "~0.7.0",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
-      }
-    },
-    "node_modules/ipld-raw/node_modules/multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
-      }
+    "node_modules/ipfs-utils/node_modules/any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3069,33 +3089,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-circular": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
-    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -3111,9 +3104,9 @@
       }
     },
     "node_modules/is-electron": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
-      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3124,11 +3117,11 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3160,38 +3153,6 @@
       }
     },
     "node_modules/is-ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
-      "integrity": "sha512-9MTn0dteHETtyUx8pxqMwg5hMBi3pvlyglJ+b79KOCca0po23337LbVV2Hl4xmMvfw++ljnO0/+5G6G+0Szh6g==",
-      "dependencies": {
-        "ip-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-ipfs": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.3.tgz",
-      "integrity": "sha512-HyRot1dvLcxImtDqPxAaY1miO6WsiP/z7Yxpg2qpaLWv5UdhAPtLvHJ4kMLM0w8GSl8AFsVF23PHe1LzuWrUlQ==",
-      "dependencies": {
-        "bs58": "^4.0.1",
-        "cids": "~0.7.0",
-        "mafmt": "^7.0.0",
-        "multiaddr": "^7.2.1",
-        "multibase": "~0.6.0",
-        "multihashes": "~0.4.13"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/is-ip": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
       "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
@@ -3202,99 +3163,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-ipfs/node_modules/multiaddr": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-      "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-      "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
-        "class-is": "^1.1.0",
-        "is-ip": "^3.1.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/cids": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-      "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "class-is": "^1.1.0",
-        "multibase": "^1.0.0",
-        "multicodec": "^1.0.1",
-        "multihashes": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/cids/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/multibase": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/multihashes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/multihashes/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3303,15 +3171,13 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-promise": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-      "integrity": "sha512-mjWH5XxnhMA8cFnDchr6qRP9S/kLntKuEfIYku+PaN1CnS8v+OG9O/BKpRCVRJvpIkgAZm0Pf5Is3iSSOILlcg=="
-    },
-    "node_modules/is-pull-stream": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/is-pull-stream/-/is-pull-stream-0.0.0.tgz",
-      "integrity": "sha512-NWLwqCc95I6m8FZDYLAmVJc9Xgk8O+8pPOoDKFTC293FH4S7FBcbLCw3WWPCdiT8uUSdzPy47VM08WPDMJJrag=="
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -3350,83 +3216,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "node_modules/iso-random-stream": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.2.tgz",
-      "integrity": "sha512-7y0tsBBgQs544iTYjyrMp5xvgrbYR8b+plQq1Bryp+03p0LssrxC9C1M0oHv4QESDt7d95c74XvMk/yawKqX+A==",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/iso-random-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/iso-random-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/iso-stream-http": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/iso-stream-http/-/iso-stream-http-0.1.2.tgz",
-      "integrity": "sha512-oHEDNOysIMTNypbg2f1SlydqRBvjl4ZbSE9+0awVxnkx3K2stGTFwB/kpVqnB6UEfF8QD36kAjDwZvqyXBLMnQ==",
-      "dependencies": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "node_modules/iso-stream-http/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/iso-url": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/isomorphic-ws": {
@@ -3442,23 +3237,75 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
-    "node_modules/iterable-ndjson": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
-      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+    "node_modules/it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+    },
+    "node_modules/it-first": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "node_modules/it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
       "dependencies": {
-        "string_decoder": "^1.2.0"
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/it-last": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
+      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+    },
+    "node_modules/it-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+    },
+    "node_modules/it-peekable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
+      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+    },
+    "node_modules/it-to-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+      "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/it-to-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/jake": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
-      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
       "dependencies": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
       },
       "bin": {
         "jake": "bin/cli.js"
@@ -3466,11 +3313,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/jake/node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/jake/node_modules/chalk": {
       "version": "4.1.2",
@@ -3487,14 +3329,23 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/jake/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jayson": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.6.6.tgz",
-      "integrity": "sha512-f71uvrAWTtrwoww6MKcl9phQTC+56AopLyEenWvKVAIMz+q0oVGj6tenLZ7Z6UiPBkJtKLj4kt0tACllFQruGQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.0.0.tgz",
+      "integrity": "sha512-v2RNpDCMu45fnLzSk47vx7I+QUaOsox6f5X0CUlabAFwxoP+8MfAY0NQRFwOEYXIxm8Ih5y6OaEa5KYiQMkyAA==",
       "dependencies": {
         "@types/connect": "^3.4.33",
-        "@types/express-serve-static-core": "^4.17.9",
-        "@types/lodash": "^4.14.159",
         "@types/node": "^12.12.54",
         "@types/ws": "^7.4.4",
         "commander": "^2.20.3",
@@ -3504,7 +3355,6 @@
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
         "JSONStream": "^1.3.5",
-        "lodash": "^4.17.20",
         "uuid": "^8.3.2",
         "ws": "^7.4.5"
       },
@@ -3549,9 +3399,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3585,14 +3435,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
-    "node_modules/json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
-      "dependencies": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -3602,14 +3444,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/jsonparse": {
@@ -3649,16 +3483,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/just-kebab-case": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/just-kebab-case/-/just-kebab-case-1.1.0.tgz",
-      "integrity": "sha512-QkuwuBMQ9BQHMUEkAtIA4INLrkmnnveqlFB1oFi09gbU0wBdZo6tTnyxNWMR84zHxBuwK7GLAwqN8nrvVxOLTA=="
-    },
-    "node_modules/just-map-keys": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/just-map-keys/-/just-map-keys-1.2.1.tgz",
-      "integrity": "sha512-Dmyz1Cy2SWM+PpqDPB1kdDglyexdzMthnAsvOIE9w4OPj8NDRuY1mh20x/JfG5w6fCGw9F0WmcofJhYZ4MiuyA=="
-    },
     "node_modules/keccak": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
@@ -3686,130 +3510,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/keypair": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.4.tgz",
-      "integrity": "sha512-zwhgOhhniaL7oxMgUMKKw5219PWWABMO+dgMnzJOQ2/5L3XJtTJGhW2PEXlxXj9zaccdReZJZ83+4NPhVfNVDg=="
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ky": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.11.2.tgz",
-      "integrity": "sha512-5Aou5BWue5/mkPqIRqzSWW+0Hkl403pr/2AIrCKYw7cVl/Xoe8Xe4KLBO0PRjbz7GnRe1/8wW1KhqQNFFE7/GQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ky-universal": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.2.2.tgz",
-      "integrity": "sha512-fb32o/fKy/ux2ALWa9HU2hvGtfOq7/vn2nH0FpVE+jwNzyTeORlAbj3Fiw+WLMbUlmVqZIWupnLZ2USHvqwZHw==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "ky": ">=0.10.0"
-      }
-    },
-    "node_modules/libp2p-crypto": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.4.tgz",
-      "integrity": "sha512-II8HxKc9jbmQp34pprlluNxsBCWJDjHRPYJzuRy7ragztNip9Zb7uJ4lCje6gGzz4DNAcHkAUn+GqCIK1592iA==",
-      "dependencies": {
-        "asmcrypto.js": "^2.3.2",
-        "asn1.js": "^5.0.1",
-        "async": "^2.6.1",
-        "bn.js": "^4.11.8",
-        "browserify-aes": "^1.2.0",
-        "bs58": "^4.0.1",
-        "iso-random-stream": "^1.1.0",
-        "keypair": "^1.0.1",
-        "libp2p-crypto-secp256k1": "~0.3.0",
-        "multihashing-async": "~0.5.1",
-        "node-forge": "^0.10.0",
-        "pem-jwk": "^2.0.0",
-        "protons": "^1.0.1",
-        "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.10.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/libp2p-crypto-secp256k1": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.1.tgz",
-      "integrity": "sha512-evrfK/CeUSd/lcELUdDruyPBvxDmLairth75S32OLl3H+++2m2fV24JEtxzdFS9JH3xEFw0h6JFO8DBa1bP9dA==",
-      "deprecated": "Included in libp2p-crypto, use it instead. https://github.com/libp2p/js-libp2p-crypto",
-      "dependencies": {
-        "async": "^2.6.2",
-        "bs58": "^4.0.1",
-        "multihashing-async": "~0.6.0",
-        "nodeify": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "secp256k1": "^3.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/libp2p-crypto-secp256k1/node_modules/multihashing-async": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
-      "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/libp2p-crypto/node_modules/multihashing-async": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
-      "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -3934,6 +3638,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/log-symbols/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -3958,138 +3670,21 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "node_modules/looper": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-      "integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg=="
-    },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/mafmt": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
-      "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
-      "dependencies": {
-        "multiaddr": "^7.3.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/cids": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-      "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "class-is": "^1.1.0",
-        "multibase": "^1.0.0",
-        "multicodec": "^1.0.1",
-        "multihashes": "^1.0.1"
+        "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
+        "node": ">=10"
       }
     },
-    "node_modules/mafmt/node_modules/cids/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mafmt/node_modules/is-ip": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-      "dependencies": {
-        "ip-regex": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mafmt/node_modules/multiaddr": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-      "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-      "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
-        "class-is": "^1.1.0",
-        "is-ip": "^3.1.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/multibase": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/multihashes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/multihashes/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -4099,6 +3694,17 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/merge-stream": {
@@ -4190,11 +3796,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/minizlib": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
@@ -4206,11 +3807,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -4229,129 +3825,65 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multiaddr": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
-      "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
+      "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
       "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr",
       "dependencies": {
-        "bs58": "^4.0.1",
-        "class-is": "^1.1.0",
-        "hi-base32": "~0.5.0",
-        "ip": "^1.1.5",
-        "is-ip": "^2.0.0",
-        "varint": "^5.0.0"
+        "dns-over-http-resolver": "^1.2.3",
+        "err-code": "^3.0.1",
+        "is-ip": "^3.1.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
       }
     },
-    "node_modules/multibase": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-      "deprecated": "This module has been superseded by the multiformats module",
+    "node_modules/multiaddr-to-uri": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-8.0.0.tgz",
+      "integrity": "sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==",
+      "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr-to-uri",
       "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
+        "multiaddr": "^10.0.0"
       }
     },
-    "node_modules/multicodec": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
-      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "varint": "^5.0.0"
-      }
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
-    "node_modules/multihashes": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/multihashes/node_modules/multibase": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      }
-    },
-    "node_modules/multihashing-async": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-      "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "buffer": "^5.4.3",
-        "err-code": "^2.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^1.0.1",
-        "murmurhash3js-revisited": "^3.0.0"
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/multihashing-async/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
+    "node_modules/native-abort-controller": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
+      "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
+      "peerDependencies": {
+        "abort-controller": "*"
       }
     },
-    "node_modules/multihashing-async/node_modules/multihashes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/murmurhash3js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
-      "integrity": "sha512-KL8QYUaxq7kUbcl0Yto51rMcYt7E/4N4BG3/c96Iqw1PQrTRspu8Cpx4TZ4Nunib1d4bEkIH3gjCYlP2RLBdow==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/murmurhash3js-revisited": {
+    "node_modules/native-fetch": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
-      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==",
-      "engines": {
-        "node": ">=8.0.0"
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "peerDependencies": {
+        "node-fetch": "*"
       }
-    },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
-    },
-    "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
     },
     "node_modules/natural-orderby": {
       "version": "2.0.3",
@@ -4361,44 +3893,28 @@
         "node": "*"
       }
     },
-    "node_modules/ndjson": {
-      "version": "1.5.0",
-      "resolved": "git+ssh://git@github.com/hugomrdias/ndjson.git#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.0",
-        "split2": "^3.1.0",
-        "through2": "^3.0.0"
-      },
-      "bin": {
-        "ndjson": "cli.js"
-      }
-    },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "engines": {
-        "node": ">= 6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-gyp-build": {
@@ -4409,15 +3925,6 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/nodeify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
-      "integrity": "sha512-n7C2NyEze8GCo/z73KdbjRsBiLbv6eBn1FxwYKQ23IqGo7pQY3mhQan61Sv7eEDJCiyUjTVrVkXTzJCo1dW7Aw==",
-      "dependencies": {
-        "is-promise": "~1.0.0",
-        "promise": "~1.3.0"
       }
     },
     "node_modules/normalize-path": {
@@ -4511,41 +4018,121 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "dependencies": {
-        "wordwrap": "~0.0.2"
-      }
-    },
     "node_modules/ora": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
-      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.2.tgz",
+      "integrity": "sha512-YUOZbamht5mfLxPmk4M35CD/5DuOkAacxlEUbStVXpBAt4fyhBf+vZHI/HRkI++QUp3sNoeA2Gw4C+hi4eGSig==",
       "dependencies": {
-        "chalk": "^3.0.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^3.1.0",
         "cli-spinners": "^2.2.0",
         "is-interactive": "^1.0.0",
         "log-symbols": "^3.0.0",
-        "mute-stream": "0.0.8",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^5.2.0",
         "wcwidth": "^1.0.1"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/ora/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "dependencies": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
       }
     },
     "node_modules/parent-module": {
@@ -4563,6 +4150,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+    },
+    "node_modules/parse-duration": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -4582,81 +4174,12 @@
       }
     },
     "node_modules/password-prompt": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
-      "integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
+      "integrity": "sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==",
       "dependencies": {
-        "ansi-escapes": "^3.1.0",
-        "cross-spawn": "^6.0.5"
-      }
-    },
-    "node_modules/password-prompt/node_modules/ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/password-prompt/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/password-prompt/node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/password-prompt/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/password-prompt/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/password-prompt/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/password-prompt/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
+        "ansi-escapes": "^4.3.2",
+        "cross-spawn": "^7.0.3"
       }
     },
     "node_modules/path-is-absolute": {
@@ -4673,6 +4196,37 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-type": {
@@ -4696,62 +4250,6 @@
       },
       "engines": {
         "node": ">=0.12"
-      }
-    },
-    "node_modules/peer-id": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.5.tgz",
-      "integrity": "sha512-3xVWrtIvNm9/OPzaQBgXDrfWNx63AftgFQkvqO6YSZy7sP3Fuadwwbn54F/VO9AnpyW/26i0WRQz9FScivXrmw==",
-      "dependencies": {
-        "async": "^2.6.3",
-        "class-is": "^1.1.0",
-        "libp2p-crypto": "~0.16.1",
-        "multihashes": "~0.4.15"
-      },
-      "bin": {
-        "peer-id": "src/bin.js"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/peer-info": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
-      "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
-      "deprecated": "No longer supported for js-libp2p0.28.0 or later",
-      "dependencies": {
-        "mafmt": "^6.0.2",
-        "multiaddr": "^6.0.3",
-        "peer-id": "~0.12.2",
-        "unique-by": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/peer-info/node_modules/mafmt": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
-      "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
-      "dependencies": {
-        "multiaddr": "^6.1.0"
-      }
-    },
-    "node_modules/pem-jwk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
-      "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
-      "dependencies": {
-        "asn1.js": "^5.0.1"
-      },
-      "bin": {
-        "pem-jwk": "bin/pem-jwk.js"
-      },
-      "engines": {
-        "node": ">=5.10.0"
       }
     },
     "node_modules/performance-now": {
@@ -4779,14 +4277,14 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -4797,93 +4295,40 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "node_modules/promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
-      "integrity": "sha512-R9WrbTF3EPkVtWjp7B7umQGVndpsi+rsDAfrR4xAALQpFLa/+2OriecLhawxzvii2gd9+DZFwROWDuUUaqS5yA==",
+    "node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
       "dependencies": {
-        "is-promise": "~1"
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
-    "node_modules/promise-nodeify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/promise-nodeify/-/promise-nodeify-3.0.1.tgz",
-      "integrity": "sha512-ghsSuzZXJX8iO7WVec2z7GI+Xk/EyiD+JZK7AZKhUqYfpLa/Zs4ylUD+CwwnKlG6G3HnkUPMAi6PO7zeqGKssg==",
-      "engines": {
-        "node": ">=6",
-        "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/promisify-es6": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
-      "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA==",
-      "deprecated": "Unmaintained"
-    },
-    "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
-    },
-    "node_modules/protons": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
-      "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
-      "deprecated": "This module is no longer maintained",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "protocol-buffers-schema": "^3.3.1",
-        "signed-varint": "^2.0.1",
-        "varint": "^5.0.0"
-      }
+    "node_modules/protobufjs/node_modules/@types/node": {
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-    },
-    "node_modules/pull-defer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
-    },
-    "node_modules/pull-stream": {
-      "version": "3.6.14",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
-    },
-    "node_modules/pull-to-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.1.tgz",
-      "integrity": "sha512-thZkMv6F9PILt9zdvpI2gxs19mkDrlixYKX6cOBxAW16i1NZH+yLAmF4r8QfJ69zuQh27e01JZP9y27tsH021w==",
-      "dependencies": {
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pull-to-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -4891,6 +4336,22 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "dependencies": {
+        "tslib": "^2.6.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/qs": {
@@ -4926,30 +4387,20 @@
         }
       ]
     },
-    "node_modules/ramda": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
-    },
-    "node_modules/ramdasauce": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ramdasauce/-/ramdasauce-2.1.3.tgz",
-      "integrity": "sha512-Ml3CPim4SKwmg5g9UI77lnRSeKr/kQw7YhQ6rfdMcBYy6DMlwmkEwQqjygJ3OhxPR+NfFfpjKl3Tf8GXckaqqg==",
-      "dependencies": {
-        "ramda": "^0.24.1"
-      }
-    },
-    "node_modules/ramdasauce/node_modules/ramda": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-      "integrity": "sha512-HEm619G8PaZMfkqCa23qiOe7r3R0brPu7ZgOsgKUsnvLhd0qhc/vTjkUovomgPWa5ECBa08fJZixth9LaoBo5w=="
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react-native-fetch-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
+      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+      "dependencies": {
+        "p-defer": "^3.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -4980,14 +4431,22 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/redeyed": {
@@ -4997,11 +4456,6 @@
       "dependencies": {
         "esprima": "~4.0.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/request": {
       "version": "2.88.2",
@@ -5062,6 +4516,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -5109,34 +4568,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
-    },
-    "node_modules/rsa-pem-to-jwk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
-      "integrity": "sha512-ZlVavEvTnD8Rzh/pdB8NH4VF5GNEtF6biGQcTtC4GKFMsbZR08oHtOYefbhCN+JnJIuMItiCDCMycdcMrw6blA==",
-      "dependencies": {
-        "object-assign": "^2.0.0",
-        "rsa-unpack": "0.0.6"
-      }
-    },
-    "node_modules/rsa-pem-to-jwk/node_modules/object-assign": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-      "integrity": "sha512-CdsOUYIh5wIiozhJ3rLQgmUTgcyzFwZZrqhkKhODMoGtPKM+wt0h0CNIoauJWMsS9822EdzPsF/6mb4nLvPN5g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rsa-unpack": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/rsa-unpack/-/rsa-unpack-0.0.6.tgz",
-      "integrity": "sha512-HRrl8GHjjPziPFRDJPq/v5OxZ3IPdksV5h3cime/oHgcgM1k1toO5OdtzClgBqRf5dF6IgptOB0g/zFb0w5zQw==",
-      "dependencies": {
-        "optimist": "~0.3.5"
-      },
-      "bin": {
-        "rsa-unpack": "bin/cmd.js"
-      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -5189,29 +4620,10 @@
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
-    "node_modules/secp256k1": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.5.2",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5221,22 +4633,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -5292,14 +4688,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
-    "node_modules/signed-varint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
-      "integrity": "sha512-abgDPg1106vuZZOvw7cFwdCABddfJRz5akcCcchzTbhyhYnsG31y4AlZEgp315T7W3nQq5P4xeOm186ZiPVFzw==",
-      "dependencies": {
-        "varint": "~5.0.0"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5329,27 +4717,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
-    },
-    "node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
-    "node_modules/split2/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -5385,19 +4752,20 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
-    },
-    "node_modules/stream-to-pull-stream": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
+    "node_modules/stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "dependencies": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
+        "get-iterator": "^1.0.2"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -5409,34 +4777,16 @@
       }
     },
     "node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -5471,14 +4821,17 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-hyperlinks": {
@@ -5488,6 +4841,17 @@
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -5592,49 +4956,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/then-request": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
@@ -5674,13 +4995,14 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
-    "node_modules/through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+    "node_modules/timeout-abort-controller": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-2.0.0.tgz",
+      "integrity": "sha512-2FAPXfzTPYEgw27bQGTHc0SzrbmnU2eso4qo172zMLZzaGqeu09PFa5B2FCUHM1tflgRqPgn5KQgp6+Vex4uNA==",
       "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.4",
+        "retimer": "^3.0.0"
       }
     },
     "node_modules/tmp": {
@@ -5695,9 +5017,9 @@
       }
     },
     "node_modules/tmp-promise": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.2.tgz",
-      "integrity": "sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "dependencies": {
         "tmp": "^0.2.0"
       }
@@ -5730,10 +5052,57 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -5745,11 +5114,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
@@ -5767,18 +5131,31 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
-    "node_modules/unique-by": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
-      "integrity": "sha512-rJRXK5V0zL6TiSzhoGNpJp5dr+TZBLoPJFC06rLn17Ug++7Aa0Qnve5v+skXeQxx6/sI7rBsSesa6MAcmFi8Ew==",
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
       "engines": {
-        "node": ">= 0.10.x"
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -5791,18 +5168,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/ursa-optional": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.2.tgz",
-      "integrity": "sha512-TKdwuLboBn7M34RcvVTuQyhvrA8gYKapuVdm0nBP0mnBc7oECOfUQZrY91cefL3/nm64ZyrejSRrhTVdX7NG/A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.14.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+    "node_modules/urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ=="
     },
     "node_modules/utf8": {
       "version": "3.0.0",
@@ -5823,10 +5192,15 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
     "node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "node_modules/verror": {
       "version": "1.10.0",
@@ -5852,6 +5226,14 @@
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/web3-eth-abi": {
@@ -5883,6 +5265,32 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/webcrypto-core": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5908,34 +5316,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/widest-line/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -5951,27 +5335,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -6008,28 +5371,32 @@
       }
     },
     "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
-      "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      },
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/subgraphs/lido/package.json
+++ b/subgraphs/lido/package.json
@@ -5,8 +5,8 @@
     "codegen": "graph codegen"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.42.4",
-    "@graphprotocol/graph-ts": "0.29.3",
-    "prettier": "^2.7.1"
+    "@graphprotocol/graph-cli": "^0.56.0",
+    "@graphprotocol/graph-ts": "^0.31.0",
+    "prettier": "^3.0.2"
   }
 }

--- a/subgraphs/lido/src/prices/common/constants.ts
+++ b/subgraphs/lido/src/prices/common/constants.ts
@@ -23,7 +23,7 @@ export const CHAIN_LINK_USD_ADDRESS = Address.fromString(
   "0x0000000000000000000000000000000000000348"
 );
 
-export const PRICE_LIB_VERSION = "1.3.1";
+export const PRICE_LIB_VERSION = "1.3.2";
 
 export const INT_ZERO = 0 as i32;
 export const INT_ONE = 1 as i32;

--- a/subgraphs/lido/src/prices/common/utils.ts
+++ b/subgraphs/lido/src/prices/common/utils.ts
@@ -29,6 +29,15 @@ export function isNullAddress(tokenAddr: Address): boolean {
   return tokenAddr.equals(constants.NULL.TYPE_ADDRESS);
 }
 
+export function bigIntToBigDecimal(
+  quantity: BigInt,
+  decimals: i32 = constants.DEFAULT_DECIMALS.toI32()
+): BigDecimal {
+  return quantity.divDecimal(
+    constants.BIGINT_TEN.pow(decimals as u8).toBigDecimal()
+  );
+}
+
 export function readValue<T>(
   callResult: ethereum.CallResult<T>,
   defaultValue: T

--- a/subgraphs/lido/src/prices/config/mainnet.ts
+++ b/subgraphs/lido/src/prices/config/mainnet.ts
@@ -102,7 +102,7 @@ export const HARDCODED_STABLES: Address[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 // https://github.com/messari/subgraphs/issues/2090
-class spellOverride implements OracleConfig {
+class SpellOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -119,7 +119,7 @@ class spellOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/726
-class stETHOverride implements OracleConfig {
+class StETHOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -136,7 +136,7 @@ class stETHOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/2097
-class baxaOverride implements OracleConfig {
+class BaxaOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -153,7 +153,7 @@ class baxaOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/2329
-class delperOverride implements OracleConfig {
+class DelperOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -257,7 +257,7 @@ export class config implements Configurations {
           Address.fromString("0x090185f2135308bad17527004364ebcc2d37e5f6"), // SPELL
         ].includes(tokenAddr)
       ) {
-        return new spellOverride();
+        return new SpellOverride();
       }
       if (
         tokenAddr &&
@@ -268,7 +268,7 @@ export class config implements Configurations {
         block.number.gt(BigInt.fromString("14019699")) &&
         block.number.lt(BigInt.fromString("14941265"))
       ) {
-        return new stETHOverride();
+        return new StETHOverride();
       }
       if (
         tokenAddr &&
@@ -276,7 +276,7 @@ export class config implements Configurations {
           Address.fromString("0x91b08f4a7c1251dfccf5440f8894f8daa10c8de5"), // BAXA
         ].includes(tokenAddr)
       ) {
-        return new baxaOverride();
+        return new BaxaOverride();
       }
       if (
         tokenAddr &&
@@ -284,7 +284,7 @@ export class config implements Configurations {
           Address.fromString("0x077416cc6242b3a7d8e42652b8a6a2599fda4a92"), // DPR
         ].includes(tokenAddr)
       ) {
-        return new delperOverride();
+        return new DelperOverride();
       }
     }
 

--- a/subgraphs/lido/src/prices/config/mainnet.ts
+++ b/subgraphs/lido/src/prices/config/mainnet.ts
@@ -152,6 +152,23 @@ class baxaOverride implements OracleConfig {
   }
 }
 
+// https://github.com/messari/subgraphs/issues/2329
+class delperOverride implements OracleConfig {
+  oracleCount(): number {
+    return constants.INT_ONE;
+  }
+  oracleOrder(): string[] {
+    return [
+      constants.OracleType.UNISWAP_FORKS_ROUTER,
+      constants.OracleType.YEARN_LENS_ORACLE,
+      constants.OracleType.CHAINLINK_FEED,
+      constants.OracleType.CURVE_CALCULATIONS,
+      constants.OracleType.CURVE_ROUTER,
+      constants.OracleType.SUSHI_CALCULATIONS,
+    ];
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 ///////////////////////////////// HELPERS /////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////
@@ -260,6 +277,14 @@ export class config implements Configurations {
         ].includes(tokenAddr)
       ) {
         return new baxaOverride();
+      }
+      if (
+        tokenAddr &&
+        [
+          Address.fromString("0x077416cc6242b3a7d8e42652b8a6a2599fda4a92"), // DPR
+        ].includes(tokenAddr)
+      ) {
+        return new delperOverride();
       }
     }
 

--- a/subgraphs/lido/src/prices/config/template.ts
+++ b/subgraphs/lido/src/prices/config/template.ts
@@ -46,7 +46,7 @@ export const HARDCODED_STABLES: Address[] = [];
 ///////////////////////// ORACLE CONFIG OVERRIDES /////////////////////////
 ///////////////////////////////////////////////////////////////////////////
 
-class someOverride implements OracleConfig {
+class SomeOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -137,6 +137,6 @@ export class config implements Configurations {
     tokenAddr: Address | null,
     block: ethereum.Block | null
   ): OracleConfig | null {
-    return new someOverride();
+    return new SomeOverride();
   }
 }

--- a/subgraphs/lido/src/prices/index.ts
+++ b/subgraphs/lido/src/prices/index.ts
@@ -116,13 +116,13 @@ export function getLiquidityBoundPrice(
       .div(amount);
 
     log.warning(
-      "[getLiquidityBoundPrice] reported (token price * amount): ({} * {}) bound to: {} for token: {} due to insufficient liquidity: {}",
+      "[getLiquidityBoundPrice] token: {} (reported price * amount): ({} * {}) bound to available liquidity: {}; new price: {}",
       [
+        tokenAddress.toHexString(),
         tokenPrice.usdPrice.toString(),
         amount.toString(),
-        liquidityBoundPriceUSD.toString(),
-        tokenAddress.toHexString(),
         liquidity.toString(),
+        liquidityBoundPriceUSD.toString(),
       ]
     );
   }

--- a/subgraphs/optimism-bridge-v2/package-lock.json
+++ b/subgraphs/optimism-bridge-v2/package-lock.json
@@ -5,43 +5,107 @@
   "packages": {
     "": {
       "name": "optimism-bridge-v2",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "dependencies": {
-        "@graphprotocol/graph-cli": "^0.44.0",
-        "@graphprotocol/graph-ts": "^0.29.1",
-        "mustache": "^4.2.0"
+        "@graphprotocol/graph-cli": "^0.56.0",
+        "@graphprotocol/graph-ts": "^0.31.0"
       },
       "devDependencies": {
-        "prettier": "^2.7.1",
-        "typescript": "^4.9.4"
+        "prettier": "^3.0.2",
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
+      "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.22.10",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
+      "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.5",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -85,6 +149,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -104,14 +176,15 @@
         "node": ">=4"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.20.7",
-      "license": "MIT",
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=12"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -496,39 +569,39 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.44.0.tgz",
-      "integrity": "sha512-H7864nlKcrl0tT7H1oi9vSDdUikDyIMlrzzRDTfJmVMsr2RYhW7q7X6h7zATUWdR5SiCVPI3vzA6t6ebi8MHjg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.56.0.tgz",
+      "integrity": "sha512-bOVtYLDLJpyqjPv9RX8DwRFePOiIlzWZhQGuznb6lY7Uk+uvjc0JSBsgPOAWjwkAI+3U1Ux7GPVwgYSLIOBXoQ==",
       "dependencies": {
         "@float-capital/float-subgraph-uncrashable": "^0.0.0-alpha.4",
-        "@oclif/core": "2.0.7",
+        "@oclif/core": "2.8.6",
+        "@whatwg-node/fetch": "^0.8.4",
         "assemblyscript": "0.19.23",
         "binary-install-raw": "0.0.13",
         "chalk": "3.0.0",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
-        "docker-compose": "0.23.4",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "docker-compose": "0.23.19",
         "dockerode": "2.5.8",
-        "fs-extra": "9.0.0",
-        "glob": "7.1.6",
-        "gluegun": "git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep",
+        "fs-extra": "9.1.0",
+        "glob": "9.3.5",
+        "gluegun": "5.1.2",
         "graphql": "15.5.0",
         "immutable": "4.2.1",
-        "ipfs-http-client": "34.0.0",
-        "jayson": "3.6.6",
-        "js-yaml": "3.13.1",
-        "node-fetch": "2.6.0",
+        "ipfs-http-client": "55.0.0",
+        "jayson": "4.0.0",
+        "js-yaml": "3.14.1",
         "prettier": "1.19.1",
         "request": "2.88.2",
-        "semver": "7.3.5",
+        "semver": "7.4.0",
         "sync-request": "6.1.0",
-        "tmp-promise": "3.0.2",
+        "tmp-promise": "3.0.3",
         "web3-eth-abi": "1.7.0",
         "which": "2.0.2",
-        "yaml": "1.9.2"
+        "yaml": "1.10.2"
       },
       "bin": {
-        "graph": "dist/bin.js"
+        "graph": "bin/run"
       },
       "engines": {
         "node": ">=14"
@@ -558,19 +631,26 @@
         "wasm-opt": "bin/wasm-opt"
       }
     },
+    "node_modules/@graphprotocol/graph-cli/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@graphprotocol/graph-cli/node_modules/glob": {
-      "version": "7.1.6",
-      "license": "ISC",
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -587,6 +667,28 @@
       "version": "5.2.1",
       "license": "Apache-2.0"
     },
+    "node_modules/@graphprotocol/graph-cli/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@graphprotocol/graph-cli/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@graphprotocol/graph-cli/node_modules/prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -599,11 +701,59 @@
       }
     },
     "node_modules/@graphprotocol/graph-ts": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.29.1.tgz",
-      "integrity": "sha512-GhAP2ijk3cTM0xBjoAFxEmdZbYl1BueCYqAGw5G7UyBX3EV8FWkvD5DMam6IkLGqXasBmelCFrROK3B5t6zVdg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.31.0.tgz",
+      "integrity": "sha512-xreRVM6ho2BtolyOh2flDkNoGZximybnzUnF53zJVp0+Ed0KnAlO1/KOCUYw06euVI9tk0c9nA2Z/D5SIQV2Rg==",
       "dependencies": {
         "assemblyscript": "0.19.10"
+      }
+    },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "dependencies": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@ipld/dag-json": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
+      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
+      "dependencies": {
+        "cborg": "^1.5.4",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@ipld/dag-pb": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "dependencies": {
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -639,9 +789,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.7.tgz",
-      "integrity": "sha512-pj7hIH8SBeH3qha47fmyqdaBdNVEqesRgnKFh8Ytdb4S41/4BYOiQuyQGuvnKgvicH6DMxp4FbM9EQEW46V9xw==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.6.tgz",
+      "integrity": "sha512-1QlPaHMhOORySCXkQyzjsIsy2GYTilOw3LkjeHkCgsPJQjAT4IclVytJusWktPbYNys9O+O4V23J44yomQvnBQ==",
       "dependencies": {
         "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
@@ -649,9 +799,9 @@
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -667,7 +817,8 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -702,127 +853,119 @@
         "node": ">=8"
       }
     },
-    "node_modules/@oclif/core/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
+      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
       "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
       "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
+        "tslib": "^2.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
       "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=10.12.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
-    "node_modules/@oclif/core/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
-    "node_modules/@oclif/core/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
-    "node_modules/@oclif/core/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
-    "node_modules/@oclif/core/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
-    "node_modules/@oclif/core/node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@rescript/std": {
       "version": "9.0.0",
       "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.1",
@@ -848,18 +991,10 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.32",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
       }
     },
     "node_modules/@types/form-data": {
@@ -869,9 +1004,15 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.191",
-      "license": "MIT"
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "node_modules/@types/node": {
       "version": "18.11.18",
@@ -893,10 +1034,6 @@
       "version": "6.9.7",
       "license": "MIT"
     },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.4",
-      "license": "MIT"
-    },
     "node_modules/@types/secp256k1": {
       "version": "4.0.3",
       "license": "MIT",
@@ -906,19 +1043,69 @@
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "dependencies": {
         "@types/node": "*"
       }
     },
+    "node_modules/@whatwg-node/events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
+      "integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA=="
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
+      "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "@whatwg-node/node-fetch": "^0.3.6",
+        "busboy": "^1.6.0",
+        "urlpattern-polyfill": "^8.0.0",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
+      "integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
+      "dependencies": {
+        "@whatwg-node/events": "^0.0.3",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "fast-url-parser": "^1.1.3",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -936,9 +1123,9 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "engines": {
         "node": ">=6"
       }
@@ -984,9 +1171,19 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
     },
+    "node_modules/any-signal": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
+      "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.3"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -996,12 +1193,11 @@
       }
     },
     "node_modules/apisauce": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-1.1.5.tgz",
-      "integrity": "sha512-gKC8qb/bDJsPsnEXLZnXJ7gVx7dh87CEVNeIwv1dvaffnXoh5GHwac5pWR1P2broLiVj/fqFMQvLDDt/RhjiqA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-2.1.6.tgz",
+      "integrity": "sha512-MdxR391op/FucS2YQRfB/NMRyCnHEPDd4h17LRIuVYi0BpGmMhpxc0shbOpfs5ahABuBEffNCGal5EcsydbBWg==",
       "dependencies": {
-        "axios": "^0.21.2",
-        "ramda": "^0.25.0"
+        "axios": "^0.21.4"
       }
     },
     "node_modules/app-module-path": {
@@ -1009,9 +1205,15 @@
       "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
       "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ=="
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -1028,10 +1230,6 @@
       "version": "2.0.6",
       "license": "MIT"
     },
-    "node_modules/asmcrypto.js": {
-      "version": "2.3.2",
-      "license": "MIT"
-    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "license": "MIT",
@@ -1039,14 +1237,17 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "license": "MIT",
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
       "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/assemblyscript": {
@@ -1073,11 +1274,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.4",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1085,7 +1284,8 @@
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -1121,6 +1321,8 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -1134,8 +1336,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1144,16 +1345,10 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/bignumber.js": {
-      "version": "9.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "engines": {
         "node": ">=8"
       }
@@ -1177,50 +1372,21 @@
         "wasm-opt": "bin/wasm-opt"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bip66": {
-      "version": "1.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/bl": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^3.0.1"
-      }
-    },
     "node_modules/blakejs": {
       "version": "1.2.1",
       "license": "MIT"
     },
+    "node_modules/blob-to-it": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
+      "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
+      "dependencies": {
+        "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
     "node_modules/bn.js": {
       "version": "4.12.0",
       "license": "MIT"
-    },
-    "node_modules/borc": {
-      "version": "2.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1232,7 +1398,8 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -1243,6 +1410,11 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "license": "MIT"
+    },
+    "node_modules/browser-readablestream-to-it": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
+      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -1273,7 +1445,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -1288,10 +1462,9 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-alloc": {
@@ -1318,9 +1491,16 @@
       "version": "1.0.3",
       "license": "MIT"
     },
-    "node_modules/builtin-status-codes": {
-      "version": "3.0.0",
-      "license": "MIT"
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -1341,14 +1521,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
@@ -1365,6 +1537,14 @@
       "version": "0.12.0",
       "license": "Apache-2.0"
     },
+    "node_modules/cborg": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz",
+      "integrity": "sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug==",
+      "bin": {
+        "cborg": "cli.js"
+      }
+    },
     "node_modules/chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -1377,43 +1557,46 @@
         "node": ">=8"
       }
     },
-    "node_modules/chokidar": {
-      "version": "3.5.1",
-      "license": "MIT",
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
-        "anymatch": "~3.1.1",
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "engines": {
         "node": ">= 8.10.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chownr": {
       "version": "1.1.4",
       "license": "ISC"
-    },
-    "node_modules/cids": {
-      "version": "0.7.5",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "class-is": "^1.1.0",
-        "multibase": "~0.6.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
     },
     "node_modules/cipher-base": {
       "version": "1.0.4",
@@ -1423,10 +1606,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/class-is": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -1434,17 +1613,6 @@
       "dependencies": {
         "escape-string-regexp": "4.0.0"
       },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clean-stack/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
       },
@@ -1474,31 +1642,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/cli-progress/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-progress/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cli-spinners": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
-      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
       "engines": {
         "node": ">=6"
       },
@@ -1507,15 +1654,15 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dependencies": {
         "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
+        "string-width": "^4.2.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
         "colors": "^1.1.2"
@@ -1546,9 +1693,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -1565,7 +1712,8 @@
     },
     "node_modules/commander": {
       "version": "2.20.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1613,18 +1761,18 @@
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/create-hash": {
@@ -1650,6 +1798,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1674,8 +1827,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "license": "MIT",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1686,14 +1840,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/defaults": {
@@ -1709,7 +1855,8 @@
     },
     "node_modules/delay": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
       "engines": {
         "node": ">=10"
       },
@@ -1724,13 +1871,13 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delimit-stream": {
-      "version": "0.1.0",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "license": "MIT"
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1743,9 +1890,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/dns-over-http-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^3.0.0",
+        "receptacle": "^1.3.2"
+      }
+    },
     "node_modules/docker-compose": {
-      "version": "0.23.4",
-      "license": "MIT",
+      "version": "0.23.19",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.19.tgz",
+      "integrity": "sha512-v5vNLIdUqwj4my80wxFDkNH+4S85zsRuH29SO7dCWVWPCMt/ohZBsGN6g6KXWifT0pzQ7uOxqEKCYCDPJ8Vz4g==",
+      "dependencies": {
+        "yaml": "^1.10.2"
+      },
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -1818,18 +1979,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/drbg.js": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "license": "MIT",
@@ -1839,12 +1988,28 @@
       }
     },
     "node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron-fetch": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
+      "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
+      "dependencies": {
+        "encoding": "^0.1.13"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/elliptic": {
@@ -1865,6 +2030,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "license": "MIT",
@@ -1873,19 +2046,20 @@
       }
     },
     "node_modules/enquirer": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.4.tgz",
-      "integrity": "sha512-pkYrrDZumL2VS6VBGDhqbajCM2xpkUNLuKfGPjfKaSIBKYopQbqEFyrOkRMIb2HDR/rO1kGhEt/5twBwtzKBXw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dependencies": {
-        "ansi-colors": "^3.2.1"
+        "ansi-colors": "^4.1.1"
       },
       "engines": {
         "node": ">=8.6"
       }
     },
     "node_modules/err-code": {
-      "version": "2.0.3",
-      "license": "MIT"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -1897,26 +2071,32 @@
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
       "dependencies": {
         "es6-promise": "^4.0.3"
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -2002,7 +2182,8 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "engines": {
         "node": ">=6"
       }
@@ -2016,28 +2197,26 @@
       }
     },
     "node_modules/execa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
         "is-stream": "^2.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
       },
       "engines": {
-        "node": "^8.12.0 || >=9.7.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
-    },
-    "node_modules/explain-error": {
-      "version": "1.0.4",
-      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2052,18 +2231,30 @@
     },
     "node_modules/eyes": {
       "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
       "engines": {
         "node": "> 0.1.90"
       }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2079,6 +2270,27 @@
       "version": "2.1.0",
       "license": "MIT"
     },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "dependencies": {
+        "punycode": "^1.3.2"
+      }
+    },
+    "node_modules/fast-url-parser/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -2086,10 +2298,6 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -2120,17 +2328,14 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/flatmap": {
-      "version": "0.0.3",
-      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -2174,28 +2379,26 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "9.0.0",
-      "license": "MIT",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/fs-jetpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-2.4.0.tgz",
-      "integrity": "sha512-S/o9Dd7K9A7gicVU32eT8G0kHcmSu0rCVdP79P0MWInKFb8XpTc8Syhoo66k9no+HDshtlh4pUJTws8X+8fdFQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-4.3.1.tgz",
+      "integrity": "sha512-dbeOK84F6BiQzk2yqqCVwCPWTxAvVGJ3fMQc6E2wuEohS28mR6yHngbrKuVCK1KHRx/ccByDylqu4H5PCP2urQ==",
       "dependencies": {
         "minimatch": "^3.0.2",
         "rimraf": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/fs-jetpack/node_modules/rimraf": {
@@ -2224,8 +2427,10 @@
       "license": "ISC"
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "license": "MIT",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2250,6 +2455,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2266,14 +2476,11 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2306,7 +2513,8 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -2334,20 +2542,20 @@
       }
     },
     "node_modules/gluegun": {
-      "version": "4.3.1",
-      "resolved": "git+ssh://git@github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a",
-      "license": "MIT",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/gluegun/-/gluegun-5.1.2.tgz",
+      "integrity": "sha512-Cwx/8S8Z4YQg07a6AFsaGnnnmd8mN17414NcPS3OoDtZRwxgsvwRNJNg69niD6fDa8oNwslCG0xH7rEpRNNE/g==",
       "dependencies": {
-        "apisauce": "^1.0.1",
+        "apisauce": "^2.1.5",
         "app-module-path": "^2.2.0",
-        "cli-table3": "~0.5.0",
-        "colors": "1.3.3",
-        "cosmiconfig": "6.0.0",
-        "cross-spawn": "^7.0.0",
-        "ejs": "^2.6.1",
-        "enquirer": "2.3.4",
-        "execa": "^3.0.0",
-        "fs-jetpack": "^2.2.2",
+        "cli-table3": "0.6.0",
+        "colors": "1.4.0",
+        "cosmiconfig": "7.0.1",
+        "cross-spawn": "7.0.3",
+        "ejs": "3.1.6",
+        "enquirer": "2.3.6",
+        "execa": "5.1.1",
+        "fs-jetpack": "4.3.1",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.lowercase": "^4.3.0",
@@ -2363,20 +2571,48 @@
         "lodash.trimstart": "^4.5.1",
         "lodash.uppercase": "^4.3.0",
         "lodash.upperfirst": "^4.3.1",
-        "ora": "^4.0.0",
+        "ora": "4.0.2",
         "pluralize": "^8.0.0",
-        "ramdasauce": "^2.1.0",
-        "semver": "^7.0.0",
-        "which": "^2.0.0",
-        "yargs-parser": "^16.1.0"
+        "semver": "7.3.5",
+        "which": "2.0.2",
+        "yargs-parser": "^21.0.0"
       },
       "bin": {
         "gluegun": "bin/gluegun"
       }
     },
+    "node_modules/gluegun/node_modules/ejs": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+      "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+      "dependencies": {
+        "jake": "^10.6.1"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gluegun/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "license": "ISC"
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphql": {
       "version": "16.6.0",
@@ -2458,10 +2694,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "node_modules/hi-base32": {
-      "version": "0.5.1",
-      "license": "MIT"
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "license": "MIT",
@@ -2509,11 +2741,11 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=10.17.0"
       }
     },
     "node_modules/hyperlinker": {
@@ -2524,8 +2756,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -2539,8 +2784,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -2590,255 +2834,143 @@
       "version": "2.0.4",
       "license": "ISC"
     },
-    "node_modules/ip": {
-      "version": "1.1.8",
-      "license": "MIT"
-    },
-    "node_modules/ip-regex": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+    "node_modules/interface-datastore": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
+      "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "dependencies": {
+        "interface-store": "^2.0.2",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
       }
     },
-    "node_modules/ipfs-block": {
-      "version": "0.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0"
-      },
+    "node_modules/interface-store": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
       "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/ipfs-core-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.9.0.tgz",
+      "integrity": "sha512-VJ8vJSHvI1Zm7/SxsZo03T+zzpsg8pkgiIi5hfwSJlsrJ1E2v68QPlnLshGHUSYw89Oxq0IbETYl2pGTFHTWfg==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dependencies": {
+        "interface-datastore": "^6.0.2",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13"
+      }
+    },
+    "node_modules/ipfs-core-utils": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.13.0.tgz",
+      "integrity": "sha512-HP5EafxU4/dLW3U13CFsgqVO5Ika8N4sRSIb/dTg16NjLOozMH31TXV0Grtu2ZWo1T10ahTzMvrfT5f4mhioXw==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dependencies": {
+        "any-signal": "^2.1.2",
+        "blob-to-it": "^1.0.1",
+        "browser-readablestream-to-it": "^1.0.1",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.9.0",
+        "ipfs-unixfs": "^6.0.3",
+        "ipfs-utils": "^9.0.2",
+        "it-all": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-peekable": "^1.0.2",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "multiformats": "^9.4.13",
+        "nanoid": "^3.1.23",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^2.0.0",
+        "uint8arrays": "^3.0.0"
       }
     },
     "node_modules/ipfs-http-client": {
-      "version": "34.0.0",
-      "license": "MIT",
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-55.0.0.tgz",
+      "integrity": "sha512-GpvEs7C7WL9M6fN/kZbjeh4Y8YN7rY8b18tVWZnKxRsVwM25cIFrRI8CwNt3Ugin9yShieI3i9sPyzYGMrLNnQ==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
       "dependencies": {
+        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-json": "^8.0.1",
+        "@ipld/dag-pb": "^2.1.3",
         "abort-controller": "^3.0.0",
-        "async": "^2.6.1",
-        "bignumber.js": "^9.0.0",
-        "bl": "^3.0.0",
-        "bs58": "^4.0.1",
-        "buffer": "^5.4.2",
-        "cids": "~0.7.1",
-        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "end-of-stream": "^1.4.1",
-        "err-code": "^2.0.0",
-        "explain-error": "^1.0.4",
-        "flatmap": "0.0.3",
-        "glob": "^7.1.3",
-        "ipfs-block": "~0.8.1",
-        "ipfs-utils": "~0.0.3",
-        "ipld-dag-cbor": "~0.15.0",
-        "ipld-dag-pb": "~0.17.3",
-        "ipld-raw": "^4.0.0",
-        "is-ipfs": "~0.6.1",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "iso-stream-http": "~0.1.2",
-        "iso-url": "~0.4.6",
-        "iterable-ndjson": "^1.1.0",
-        "just-kebab-case": "^1.1.0",
-        "just-map-keys": "^1.1.0",
-        "kind-of": "^6.0.2",
-        "ky": "^0.11.2",
-        "ky-universal": "^0.2.2",
-        "lru-cache": "^5.1.1",
-        "multiaddr": "^6.0.6",
-        "multibase": "~0.6.0",
-        "multicodec": "~0.5.1",
-        "multihashes": "~0.4.14",
-        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.3",
-        "peer-info": "~0.15.1",
-        "promise-nodeify": "^3.0.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "pull-to-stream": "~0.1.1",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^3.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^2.0.1",
-        "through2": "^3.0.1"
+        "any-signal": "^2.1.2",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.9.0",
+        "ipfs-core-utils": "^0.13.0",
+        "ipfs-utils": "^9.0.2",
+        "it-first": "^1.0.6",
+        "it-last": "^1.0.4",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13",
+        "native-abort-controller": "^1.0.3",
+        "parse-duration": "^1.0.0",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^3.0.0"
       },
       "engines": {
-        "node": ">=8.3.0",
+        "node": ">=14.0.0",
         "npm": ">=3.0.0"
       }
     },
-    "node_modules/ipfs-http-client/node_modules/concat-stream": {
-      "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/hugomrdias/concat-stream.git#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-      "license": "MIT",
+    "node_modules/ipfs-unixfs": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
+      "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2"
+        "err-code": "^3.0.1",
+        "protobufjs": "^6.10.2"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
-    },
-    "node_modules/ipfs-http-client/node_modules/debug": {
-      "version": "4.3.4",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ipfs-http-client/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/ipfs-http-client/node_modules/multicodec": {
-      "version": "0.5.7",
-      "license": "MIT",
-      "dependencies": {
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/ipfs-http-client/node_modules/yallist": {
-      "version": "3.1.1",
-      "license": "ISC"
     },
     "node_modules/ipfs-utils": {
-      "version": "0.0.4",
-      "license": "MIT",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
+      "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
       "dependencies": {
-        "buffer": "^5.2.1",
-        "is-buffer": "^2.0.3",
+        "any-signal": "^3.0.0",
+        "browser-readablestream-to-it": "^1.0.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
         "is-electron": "^2.2.0",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "kind-of": "^6.0.2",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor": {
-      "version": "0.15.3",
-      "license": "MIT",
-      "dependencies": {
-        "borc": "^2.1.2",
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
-        "is-circular": "^1.0.2",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
+        "iso-url": "^1.1.5",
+        "it-all": "^1.0.4",
+        "it-glob": "^1.0.1",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "^2.6.8",
+        "react-native-fetch-api": "^3.0.0",
+        "stream-to-it": "^0.2.2"
       },
       "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipld-dag-cbor/node_modules/cids": {
-      "version": "0.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "class-is": "^1.1.0",
-        "multibase": "^1.0.0",
-        "multicodec": "^1.0.1",
-        "multihashes": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor/node_modules/multibase": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor/node_modules/multihashes": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/ipld-dag-pb": {
-      "version": "0.17.4",
-      "license": "MIT",
-      "dependencies": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0",
-        "multicodec": "~0.5.1",
-        "multihashing-async": "~0.7.0",
-        "protons": "^1.0.1",
-        "stable": "~0.1.8"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-dag-pb/node_modules/err-code": {
-      "version": "1.1.2",
-      "license": "MIT"
-    },
-    "node_modules/ipld-dag-pb/node_modules/multicodec": {
-      "version": "0.5.7",
-      "license": "MIT",
-      "dependencies": {
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/ipld-dag-pb/node_modules/multihashing-async": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "buffer": "^5.2.1",
-        "err-code": "^1.1.2",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-raw": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "cids": "~0.7.0",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
-      }
+    "node_modules/ipfs-utils/node_modules/any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -2847,38 +2979,14 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-circular": {
-      "version": "1.0.2",
-      "license": "MIT"
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
@@ -2895,27 +3003,30 @@
       }
     },
     "node_modules/is-electron": {
-      "version": "2.2.1",
-      "license": "MIT"
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2940,37 +3051,9 @@
       }
     },
     "node_modules/is-ip": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ip-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-ipfs": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "bs58": "^4.0.1",
-        "cids": "~0.7.0",
-        "mafmt": "^7.0.0",
-        "multiaddr": "^7.2.1",
-        "multibase": "~0.6.0",
-        "multihashes": "~0.4.13"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/is-ip": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
       "dependencies": {
         "ip-regex": "^4.0.0"
       },
@@ -2978,103 +3061,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-ipfs/node_modules/mafmt": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "multiaddr": "^7.3.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr": {
-      "version": "7.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
-        "class-is": "^1.1.0",
-        "is-ip": "^3.1.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/cids": {
-      "version": "0.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "class-is": "^1.1.0",
-        "multibase": "^1.0.0",
-        "multicodec": "^1.0.1",
-        "multihashes": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/cids/node_modules/multibase": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/multibase": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/multihashes": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/multihashes/node_modules/multibase": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-promise": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/is-pull-stream": {
-      "version": "0.0.0",
-      "license": "MIT"
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "engines": {
         "node": ">=8"
       },
@@ -3106,58 +3112,18 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "node_modules/iso-random-stream": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/iso-random-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/iso-stream-http": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
     "node_modules/iso-url": {
-      "version": "0.4.7",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "peerDependencies": {
         "ws": "*"
       }
@@ -3166,11 +3132,51 @@
       "version": "0.1.2",
       "license": "MIT"
     },
-    "node_modules/iterable-ndjson": {
-      "version": "1.1.0",
-      "license": "MIT",
+    "node_modules/it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+    },
+    "node_modules/it-first": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "node_modules/it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
       "dependencies": {
-        "string_decoder": "^1.2.0"
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/it-last": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
+      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+    },
+    "node_modules/it-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+    },
+    "node_modules/it-peekable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
+      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+    },
+    "node_modules/it-to-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+      "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
       }
     },
     "node_modules/jake": {
@@ -3190,11 +3196,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/jake/node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
-    },
     "node_modules/jake/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3210,13 +3211,23 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/jake/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jayson": {
-      "version": "3.6.6",
-      "license": "MIT",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.0.0.tgz",
+      "integrity": "sha512-v2RNpDCMu45fnLzSk47vx7I+QUaOsox6f5X0CUlabAFwxoP+8MfAY0NQRFwOEYXIxm8Ih5y6OaEa5KYiQMkyAA==",
       "dependencies": {
         "@types/connect": "^3.4.33",
-        "@types/express-serve-static-core": "^4.17.9",
-        "@types/lodash": "^4.14.159",
         "@types/node": "^12.12.54",
         "@types/ws": "^7.4.4",
         "commander": "^2.20.3",
@@ -3226,7 +3237,6 @@
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
         "JSONStream": "^1.3.5",
-        "lodash": "^4.17.20",
         "uuid": "^8.3.2",
         "ws": "^7.4.5"
       },
@@ -3239,11 +3249,13 @@
     },
     "node_modules/jayson/node_modules/@types/node": {
       "version": "12.20.55",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "node_modules/jayson/node_modules/uuid": {
       "version": "8.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -3258,8 +3270,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "license": "MIT",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3289,28 +3302,15 @@
       "version": "5.0.1",
       "license": "ISC"
     },
-    "node_modules/json-text-sequence": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/jsonparse": {
@@ -3322,7 +3322,8 @@
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
-      "license": "(MIT OR Apache-2.0)",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dependencies": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -3347,14 +3348,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/just-kebab-case": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
-    "node_modules/just-map-keys": {
-      "version": "1.2.1",
-      "license": "MIT"
-    },
     "node_modules/keccak": {
       "version": "3.0.3",
       "hasInstallScript": true,
@@ -3368,140 +3361,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/keypair": {
-      "version": "1.0.4",
-      "license": "BSD / GPL"
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ky": {
-      "version": "0.11.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ky-universal": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "ky": ">=0.10.0"
-      }
-    },
-    "node_modules/ky-universal/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/libp2p-crypto": {
-      "version": "0.16.4",
-      "license": "MIT",
-      "dependencies": {
-        "asmcrypto.js": "^2.3.2",
-        "asn1.js": "^5.0.1",
-        "async": "^2.6.1",
-        "bn.js": "^4.11.8",
-        "browserify-aes": "^1.2.0",
-        "bs58": "^4.0.1",
-        "iso-random-stream": "^1.1.0",
-        "keypair": "^1.0.1",
-        "libp2p-crypto-secp256k1": "~0.3.0",
-        "multihashing-async": "~0.5.1",
-        "node-forge": "^0.10.0",
-        "pem-jwk": "^2.0.0",
-        "protons": "^1.0.1",
-        "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.10.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/libp2p-crypto-secp256k1": {
-      "version": "0.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "async": "^2.6.2",
-        "bs58": "^4.0.1",
-        "multihashing-async": "~0.6.0",
-        "nodeify": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "secp256k1": "^3.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/libp2p-crypto-secp256k1/node_modules/multihashing-async": {
-      "version": "0.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/libp2p-crypto/node_modules/multihashing-async": {
-      "version": "0.5.2",
-      "license": "MIT",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/libp2p-crypto/node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "license": "Unlicense"
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -3626,6 +3489,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/log-symbols/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -3649,13 +3520,10 @@
       "version": "4.0.0",
       "license": "Apache-2.0"
     },
-    "node_modules/looper": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3663,12 +3531,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/mafmt": {
-      "version": "6.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "multiaddr": "^6.1.0"
-      }
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -3677,6 +3543,17 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/merge-stream": {
@@ -3787,124 +3664,69 @@
     },
     "node_modules/ms": {
       "version": "2.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multiaddr": {
-      "version": "6.1.1",
-      "license": "MIT",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
+      "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
+      "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr",
       "dependencies": {
-        "bs58": "^4.0.1",
-        "class-is": "^1.1.0",
-        "hi-base32": "~0.5.0",
-        "ip": "^1.1.5",
-        "is-ip": "^2.0.0",
-        "varint": "^5.0.0"
+        "dns-over-http-resolver": "^1.2.3",
+        "err-code": "^3.0.1",
+        "is-ip": "^3.1.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
       }
     },
-    "node_modules/multibase": {
-      "version": "0.6.1",
-      "license": "MIT",
+    "node_modules/multiaddr-to-uri": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-8.0.0.tgz",
+      "integrity": "sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==",
+      "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr-to-uri",
       "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
+        "multiaddr": "^10.0.0"
       }
     },
-    "node_modules/multicodec": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
-      }
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
-    "node_modules/multihashes": {
-      "version": "0.4.21",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/multihashes/node_modules/multibase": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      }
-    },
-    "node_modules/multihashing-async": {
-      "version": "0.8.2",
-      "license": "MIT",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "buffer": "^5.4.3",
-        "err-code": "^2.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^1.0.1",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multihashing-async/node_modules/multibase": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multihashing-async/node_modules/multihashes": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/murmurhash3js": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/murmurhash3js-revisited": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
-        "mustache": "bin/mustache"
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    "node_modules/native-abort-controller": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
+      "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
+      "peerDependencies": {
+        "abort-controller": "*"
+      }
     },
-    "node_modules/nan": {
-      "version": "2.17.0",
-      "license": "MIT"
+    "node_modules/native-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "peerDependencies": {
+        "node-fetch": "*"
+      }
     },
     "node_modules/natural-orderby": {
       "version": "2.0.3",
@@ -3914,41 +3736,27 @@
         "node": "*"
       }
     },
-    "node_modules/ndjson": {
-      "version": "1.5.0",
-      "resolved": "git+ssh://git@github.com/hugomrdias/ndjson.git#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.0",
-        "split2": "^3.1.0",
-        "through2": "^3.0.0"
-      },
-      "bin": {
-        "ndjson": "cli.js"
-      }
-    },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
-      "version": "2.6.0",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "0.10.0",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-gyp-build": {
@@ -3960,24 +3768,10 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/nodeify": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-promise": "~1.0.0",
-        "promise": "~1.3.0"
-      }
-    },
-    "node_modules/nodeify/node_modules/promise": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-promise": "~1"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4060,40 +3854,121 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optimist": {
-      "version": "0.3.7",
-      "license": "MIT/X11",
-      "dependencies": {
-        "wordwrap": "~0.0.2"
-      }
-    },
     "node_modules/ora": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
-      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.2.tgz",
+      "integrity": "sha512-YUOZbamht5mfLxPmk4M35CD/5DuOkAacxlEUbStVXpBAt4fyhBf+vZHI/HRkI++QUp3sNoeA2Gw4C+hi4eGSig==",
       "dependencies": {
-        "chalk": "^3.0.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^3.1.0",
         "cli-spinners": "^2.2.0",
         "is-interactive": "^1.0.0",
         "log-symbols": "^3.0.0",
-        "mute-stream": "0.0.8",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^5.2.0",
         "wcwidth": "^1.0.1"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/ora/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "dependencies": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
       }
     },
     "node_modules/parent-module": {
@@ -4109,6 +3984,11 @@
     },
     "node_modules/parse-cache-control": {
       "version": "1.0.1"
+    },
+    "node_modules/parse-duration": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -4128,81 +4008,12 @@
       }
     },
     "node_modules/password-prompt": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
-      "integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
+      "integrity": "sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==",
       "dependencies": {
-        "ansi-escapes": "^3.1.0",
-        "cross-spawn": "^6.0.5"
-      }
-    },
-    "node_modules/password-prompt/node_modules/ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/password-prompt/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/password-prompt/node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/password-prompt/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/password-prompt/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/password-prompt/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/password-prompt/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
+        "ansi-escapes": "^4.3.2",
+        "cross-spawn": "^7.0.3"
       }
     },
     "node_modules/path-is-absolute": {
@@ -4218,6 +4029,37 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-type": {
@@ -4242,57 +4084,14 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/peer-id": {
-      "version": "0.12.5",
-      "license": "MIT",
-      "dependencies": {
-        "async": "^2.6.3",
-        "class-is": "^1.1.0",
-        "libp2p-crypto": "~0.16.1",
-        "multihashes": "~0.4.15"
-      },
-      "bin": {
-        "peer-id": "src/bin.js"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/peer-info": {
-      "version": "0.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "mafmt": "^6.0.2",
-        "multiaddr": "^6.0.3",
-        "peer-id": "~0.12.2",
-        "unique-by": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/pem-jwk": {
-      "version": "2.0.0",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "asn1.js": "^5.0.1"
-      },
-      "bin": {
-        "pem-jwk": "bin/pem-jwk.js"
-      },
-      "engines": {
-        "node": ">=5.10.0"
-      }
-    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -4309,15 +4108,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -4334,67 +4133,56 @@
         "asap": "~2.0.6"
       }
     },
-    "node_modules/promise-nodeify": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6",
-        "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/promisify-es6": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
-    "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "license": "MIT"
-    },
-    "node_modules/protons": {
-      "version": "1.2.1",
-      "license": "MIT",
+    "node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
       "dependencies": {
-        "buffer": "^5.5.0",
-        "protocol-buffers-schema": "^3.3.1",
-        "signed-varint": "^2.0.1",
-        "varint": "^5.0.0"
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
     "node_modules/psl": {
       "version": "1.9.0",
       "license": "MIT"
     },
-    "node_modules/pull-defer": {
-      "version": "0.2.3",
-      "license": "MIT"
-    },
-    "node_modules/pull-stream": {
-      "version": "3.7.0",
-      "license": "MIT"
-    },
-    "node_modules/pull-to-stream": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "dependencies": {
+        "tslib": "^2.6.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/qs": {
@@ -4429,29 +4217,19 @@
         }
       ]
     },
-    "node_modules/ramda": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
-    },
-    "node_modules/ramdasauce": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ramdasauce/-/ramdasauce-2.1.3.tgz",
-      "integrity": "sha512-Ml3CPim4SKwmg5g9UI77lnRSeKr/kQw7YhQ6rfdMcBYy6DMlwmkEwQqjygJ3OhxPR+NfFfpjKl3Tf8GXckaqqg==",
-      "dependencies": {
-        "ramda": "^0.24.1"
-      }
-    },
-    "node_modules/ramdasauce/node_modules/ramda": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-      "integrity": "sha512-HEm619G8PaZMfkqCa23qiOe7r3R0brPu7ZgOsgKUsnvLhd0qhc/vTjkUovomgPWa5ECBa08fJZixth9LaoBo5w=="
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react-native-fetch-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
+      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+      "dependencies": {
+        "p-defer": "^3.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -4467,13 +4245,22 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.5.0",
-      "license": "MIT",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/redeyed": {
@@ -4483,10 +4270,6 @@
       "dependencies": {
         "esprima": "~4.0.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "license": "MIT"
     },
     "node_modules/request": {
       "version": "2.88.2",
@@ -4544,6 +4327,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -4587,31 +4375,6 @@
     "node_modules/rlp/node_modules/bn.js": {
       "version": "5.2.1",
       "license": "MIT"
-    },
-    "node_modules/rsa-pem-to-jwk": {
-      "version": "1.1.3",
-      "license": "Apache 2.0",
-      "dependencies": {
-        "object-assign": "^2.0.0",
-        "rsa-unpack": "0.0.6"
-      }
-    },
-    "node_modules/rsa-pem-to-jwk/node_modules/object-assign": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rsa-unpack": {
-      "version": "0.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "optimist": "~0.3.5"
-      },
-      "bin": {
-        "rsa-unpack": "bin/cmd.js"
-      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -4661,27 +4424,10 @@
       "version": "3.0.1",
       "license": "MIT"
     },
-    "node_modules/secp256k1": {
-      "version": "3.8.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.5.2",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "license": "ISC",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4743,13 +4489,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
-    "node_modules/signed-varint": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "varint": "~5.0.0"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4777,16 +4516,10 @@
       "version": "1.0.1",
       "license": "ISC"
     },
-    "node_modules/split2": {
-      "version": "3.2.2",
-      "license": "ISC",
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/sshpk": {
       "version": "1.17.0",
@@ -4811,16 +4544,20 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "license": "MIT"
-    },
-    "node_modules/stream-to-pull-stream": {
-      "version": "1.7.3",
-      "license": "MIT",
+    "node_modules/stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "dependencies": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
+        "get-iterator": "^1.0.2"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -4831,34 +4568,16 @@
       }
     },
     "node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -4892,14 +4611,17 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-hyperlinks": {
@@ -4909,6 +4631,17 @@
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -5018,29 +4751,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/bl": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/tar/node_modules/chownr": {
       "version": "2.0.0",
       "license": "ISC",
@@ -5108,17 +4818,20 @@
       "version": "2.3.8",
       "license": "MIT"
     },
-    "node_modules/through2": {
-      "version": "3.0.2",
-      "license": "MIT",
+    "node_modules/timeout-abort-controller": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-2.0.0.tgz",
+      "integrity": "sha512-2FAPXfzTPYEgw27bQGTHc0SzrbmnU2eso4qo172zMLZzaGqeu09PFa5B2FCUHM1tflgRqPgn5KQgp6+Vex4uNA==",
       "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.4",
+        "retimer": "^3.0.0"
       }
     },
     "node_modules/tmp": {
       "version": "0.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "dependencies": {
         "rimraf": "^3.0.0"
       },
@@ -5127,8 +4840,9 @@
       }
     },
     "node_modules/tmp-promise": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "dependencies": {
         "tmp": "^0.2.0"
       }
@@ -5139,7 +4853,8 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -5160,12 +4875,55 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -5197,27 +4955,29 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "dev": true,
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
-    "node_modules/unique-by": {
-      "version": "1.0.0",
-      "engines": {
-        "node": ">= 0.10.x"
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/universalify": {
-      "version": "1.0.0",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -5229,17 +4989,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/ursa-optional": {
-      "version": "0.10.2",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.14.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+    "node_modules/urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ=="
     },
     "node_modules/utf8": {
       "version": "3.0.0",
@@ -5256,9 +5009,15 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
     "node_modules/varint": {
-      "version": "5.0.2",
-      "license": "MIT"
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "node_modules/verror": {
       "version": "1.10.0",
@@ -5291,6 +5050,14 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/web3-eth-abi": {
       "version": "1.7.0",
       "license": "LGPL-3.0",
@@ -5318,13 +5085,27 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/webcrypto-core": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -5355,33 +5136,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/widest-line/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -5399,34 +5157,14 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
     },
     "node_modules/ws": {
       "version": "7.5.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -5455,46 +5193,103 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.9.2",
-      "license": "ISC",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      },
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
       }
     }
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
+      "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
       "requires": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.22.10",
+        "chalk": "^2.4.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ=="
     },
     "@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
+      "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.5",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
@@ -5529,6 +5324,11 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5544,10 +5344,12 @@
         }
       }
     },
-    "@babel/runtime": {
-      "version": "7.20.7",
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@ethersproject/abi": {
@@ -5739,36 +5541,36 @@
       }
     },
     "@graphprotocol/graph-cli": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.44.0.tgz",
-      "integrity": "sha512-H7864nlKcrl0tT7H1oi9vSDdUikDyIMlrzzRDTfJmVMsr2RYhW7q7X6h7zATUWdR5SiCVPI3vzA6t6ebi8MHjg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.56.0.tgz",
+      "integrity": "sha512-bOVtYLDLJpyqjPv9RX8DwRFePOiIlzWZhQGuznb6lY7Uk+uvjc0JSBsgPOAWjwkAI+3U1Ux7GPVwgYSLIOBXoQ==",
       "requires": {
         "@float-capital/float-subgraph-uncrashable": "^0.0.0-alpha.4",
-        "@oclif/core": "2.0.7",
+        "@oclif/core": "2.8.6",
+        "@whatwg-node/fetch": "^0.8.4",
         "assemblyscript": "0.19.23",
         "binary-install-raw": "0.0.13",
         "chalk": "3.0.0",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
-        "docker-compose": "0.23.4",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "docker-compose": "0.23.19",
         "dockerode": "2.5.8",
-        "fs-extra": "9.0.0",
-        "glob": "7.1.6",
-        "gluegun": "git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep",
+        "fs-extra": "9.1.0",
+        "glob": "9.3.5",
+        "gluegun": "5.1.2",
         "graphql": "15.5.0",
         "immutable": "4.2.1",
-        "ipfs-http-client": "34.0.0",
-        "jayson": "3.6.6",
-        "js-yaml": "3.13.1",
-        "node-fetch": "2.6.0",
+        "ipfs-http-client": "55.0.0",
+        "jayson": "4.0.0",
+        "js-yaml": "3.14.1",
         "prettier": "1.19.1",
         "request": "2.88.2",
-        "semver": "7.3.5",
+        "semver": "7.4.0",
         "sync-request": "6.1.0",
-        "tmp-promise": "3.0.2",
+        "tmp-promise": "3.0.3",
         "web3-eth-abi": "1.7.0",
         "which": "2.0.2",
-        "yaml": "1.9.2"
+        "yaml": "1.10.2"
       },
       "dependencies": {
         "assemblyscript": {
@@ -5782,15 +5584,23 @@
         "binaryen": {
           "version": "102.0.0-nightly.20211028"
         },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "glob": {
-          "version": "7.1.6",
+          "version": "9.3.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+          "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
           "requires": {
             "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "minimatch": "^8.0.2",
+            "minipass": "^4.2.4",
+            "path-scurry": "^1.6.1"
           }
         },
         "graphql": {
@@ -5798,6 +5608,19 @@
         },
         "long": {
           "version": "5.2.1"
+        },
+        "minimatch": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+          "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="
         },
         "prettier": {
           "version": "1.19.1",
@@ -5807,11 +5630,56 @@
       }
     },
     "@graphprotocol/graph-ts": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.29.1.tgz",
-      "integrity": "sha512-GhAP2ijk3cTM0xBjoAFxEmdZbYl1BueCYqAGw5G7UyBX3EV8FWkvD5DMam6IkLGqXasBmelCFrROK3B5t6zVdg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.31.0.tgz",
+      "integrity": "sha512-xreRVM6ho2BtolyOh2flDkNoGZximybnzUnF53zJVp0+Ed0KnAlO1/KOCUYw06euVI9tk0c9nA2Z/D5SIQV2Rg==",
       "requires": {
         "assemblyscript": "0.19.10"
+      }
+    },
+    "@ipld/dag-cbor": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "requires": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@ipld/dag-json": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
+      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
+      "requires": {
+        "cborg": "^1.5.4",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@ipld/dag-pb": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "requires": {
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "@nodelib/fs.scandir": {
@@ -5838,9 +5706,9 @@
       }
     },
     "@oclif/core": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.7.tgz",
-      "integrity": "sha512-pj7hIH8SBeH3qha47fmyqdaBdNVEqesRgnKFh8Ytdb4S41/4BYOiQuyQGuvnKgvicH6DMxp4FbM9EQEW46V9xw==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.6.tgz",
+      "integrity": "sha512-1QlPaHMhOORySCXkQyzjsIsy2GYTilOw3LkjeHkCgsPJQjAT4IclVytJusWktPbYNys9O+O4V23J44yomQvnBQ==",
       "requires": {
         "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
@@ -5848,9 +5716,9 @@
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -5866,7 +5734,8 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -5890,88 +5759,115 @@
               }
             }
           }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ejs": {
-          "version": "3.1.9",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-          "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
-          "requires": {
-            "jake": "^10.8.5"
-          }
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
         }
       }
     },
+    "@peculiar/asn1-schema": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
+      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+      "requires": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
+      }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "@rescript/std": {
       "version": "9.0.0"
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "@types/bn.js": {
       "version": "5.1.1",
@@ -5995,16 +5891,10 @@
     },
     "@types/connect": {
       "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.17.32",
-      "requires": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
       }
     },
     "@types/form-data": {
@@ -6013,8 +5903,15 @@
         "@types/node": "*"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.191"
+    "@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "@types/node": {
       "version": "18.11.18"
@@ -6033,9 +5930,6 @@
     "@types/qs": {
       "version": "6.9.7"
     },
-    "@types/range-parser": {
-      "version": "1.2.4"
-    },
     "@types/secp256k1": {
       "version": "4.0.3",
       "requires": {
@@ -6044,15 +5938,58 @@
     },
     "@types/ws": {
       "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "requires": {
         "@types/node": "*"
       }
     },
+    "@whatwg-node/events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
+      "integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA=="
+    },
+    "@whatwg-node/fetch": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
+      "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
+      "requires": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "@whatwg-node/node-fetch": "^0.3.6",
+        "busboy": "^1.6.0",
+        "urlpattern-polyfill": "^8.0.0",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "@whatwg-node/node-fetch": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
+      "integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
+      "requires": {
+        "@whatwg-node/events": "^0.0.3",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "fast-url-parser": "^1.1.3",
+        "tslib": "^2.3.1"
+      }
+    },
     "abort-controller": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "requires": {
         "event-target-shim": "^5.0.0"
       }
+    },
+    "acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -6064,9 +6001,9 @@
       }
     },
     "ansi-colors": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -6094,20 +6031,30 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
     },
+    "any-signal": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
+      "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.3"
+      }
+    },
     "anymatch": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
     },
     "apisauce": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-1.1.5.tgz",
-      "integrity": "sha512-gKC8qb/bDJsPsnEXLZnXJ7gVx7dh87CEVNeIwv1dvaffnXoh5GHwac5pWR1P2broLiVj/fqFMQvLDDt/RhjiqA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-2.1.6.tgz",
+      "integrity": "sha512-MdxR391op/FucS2YQRfB/NMRyCnHEPDd4h17LRIuVYi0BpGmMhpxc0shbOpfs5ahABuBEffNCGal5EcsydbBWg==",
       "requires": {
-        "axios": "^0.21.2",
-        "ramda": "^0.25.0"
+        "axios": "^0.21.4"
       }
     },
     "app-module-path": {
@@ -6115,8 +6062,15 @@
       "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
       "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ=="
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+    },
     "argparse": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -6129,22 +6083,20 @@
     "asap": {
       "version": "2.0.6"
     },
-    "asmcrypto.js": {
-      "version": "2.3.2"
-    },
     "asn1": {
       "version": "0.2.6",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
-    "asn1.js": {
-      "version": "5.4.1",
+    "asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
       }
     },
     "assemblyscript": {
@@ -6158,16 +6110,17 @@
       "version": "1.0.0"
     },
     "async": {
-      "version": "2.6.4",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "asynckit": {
       "version": "0.4.0"
     },
     "at-least-node": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "aws-sign2": {
       "version": "0.7.0"
@@ -6191,7 +6144,9 @@
       }
     },
     "base64-js": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -6199,11 +6154,10 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bignumber.js": {
-      "version": "9.1.1"
-    },
     "binary-extensions": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "binary-install-raw": {
       "version": "0.0.13",
@@ -6216,41 +6170,19 @@
     "binaryen": {
       "version": "101.0.0-nightly.20210723"
     },
-    "bindings": {
-      "version": "1.5.0",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "bl": {
-      "version": "3.0.1",
-      "requires": {
-        "readable-stream": "^3.0.1"
-      }
-    },
     "blakejs": {
       "version": "1.2.1"
     },
+    "blob-to-it": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
+      "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
+      "requires": {
+        "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
     "bn.js": {
       "version": "4.12.0"
-    },
-    "borc": {
-      "version": "2.1.2",
-      "requires": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -6261,12 +6193,19 @@
     },
     "braces": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
       }
     },
     "brorand": {
       "version": "1.1.0"
+    },
+    "browser-readablestream-to-it": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
+      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -6294,10 +6233,12 @@
       }
     },
     "buffer": {
-      "version": "5.7.1",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-alloc": {
@@ -6319,8 +6260,13 @@
     "buffer-xor": {
       "version": "1.0.3"
     },
-    "builtin-status-codes": {
-      "version": "3.0.0"
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -6334,11 +6280,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
-    "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-    },
     "cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
@@ -6351,6 +6292,11 @@
     "caseless": {
       "version": "0.12.0"
     },
+    "cborg": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz",
+      "integrity": "sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug=="
+    },
     "chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -6358,33 +6304,35 @@
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "chokidar": {
-      "version": "3.5.1",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "chownr": {
       "version": "1.1.4"
-    },
-    "cids": {
-      "version": "0.7.5",
-      "requires": {
-        "buffer": "^5.5.0",
-        "class-is": "^1.1.0",
-        "multibase": "~0.6.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15"
-      }
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -6393,22 +6341,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "class-is": {
-      "version": "1.1.0"
-    },
     "clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
       "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
       "requires": {
         "escape-string-regexp": "4.0.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        }
       }
     },
     "cli-cursor": {
@@ -6425,38 +6363,21 @@
       "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "requires": {
         "string-width": "^4.2.3"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
       }
     },
     "cli-spinners": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
-      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g=="
     },
     "cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "requires": {
         "colors": "^1.1.2",
         "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
+        "string-width": "^4.2.0"
       }
     },
     "clone": {
@@ -6478,9 +6399,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -6489,7 +6410,9 @@
       }
     },
     "commander": {
-      "version": "2.20.3"
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1"
@@ -6530,15 +6453,15 @@
       "version": "1.0.3"
     },
     "cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "requires": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       }
     },
     "create-hash": {
@@ -6562,6 +6485,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -6579,15 +6507,12 @@
       }
     },
     "debug": {
-      "version": "4.3.1",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
     },
     "defaults": {
       "version": "1.0.4",
@@ -6598,16 +6523,17 @@
       }
     },
     "delay": {
-      "version": "5.0.0"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="
     },
     "delayed-stream": {
       "version": "1.0.0"
     },
-    "delimit-stream": {
-      "version": "0.1.0"
-    },
-    "detect-node": {
-      "version": "2.1.0"
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -6617,8 +6543,23 @@
         "path-type": "^4.0.0"
       }
     },
+    "dns-over-http-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "requires": {
+        "debug": "^4.3.1",
+        "native-fetch": "^3.0.0",
+        "receptacle": "^1.3.2"
+      }
+    },
     "docker-compose": {
-      "version": "0.23.4"
+      "version": "0.23.19",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.19.tgz",
+      "integrity": "sha512-v5vNLIdUqwj4my80wxFDkNH+4S85zsRuH29SO7dCWVWPCMt/ohZBsGN6g6KXWifT0pzQ7uOxqEKCYCDPJ8Vz4g==",
+      "requires": {
+        "yaml": "^1.10.2"
+      }
     },
     "docker-modem": {
       "version": "1.0.9",
@@ -6670,14 +6611,6 @@
         "tar-fs": "~1.16.3"
       }
     },
-    "drbg.js": {
-      "version": "1.0.1",
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "requires": {
@@ -6686,9 +6619,20 @@
       }
     },
     "ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "requires": {
+        "jake": "^10.8.5"
+      }
+    },
+    "electron-fetch": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
+      "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
+      "requires": {
+        "encoding": "^0.1.13"
+      }
     },
     "elliptic": {
       "version": "6.5.4",
@@ -6707,6 +6651,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "requires": {
@@ -6714,15 +6666,17 @@
       }
     },
     "enquirer": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.4.tgz",
-      "integrity": "sha512-pkYrrDZumL2VS6VBGDhqbajCM2xpkUNLuKfGPjfKaSIBKYopQbqEFyrOkRMIb2HDR/rO1kGhEt/5twBwtzKBXw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "requires": {
-        "ansi-colors": "^3.2.1"
+        "ansi-colors": "^4.1.1"
       }
     },
     "err-code": {
-      "version": "2.0.3"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -6733,21 +6687,27 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.8"
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
       "requires": {
         "es6-promise": "^4.0.3"
       }
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "esprima": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "ethereum-bloom-filters": {
       "version": "1.0.10",
@@ -6813,7 +6773,9 @@
       }
     },
     "event-target-shim": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -6823,24 +6785,20 @@
       }
     },
     "execa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "requires": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
         "is-stream": "^2.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
       }
-    },
-    "explain-error": {
-      "version": "1.0.4"
     },
     "extend": {
       "version": "3.0.2"
@@ -6849,15 +6807,27 @@
       "version": "1.3.0"
     },
     "eyes": {
-      "version": "0.1.8"
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ=="
+    },
+    "fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
     },
     "fast-deep-equal": {
       "version": "3.1.3"
     },
+    "fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -6869,6 +6839,29 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0"
     },
+    "fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "requires": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+        }
+      }
+    },
     "fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -6876,9 +6869,6 @@
       "requires": {
         "reusify": "^1.0.4"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0"
     },
     "filelist": {
       "version": "1.0.4",
@@ -6908,12 +6898,11 @@
     },
     "fill-range": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "flatmap": {
-      "version": "0.0.3"
     },
     "follow-redirects": {
       "version": "1.15.2"
@@ -6933,18 +6922,20 @@
       "version": "1.0.0"
     },
     "fs-extra": {
-      "version": "9.0.0",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       }
     },
     "fs-jetpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-2.4.0.tgz",
-      "integrity": "sha512-S/o9Dd7K9A7gicVU32eT8G0kHcmSu0rCVdP79P0MWInKFb8XpTc8Syhoo66k9no+HDshtlh4pUJTws8X+8fdFQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-4.3.1.tgz",
+      "integrity": "sha512-dbeOK84F6BiQzk2yqqCVwCPWTxAvVGJ3fMQc6E2wuEohS28mR6yHngbrKuVCK1KHRx/ccByDylqu4H5PCP2urQ==",
       "requires": {
         "minimatch": "^3.0.2",
         "rimraf": "^2.6.3"
@@ -6970,7 +6961,9 @@
       "version": "1.0.0"
     },
     "fsevents": {
-      "version": "2.3.2",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "optional": true
     },
     "function-bind": {
@@ -6984,6 +6977,11 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -6993,12 +6991,9 @@
       "version": "3.2.0"
     },
     "get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "requires": {
-        "pump": "^3.0.0"
-      }
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
     },
     "getpass": {
       "version": "0.1.7",
@@ -7019,6 +7014,8 @@
     },
     "glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -7037,19 +7034,20 @@
       }
     },
     "gluegun": {
-      "version": "git+ssh://git@github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a",
-      "from": "gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/gluegun/-/gluegun-5.1.2.tgz",
+      "integrity": "sha512-Cwx/8S8Z4YQg07a6AFsaGnnnmd8mN17414NcPS3OoDtZRwxgsvwRNJNg69niD6fDa8oNwslCG0xH7rEpRNNE/g==",
       "requires": {
-        "apisauce": "^1.0.1",
+        "apisauce": "^2.1.5",
         "app-module-path": "^2.2.0",
-        "cli-table3": "~0.5.0",
-        "colors": "1.3.3",
-        "cosmiconfig": "6.0.0",
-        "cross-spawn": "^7.0.0",
-        "ejs": "^2.6.1",
-        "enquirer": "2.3.4",
-        "execa": "^3.0.0",
-        "fs-jetpack": "^2.2.2",
+        "cli-table3": "0.6.0",
+        "colors": "1.4.0",
+        "cosmiconfig": "7.0.1",
+        "cross-spawn": "7.0.3",
+        "ejs": "3.1.6",
+        "enquirer": "2.3.6",
+        "execa": "5.1.1",
+        "fs-jetpack": "4.3.1",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.lowercase": "^4.3.0",
@@ -7065,16 +7063,35 @@
         "lodash.trimstart": "^4.5.1",
         "lodash.uppercase": "^4.3.0",
         "lodash.upperfirst": "^4.3.1",
-        "ora": "^4.0.0",
+        "ora": "4.0.2",
         "pluralize": "^8.0.0",
-        "ramdasauce": "^2.1.0",
-        "semver": "^7.0.0",
-        "which": "^2.0.0",
-        "yargs-parser": "^16.1.0"
+        "semver": "7.3.5",
+        "which": "2.0.2",
+        "yargs-parser": "^21.0.0"
+      },
+      "dependencies": {
+        "ejs": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+          "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+          "requires": {
+            "jake": "^10.6.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "graceful-fs": {
-      "version": "4.2.10"
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "graphql": {
       "version": "16.6.0"
@@ -7122,9 +7139,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hi-base32": {
-      "version": "0.5.1"
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "requires": {
@@ -7162,17 +7176,27 @@
       }
     },
     "human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "hyperlinker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
       "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ=="
     },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
     "ieee754": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.4",
@@ -7208,195 +7232,126 @@
     "inherits": {
       "version": "2.0.4"
     },
-    "ip": {
-      "version": "1.1.8"
+    "interface-datastore": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
+      "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "requires": {
+        "interface-store": "^2.0.2",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "interface-store": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
     },
     "ip-regex": {
-      "version": "2.1.0"
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
-    "ipfs-block": {
-      "version": "0.8.1",
+    "ipfs-core-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.9.0.tgz",
+      "integrity": "sha512-VJ8vJSHvI1Zm7/SxsZo03T+zzpsg8pkgiIi5hfwSJlsrJ1E2v68QPlnLshGHUSYw89Oxq0IbETYl2pGTFHTWfg==",
       "requires": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0"
+        "interface-datastore": "^6.0.2",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13"
+      }
+    },
+    "ipfs-core-utils": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.13.0.tgz",
+      "integrity": "sha512-HP5EafxU4/dLW3U13CFsgqVO5Ika8N4sRSIb/dTg16NjLOozMH31TXV0Grtu2ZWo1T10ahTzMvrfT5f4mhioXw==",
+      "requires": {
+        "any-signal": "^2.1.2",
+        "blob-to-it": "^1.0.1",
+        "browser-readablestream-to-it": "^1.0.1",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.9.0",
+        "ipfs-unixfs": "^6.0.3",
+        "ipfs-utils": "^9.0.2",
+        "it-all": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-peekable": "^1.0.2",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "multiformats": "^9.4.13",
+        "nanoid": "^3.1.23",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^2.0.0",
+        "uint8arrays": "^3.0.0"
       }
     },
     "ipfs-http-client": {
-      "version": "34.0.0",
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-55.0.0.tgz",
+      "integrity": "sha512-GpvEs7C7WL9M6fN/kZbjeh4Y8YN7rY8b18tVWZnKxRsVwM25cIFrRI8CwNt3Ugin9yShieI3i9sPyzYGMrLNnQ==",
       "requires": {
+        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-json": "^8.0.1",
+        "@ipld/dag-pb": "^2.1.3",
         "abort-controller": "^3.0.0",
-        "async": "^2.6.1",
-        "bignumber.js": "^9.0.0",
-        "bl": "^3.0.0",
-        "bs58": "^4.0.1",
-        "buffer": "^5.4.2",
-        "cids": "~0.7.1",
-        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "end-of-stream": "^1.4.1",
-        "err-code": "^2.0.0",
-        "explain-error": "^1.0.4",
-        "flatmap": "0.0.3",
-        "glob": "^7.1.3",
-        "ipfs-block": "~0.8.1",
-        "ipfs-utils": "~0.0.3",
-        "ipld-dag-cbor": "~0.15.0",
-        "ipld-dag-pb": "~0.17.3",
-        "ipld-raw": "^4.0.0",
-        "is-ipfs": "~0.6.1",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "iso-stream-http": "~0.1.2",
-        "iso-url": "~0.4.6",
-        "iterable-ndjson": "^1.1.0",
-        "just-kebab-case": "^1.1.0",
-        "just-map-keys": "^1.1.0",
-        "kind-of": "^6.0.2",
-        "ky": "^0.11.2",
-        "ky-universal": "^0.2.2",
-        "lru-cache": "^5.1.1",
-        "multiaddr": "^6.0.6",
-        "multibase": "~0.6.0",
-        "multicodec": "~0.5.1",
-        "multihashes": "~0.4.14",
-        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.3",
-        "peer-info": "~0.15.1",
-        "promise-nodeify": "^3.0.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "pull-to-stream": "~0.1.1",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^3.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^2.0.1",
-        "through2": "^3.0.1"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "git+ssh://git@github.com/hugomrdias/concat-stream.git#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-          "from": "concat-stream@github:hugomrdias/concat-stream#feat/smaller",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2"
-          }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "multicodec": {
-          "version": "0.5.7",
-          "requires": {
-            "varint": "^5.0.0"
-          }
-        },
-        "yallist": {
-          "version": "3.1.1"
-        }
+        "any-signal": "^2.1.2",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.9.0",
+        "ipfs-core-utils": "^0.13.0",
+        "ipfs-utils": "^9.0.2",
+        "it-first": "^1.0.6",
+        "it-last": "^1.0.4",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13",
+        "native-abort-controller": "^1.0.3",
+        "parse-duration": "^1.0.0",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "ipfs-unixfs": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
+      "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+      "requires": {
+        "err-code": "^3.0.1",
+        "protobufjs": "^6.10.2"
       }
     },
     "ipfs-utils": {
-      "version": "0.0.4",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
+      "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
       "requires": {
-        "buffer": "^5.2.1",
-        "is-buffer": "^2.0.3",
+        "any-signal": "^3.0.0",
+        "browser-readablestream-to-it": "^1.0.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
         "is-electron": "^2.2.0",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "kind-of": "^6.0.2",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "ipld-dag-cbor": {
-      "version": "0.15.3",
-      "requires": {
-        "borc": "^2.1.2",
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
-        "is-circular": "^1.0.2",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
+        "iso-url": "^1.1.5",
+        "it-all": "^1.0.4",
+        "it-glob": "^1.0.1",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "^2.6.8",
+        "react-native-fetch-api": "^3.0.0",
+        "stream-to-it": "^0.2.2"
       },
       "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
+        "any-signal": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+          "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
         }
-      }
-    },
-    "ipld-dag-pb": {
-      "version": "0.17.4",
-      "requires": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0",
-        "multicodec": "~0.5.1",
-        "multihashing-async": "~0.7.0",
-        "protons": "^1.0.1",
-        "stable": "~0.1.8"
-      },
-      "dependencies": {
-        "err-code": {
-          "version": "1.1.2"
-        },
-        "multicodec": {
-          "version": "0.5.7",
-          "requires": {
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.7.0",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.2.1",
-            "err-code": "^1.1.2",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
-      }
-    },
-    "ipld-raw": {
-      "version": "4.0.1",
-      "requires": {
-        "cids": "~0.7.0",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
       }
     },
     "is-arrayish": {
@@ -7406,15 +7361,11 @@
     },
     "is-binary-path": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "requires": {
         "binary-extensions": "^2.0.0"
       }
-    },
-    "is-buffer": {
-      "version": "2.0.5"
-    },
-    "is-circular": {
-      "version": "1.0.2"
     },
     "is-docker": {
       "version": "2.2.1",
@@ -7422,18 +7373,24 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
     },
     "is-electron": {
-      "version": "2.2.1"
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "is-extglob": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -7447,106 +7404,27 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
     },
     "is-ip": {
-      "version": "2.0.0",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
       "requires": {
-        "ip-regex": "^2.0.0"
-      }
-    },
-    "is-ipfs": {
-      "version": "0.6.3",
-      "requires": {
-        "bs58": "^4.0.1",
-        "cids": "~0.7.0",
-        "mafmt": "^7.0.0",
-        "multiaddr": "^7.2.1",
-        "multibase": "~0.6.0",
-        "multihashes": "~0.4.13"
-      },
-      "dependencies": {
-        "ip-regex": {
-          "version": "4.3.0"
-        },
-        "is-ip": {
-          "version": "3.1.0",
-          "requires": {
-            "ip-regex": "^4.0.0"
-          }
-        },
-        "mafmt": {
-          "version": "7.1.0",
-          "requires": {
-            "multiaddr": "^7.3.0"
-          }
-        },
-        "multiaddr": {
-          "version": "7.5.0",
-          "requires": {
-            "buffer": "^5.5.0",
-            "cids": "~0.8.0",
-            "class-is": "^1.1.0",
-            "is-ip": "^3.1.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "cids": {
-              "version": "0.8.3",
-              "requires": {
-                "buffer": "^5.6.0",
-                "class-is": "^1.1.0",
-                "multibase": "^1.0.0",
-                "multicodec": "^1.0.1",
-                "multihashes": "^1.0.1"
-              },
-              "dependencies": {
-                "multibase": {
-                  "version": "1.0.1",
-                  "requires": {
-                    "base-x": "^3.0.8",
-                    "buffer": "^5.5.0"
-                  }
-                }
-              }
-            },
-            "multibase": {
-              "version": "0.7.0",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            },
-            "multihashes": {
-              "version": "1.0.1",
-              "requires": {
-                "buffer": "^5.6.0",
-                "multibase": "^1.0.1",
-                "varint": "^5.0.0"
-              },
-              "dependencies": {
-                "multibase": {
-                  "version": "1.0.1",
-                  "requires": {
-                    "base-x": "^3.0.8",
-                    "buffer": "^5.5.0"
-                  }
-                }
-              }
-            }
-          }
-        }
+        "ip-regex": "^4.0.0"
       }
     },
     "is-number": {
-      "version": "7.0.0"
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
-    "is-promise": {
-      "version": "1.0.1"
-    },
-    "is-pull-stream": {
-      "version": "0.0.0"
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
     "is-stream": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-typedarray": {
       "version": "1.0.0"
@@ -7567,44 +7445,65 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "iso-random-stream": {
-      "version": "1.1.2",
-      "requires": {
-        "buffer": "^6.0.3",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        }
-      }
-    },
-    "iso-stream-http": {
-      "version": "0.1.2",
-      "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
     "iso-url": {
-      "version": "0.4.7"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
     },
     "isomorphic-ws": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "requires": {}
     },
     "isstream": {
       "version": "0.1.2"
     },
-    "iterable-ndjson": {
-      "version": "1.1.0",
+    "it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+    },
+    "it-first": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
       "requires": {
-        "string_decoder": "^1.2.0"
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "it-last": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
+      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+    },
+    "it-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+    },
+    "it-peekable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
+      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+    },
+    "it-to-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+      "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "requires": {
+        "buffer": "^6.0.3",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
       }
     },
     "jake": {
@@ -7618,11 +7517,6 @@
         "minimatch": "^3.1.2"
       },
       "dependencies": {
-        "async": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7631,15 +7525,23 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
     "jayson": {
-      "version": "3.6.6",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.0.0.tgz",
+      "integrity": "sha512-v2RNpDCMu45fnLzSk47vx7I+QUaOsox6f5X0CUlabAFwxoP+8MfAY0NQRFwOEYXIxm8Ih5y6OaEa5KYiQMkyAA==",
       "requires": {
         "@types/connect": "^3.4.33",
-        "@types/express-serve-static-core": "^4.17.9",
-        "@types/lodash": "^4.14.159",
         "@types/node": "^12.12.54",
         "@types/ws": "^7.4.4",
         "commander": "^2.20.3",
@@ -7649,16 +7551,19 @@
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
         "JSONStream": "^1.3.5",
-        "lodash": "^4.17.20",
         "uuid": "^8.3.2",
         "ws": "^7.4.5"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.55"
+          "version": "12.20.55",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
         },
         "uuid": {
-          "version": "8.3.2"
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -7671,7 +7576,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.13.1",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -7694,22 +7601,13 @@
     "json-stringify-safe": {
       "version": "5.0.1"
     },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "jsonfile": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      },
-      "dependencies": {
-        "universalify": {
-          "version": "2.0.0"
-        }
       }
     },
     "jsonparse": {
@@ -7717,6 +7615,8 @@
     },
     "JSONStream": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -7731,12 +7631,6 @@
         "verror": "1.10.0"
       }
     },
-    "just-kebab-case": {
-      "version": "1.1.0"
-    },
-    "just-map-keys": {
-      "version": "1.2.1"
-    },
     "keccak": {
       "version": "3.0.3",
       "requires": {
@@ -7745,96 +7639,10 @@
         "readable-stream": "^3.6.0"
       }
     },
-    "keypair": {
-      "version": "1.0.4"
-    },
-    "kind-of": {
-      "version": "6.0.3"
-    },
-    "ky": {
-      "version": "0.11.2"
-    },
-    "ky-universal": {
-      "version": "0.2.2",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "^2.3.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.7",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        }
-      }
-    },
-    "libp2p-crypto": {
-      "version": "0.16.4",
-      "requires": {
-        "asmcrypto.js": "^2.3.2",
-        "asn1.js": "^5.0.1",
-        "async": "^2.6.1",
-        "bn.js": "^4.11.8",
-        "browserify-aes": "^1.2.0",
-        "bs58": "^4.0.1",
-        "iso-random-stream": "^1.1.0",
-        "keypair": "^1.0.1",
-        "libp2p-crypto-secp256k1": "~0.3.0",
-        "multihashing-async": "~0.5.1",
-        "node-forge": "^0.10.0",
-        "pem-jwk": "^2.0.0",
-        "protons": "^1.0.1",
-        "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.10.0"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.5.2",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.3"
-        }
-      }
-    },
-    "libp2p-crypto-secp256k1": {
-      "version": "0.3.1",
-      "requires": {
-        "async": "^2.6.2",
-        "bs58": "^4.0.1",
-        "multihashing-async": "~0.6.0",
-        "nodeify": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "secp256k1": "^3.6.2"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.6.0",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
-      }
-    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "lodash": {
-      "version": "4.17.21"
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -7950,6 +7758,11 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -7968,20 +7781,18 @@
     "long": {
       "version": "4.0.0"
     },
-    "looper": {
-      "version": "3.0.0"
-    },
     "lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
       }
     },
-    "mafmt": {
-      "version": "6.0.10",
-      "requires": {
-        "multiaddr": "^6.1.0"
-      }
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -7989,6 +7800,14 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "requires": {
+        "is-plain-obj": "^2.1.0"
       }
     },
     "merge-stream": {
@@ -8059,146 +7878,76 @@
       }
     },
     "ms": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multiaddr": {
-      "version": "6.1.1",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
+      "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
       "requires": {
-        "bs58": "^4.0.1",
-        "class-is": "^1.1.0",
-        "hi-base32": "~0.5.0",
-        "ip": "^1.1.5",
-        "is-ip": "^2.0.0",
-        "varint": "^5.0.0"
+        "dns-over-http-resolver": "^1.2.3",
+        "err-code": "^3.0.1",
+        "is-ip": "^3.1.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
       }
     },
-    "multibase": {
-      "version": "0.6.1",
+    "multiaddr-to-uri": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-8.0.0.tgz",
+      "integrity": "sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==",
       "requires": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
+        "multiaddr": "^10.0.0"
       }
     },
-    "multicodec": {
+    "multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+    },
+    "native-abort-controller": {
       "version": "1.0.4",
-      "requires": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
-      }
+      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
+      "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
+      "requires": {}
     },
-    "multihashes": {
-      "version": "0.4.21",
-      "requires": {
-        "buffer": "^5.5.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "0.7.0",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        }
-      }
-    },
-    "multihashing-async": {
-      "version": "0.8.2",
-      "requires": {
-        "blakejs": "^1.1.0",
-        "buffer": "^5.4.3",
-        "err-code": "^2.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^1.0.1",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "1.0.1",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
-      }
-    },
-    "murmurhash3js": {
-      "version": "3.0.1"
-    },
-    "murmurhash3js-revisited": {
-      "version": "3.0.0"
-    },
-    "mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
-    },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
-    },
-    "nan": {
-      "version": "2.17.0"
+    "native-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "requires": {}
     },
     "natural-orderby": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
       "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q=="
     },
-    "ndjson": {
-      "version": "git+ssh://git@github.com/hugomrdias/ndjson.git#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-      "from": "ndjson@github:hugomrdias/ndjson#feat/readable-stream3",
-      "requires": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.0",
-        "split2": "^3.1.0",
-        "through2": "^3.0.0"
-      }
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
     "node-addon-api": {
       "version": "2.0.2"
     },
     "node-fetch": {
-      "version": "2.6.0"
-    },
-    "node-forge": {
-      "version": "0.10.0"
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-gyp-build": {
       "version": "4.6.0"
     },
-    "nodeify": {
-      "version": "1.0.1",
-      "requires": {
-        "is-promise": "~1.0.0",
-        "promise": "~1.3.0"
-      },
-      "dependencies": {
-        "promise": {
-          "version": "1.3.0",
-          "requires": {
-            "is-promise": "~1"
-          }
-        }
-      }
-    },
     "normalize-path": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -8250,31 +7999,97 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "optimist": {
-      "version": "0.3.7",
-      "requires": {
-        "wordwrap": "~0.0.2"
-      }
-    },
     "ora": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
-      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.2.tgz",
+      "integrity": "sha512-YUOZbamht5mfLxPmk4M35CD/5DuOkAacxlEUbStVXpBAt4fyhBf+vZHI/HRkI++QUp3sNoeA2Gw4C+hi4eGSig==",
       "requires": {
-        "chalk": "^3.0.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^3.1.0",
         "cli-spinners": "^2.2.0",
         "is-interactive": "^1.0.0",
         "log-symbols": "^3.0.0",
-        "mute-stream": "0.0.8",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^5.2.0",
         "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
-    "p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
+    "p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "requires": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -8286,6 +8101,11 @@
     },
     "parse-cache-control": {
       "version": "1.0.1"
+    },
+    "parse-duration": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
     },
     "parse-json": {
       "version": "5.2.0",
@@ -8299,62 +8119,12 @@
       }
     },
     "password-prompt": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
-      "integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
+      "integrity": "sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==",
       "requires": {
-        "ansi-escapes": "^3.1.0",
-        "cross-spawn": "^6.0.5"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
+        "ansi-escapes": "^4.3.2",
+        "cross-spawn": "^7.0.3"
       }
     },
     "path-is-absolute": {
@@ -8364,6 +8134,27 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "requires": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g=="
+        },
+        "minipass": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+          "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg=="
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -8380,35 +8171,13 @@
         "sha.js": "^2.4.8"
       }
     },
-    "peer-id": {
-      "version": "0.12.5",
-      "requires": {
-        "async": "^2.6.3",
-        "class-is": "^1.1.0",
-        "libp2p-crypto": "~0.16.1",
-        "multihashes": "~0.4.15"
-      }
-    },
-    "peer-info": {
-      "version": "0.15.1",
-      "requires": {
-        "mafmt": "^6.0.2",
-        "multiaddr": "^6.0.3",
-        "peer-id": "~0.12.2",
-        "unique-by": "^1.0.0"
-      }
-    },
-    "pem-jwk": {
-      "version": "2.0.0",
-      "requires": {
-        "asn1.js": "^5.0.1"
-      }
-    },
     "performance-now": {
       "version": "2.1.0"
     },
     "picomatch": {
-      "version": "2.3.1"
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pluralize": {
       "version": "8.0.0",
@@ -8416,9 +8185,9 @@
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true
     },
     "process-nextick-args": {
@@ -8430,48 +8199,44 @@
         "asap": "~2.0.6"
       }
     },
-    "promise-nodeify": {
-      "version": "3.0.1"
-    },
-    "promisify-es6": {
-      "version": "1.0.3"
-    },
-    "protocol-buffers-schema": {
-      "version": "3.6.0"
-    },
-    "protons": {
-      "version": "1.2.1",
+    "protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "requires": {
-        "buffer": "^5.5.0",
-        "protocol-buffers-schema": "^3.3.1",
-        "signed-varint": "^2.0.1",
-        "varint": "^5.0.0"
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
       }
     },
     "psl": {
       "version": "1.9.0"
     },
-    "pull-defer": {
-      "version": "0.2.3"
-    },
-    "pull-stream": {
-      "version": "3.7.0"
-    },
-    "pull-to-stream": {
-      "version": "0.1.1",
-      "requires": {
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "pump": {
-      "version": "3.0.0",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "punycode": {
       "version": "2.1.1"
+    },
+    "pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "requires": {
+        "tslib": "^2.6.1"
+      }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
     },
     "qs": {
       "version": "6.11.0",
@@ -8484,30 +8249,18 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
-    "ramda": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
-    },
-    "ramdasauce": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ramdasauce/-/ramdasauce-2.1.3.tgz",
-      "integrity": "sha512-Ml3CPim4SKwmg5g9UI77lnRSeKr/kQw7YhQ6rfdMcBYy6DMlwmkEwQqjygJ3OhxPR+NfFfpjKl3Tf8GXckaqqg==",
-      "requires": {
-        "ramda": "^0.24.1"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-          "integrity": "sha512-HEm619G8PaZMfkqCa23qiOe7r3R0brPu7ZgOsgKUsnvLhd0qhc/vTjkUovomgPWa5ECBa08fJZixth9LaoBo5w=="
-        }
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "react-native-fetch-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
+      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+      "requires": {
+        "p-defer": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -8519,9 +8272,19 @@
       }
     },
     "readdirp": {
-      "version": "3.5.0",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "requires": {
+        "ms": "^2.1.1"
       }
     },
     "redeyed": {
@@ -8531,9 +8294,6 @@
       "requires": {
         "esprima": "~4.0.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.11"
     },
     "request": {
       "version": "2.88.2",
@@ -8579,6 +8339,11 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -8608,24 +8373,6 @@
         }
       }
     },
-    "rsa-pem-to-jwk": {
-      "version": "1.1.3",
-      "requires": {
-        "object-assign": "^2.0.0",
-        "rsa-unpack": "0.0.6"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "2.1.1"
-        }
-      }
-    },
-    "rsa-unpack": {
-      "version": "0.0.6",
-      "requires": {
-        "optimist": "~0.3.5"
-      }
-    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8643,21 +8390,10 @@
     "scrypt-js": {
       "version": "3.0.1"
     },
-    "secp256k1": {
-      "version": "3.8.0",
-      "requires": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.5.2",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "semver": {
-      "version": "7.3.5",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -8698,12 +8434,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
-    "signed-varint": {
-      "version": "2.0.1",
-      "requires": {
-        "varint": "~5.0.0"
-      }
-    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8722,14 +8452,10 @@
     "split-ca": {
       "version": "1.0.1"
     },
-    "split2": {
-      "version": "3.2.2",
-      "requires": {
-        "readable-stream": "^3.0.0"
-      }
-    },
     "sprintf-js": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "sshpk": {
       "version": "1.17.0",
@@ -8745,15 +8471,18 @@
         "tweetnacl": "~0.14.0"
       }
     },
-    "stable": {
-      "version": "0.1.8"
-    },
-    "stream-to-pull-stream": {
-      "version": "1.7.3",
+    "stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "requires": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
+        "get-iterator": "^1.0.2"
       }
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -8762,27 +8491,13 @@
       }
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
@@ -8805,9 +8520,9 @@
       }
     },
     "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -8819,6 +8534,16 @@
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "sync-request": {
@@ -8925,26 +8650,6 @@
         }
       }
     },
-    "tar-stream": {
-      "version": "2.2.0",
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "4.1.0",
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        }
-      }
-    },
     "then-request": {
       "version": "6.0.2",
       "requires": {
@@ -8977,21 +8682,28 @@
     "through": {
       "version": "2.3.8"
     },
-    "through2": {
-      "version": "3.0.2",
+    "timeout-abort-controller": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-2.0.0.tgz",
+      "integrity": "sha512-2FAPXfzTPYEgw27bQGTHc0SzrbmnU2eso4qo172zMLZzaGqeu09PFa5B2FCUHM1tflgRqPgn5KQgp6+Vex4uNA==",
       "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.4",
+        "retimer": "^3.0.0"
       }
     },
     "tmp": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "requires": {
         "rimraf": "^3.0.0"
       }
     },
     "tmp-promise": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "requires": {
         "tmp": "^0.2.0"
       }
@@ -9001,6 +8713,8 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -9013,12 +8727,34 @@
       }
     },
     "tr46": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
     },
     "tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -9038,16 +8774,22 @@
       "version": "0.0.6"
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "dev": true
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
     },
-    "unique-by": {
-      "version": "1.0.0"
+    "uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "requires": {
+        "multiformats": "^9.4.2"
+      }
     },
     "universalify": {
-      "version": "1.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -9055,12 +8797,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "ursa-optional": {
-      "version": "0.10.2",
-      "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.14.2"
-      }
+    "urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ=="
     },
     "utf8": {
       "version": "3.0.0"
@@ -9071,8 +8811,15 @@
     "uuid": {
       "version": "3.4.0"
     },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
     "varint": {
-      "version": "5.0.2"
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "verror": {
       "version": "1.10.0",
@@ -9098,6 +8845,11 @@
         "defaults": "^1.0.3"
       }
     },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+    },
     "web3-eth-abi": {
       "version": "1.7.0",
       "requires": {
@@ -9117,11 +8869,27 @@
         "utf8": "3.0.0"
       }
     },
+    "webcrypto-core": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
     "webidl-conversions": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -9141,27 +8909,12 @@
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "requires": {
         "string-width": "^4.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
       }
     },
     "wordwrap": {
-      "version": "0.0.3"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -9171,23 +8924,6 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
       }
     },
     "wrappy": {
@@ -9195,6 +8931,8 @@
     },
     "ws": {
       "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "requires": {}
     },
     "xtend": {
@@ -9204,19 +8942,19 @@
       "version": "4.0.0"
     },
     "yaml": {
-      "version": "1.9.2",
-      "requires": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs-parser": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/subgraphs/optimism-bridge-v2/package.json
+++ b/subgraphs/optimism-bridge-v2/package.json
@@ -1,17 +1,16 @@
 {
   "name": "optimism-bridge-v2",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "scripts": {
     "codegen": "graph codegen",
     "build:subgraph": "graph build"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.44.0",
-    "@graphprotocol/graph-ts": "^0.29.1",
-    "mustache": "^4.2.0"
+    "@graphprotocol/graph-cli": "^0.56.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "typescript": "^4.9.4",
-    "prettier": "^2.7.1"
+    "typescript": "^5.2.2",
+    "prettier": "^3.0.2"
   }
 }

--- a/subgraphs/optimism-bridge-v2/src/prices/common/constants.ts
+++ b/subgraphs/optimism-bridge-v2/src/prices/common/constants.ts
@@ -23,7 +23,7 @@ export const CHAIN_LINK_USD_ADDRESS = Address.fromString(
   "0x0000000000000000000000000000000000000348"
 );
 
-export const PRICE_LIB_VERSION = "1.3.1";
+export const PRICE_LIB_VERSION = "1.3.2";
 
 export const INT_ZERO = 0 as i32;
 export const INT_ONE = 1 as i32;

--- a/subgraphs/optimism-bridge-v2/src/prices/common/utils.ts
+++ b/subgraphs/optimism-bridge-v2/src/prices/common/utils.ts
@@ -29,6 +29,15 @@ export function isNullAddress(tokenAddr: Address): boolean {
   return tokenAddr.equals(constants.NULL.TYPE_ADDRESS);
 }
 
+export function bigIntToBigDecimal(
+  quantity: BigInt,
+  decimals: i32 = constants.DEFAULT_DECIMALS.toI32()
+): BigDecimal {
+  return quantity.divDecimal(
+    constants.BIGINT_TEN.pow(decimals as u8).toBigDecimal()
+  );
+}
+
 export function readValue<T>(
   callResult: ethereum.CallResult<T>,
   defaultValue: T

--- a/subgraphs/optimism-bridge-v2/src/prices/config/mainnet.ts
+++ b/subgraphs/optimism-bridge-v2/src/prices/config/mainnet.ts
@@ -102,7 +102,7 @@ export const HARDCODED_STABLES: Address[] = [
 ///////////////////////////////////////////////////////////////////////////
 
 // https://github.com/messari/subgraphs/issues/2090
-class spellOverride implements OracleConfig {
+class SpellOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -119,7 +119,7 @@ class spellOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/726
-class stETHOverride implements OracleConfig {
+class StETHOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -136,7 +136,7 @@ class stETHOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/2097
-class baxaOverride implements OracleConfig {
+class BaxaOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -153,7 +153,7 @@ class baxaOverride implements OracleConfig {
 }
 
 // https://github.com/messari/subgraphs/issues/2329
-class delperOverride implements OracleConfig {
+class DelperOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -257,7 +257,7 @@ export class config implements Configurations {
           Address.fromString("0x090185f2135308bad17527004364ebcc2d37e5f6"), // SPELL
         ].includes(tokenAddr)
       ) {
-        return new spellOverride();
+        return new SpellOverride();
       }
       if (
         tokenAddr &&
@@ -268,7 +268,7 @@ export class config implements Configurations {
         block.number.gt(BigInt.fromString("14019699")) &&
         block.number.lt(BigInt.fromString("14941265"))
       ) {
-        return new stETHOverride();
+        return new StETHOverride();
       }
       if (
         tokenAddr &&
@@ -276,7 +276,7 @@ export class config implements Configurations {
           Address.fromString("0x91b08f4a7c1251dfccf5440f8894f8daa10c8de5"), // BAXA
         ].includes(tokenAddr)
       ) {
-        return new baxaOverride();
+        return new BaxaOverride();
       }
       if (
         tokenAddr &&
@@ -284,7 +284,7 @@ export class config implements Configurations {
           Address.fromString("0x077416cc6242b3a7d8e42652b8a6a2599fda4a92"), // DPR
         ].includes(tokenAddr)
       ) {
-        return new delperOverride();
+        return new DelperOverride();
       }
     }
 

--- a/subgraphs/optimism-bridge-v2/src/prices/config/mainnet.ts
+++ b/subgraphs/optimism-bridge-v2/src/prices/config/mainnet.ts
@@ -152,6 +152,23 @@ class baxaOverride implements OracleConfig {
   }
 }
 
+// https://github.com/messari/subgraphs/issues/2329
+class delperOverride implements OracleConfig {
+  oracleCount(): number {
+    return constants.INT_ONE;
+  }
+  oracleOrder(): string[] {
+    return [
+      constants.OracleType.UNISWAP_FORKS_ROUTER,
+      constants.OracleType.YEARN_LENS_ORACLE,
+      constants.OracleType.CHAINLINK_FEED,
+      constants.OracleType.CURVE_CALCULATIONS,
+      constants.OracleType.CURVE_ROUTER,
+      constants.OracleType.SUSHI_CALCULATIONS,
+    ];
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 ///////////////////////////////// HELPERS /////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////
@@ -260,6 +277,14 @@ export class config implements Configurations {
         ].includes(tokenAddr)
       ) {
         return new baxaOverride();
+      }
+      if (
+        tokenAddr &&
+        [
+          Address.fromString("0x077416cc6242b3a7d8e42652b8a6a2599fda4a92"), // DPR
+        ].includes(tokenAddr)
+      ) {
+        return new delperOverride();
       }
     }
 

--- a/subgraphs/optimism-bridge-v2/src/prices/config/template.ts
+++ b/subgraphs/optimism-bridge-v2/src/prices/config/template.ts
@@ -46,7 +46,7 @@ export const HARDCODED_STABLES: Address[] = [];
 ///////////////////////// ORACLE CONFIG OVERRIDES /////////////////////////
 ///////////////////////////////////////////////////////////////////////////
 
-class someOverride implements OracleConfig {
+class SomeOverride implements OracleConfig {
   oracleCount(): number {
     return constants.INT_ONE;
   }
@@ -137,6 +137,6 @@ export class config implements Configurations {
     tokenAddr: Address | null,
     block: ethereum.Block | null
   ): OracleConfig | null {
-    return new someOverride();
+    return new SomeOverride();
   }
 }

--- a/subgraphs/optimism-bridge-v2/src/prices/index.ts
+++ b/subgraphs/optimism-bridge-v2/src/prices/index.ts
@@ -116,13 +116,13 @@ export function getLiquidityBoundPrice(
       .div(amount);
 
     log.warning(
-      "[getLiquidityBoundPrice] reported (token price * amount): ({} * {}) bound to: {} for token: {} due to insufficient liquidity: {}",
+      "[getLiquidityBoundPrice] token: {} (reported price * amount): ({} * {}) bound to available liquidity: {}; new price: {}",
       [
+        tokenAddress.toHexString(),
         tokenPrice.usdPrice.toString(),
         amount.toString(),
-        liquidityBoundPriceUSD.toString(),
-        tokenAddress.toHexString(),
         liquidity.toString(),
+        liquidityBoundPriceUSD.toString(),
       ]
     );
   }

--- a/subgraphs/optimism-bridge-v2/src/sdk/protocols/bridge/pool.ts
+++ b/subgraphs/optimism-bridge-v2/src/sdk/protocols/bridge/pool.ts
@@ -26,7 +26,6 @@ import {
   BIGINT_ZERO,
   RewardTokenType,
 } from "../../util/constants";
-import { bigIntToBigDecimal } from "../../util/numbers";
 import { BridgePoolType, CrosschainTokenType, TransactionType } from "./enums";
 import { PoolSnapshot } from "./poolSnapshot";
 import { Bridge } from "./protocol";


### PR DESCRIPTION
- Mis-pricing of depler (DPR) token due to low liquidity: https://dexscreener.com/ethereum/0xa14d7186a935a1f07ca247fa9363a8e45e8b68e9
- Fix: 
  - there was a decimal issue in uniswap router's liquidity calculation, fixed for all usage
  - added oracle order override for delper
  ```
  [getLiquidityBoundPrice] token: 0x077416cc6242b3a7d8e42652b8a6a2599fda4a92 (reported price * amount): (43.166591 * 4999999973.145014051472408216) bound to available liquidity: 965.30624801568125952580534; new price: 0.0000001930612506400676865339973194571663
  ```
  - Updated the function `getInputTokenAmountPrice` to separately set a single token's price and its amount multiple
- Deployments:
  - arbitrum-one-bridge-ethereum: https://okgraph.xyz/?q=dhruv-chauhan%2Farbitrum-one-bridge-ethereum
- Other affected subgraphs:
  - arbitrum-one-bridge-arbitrum: https://okgraph.xyz/?q=dhruv-chauhan%2Farbitrum-one-bridge-arbitrum
  - lido-ethereum: https://okgraph.xyz/?q=dhruv-chauhan%2Flido-ethereum
  - optimism-bridge-v2-ethereum: https://okgraph.xyz/?q=dhruv-chauhan%2Foptimism-bridge-v2-ethereum
  - optimism-bridge-v2-optimism: https://okgraph.xyz/?q=dhruv-chauhan%2Foptimism-bridge-v2-optimism