### PR TITLE
fix(#patch); arrakis-finance; skip creating gauge for v2 pools

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -594,7 +594,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.2.0",
+          "subgraph": "1.2.1",
           "methodology": "1.0.0"
         },
         "files": {
@@ -620,7 +620,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.2",
           "methodology": "1.0.0"
         },
         "files": {
@@ -642,7 +642,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.1.1",
+          "subgraph": "1.1.2",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/arrakis-finance/package.json
+++ b/subgraphs/arrakis-finance/package.json
@@ -5,12 +5,10 @@
     "codegen": "graph codegen"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.30.1",
-    "@graphprotocol/graph-ts": "0.27.0"
+    "@graphprotocol/graph-cli": "^0.57.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "gluegun": "^5.1.2",
-    "mustache": "^4.2.0",
-    "prettier": "^2.7.1"
+    "prettier": "^3.0.3"
   }
 }

--- a/subgraphs/arrakis-finance/protocols/arrakis-finance/config/templates/arrakis.finance.template.yaml
+++ b/subgraphs/arrakis-finance/protocols/arrakis-finance/config/templates/arrakis.finance.template.yaml
@@ -59,6 +59,8 @@ dataSources:
       abis:
         - name: GaugeRegistry
           file: ./abis/GaugeRegistry.json
+        - name: ArrakisVaultV1
+          file: ./abis/ArrakisVaultV1.json
         - name: LiquidityGaugeV4
           file: ./abis/LiquidityGaugeV4.json
         - name: ERC20

--- a/subgraphs/arrakis-finance/src/mappings/handlers/liquidityGauge.ts
+++ b/subgraphs/arrakis-finance/src/mappings/handlers/liquidityGauge.ts
@@ -10,7 +10,7 @@ import {
   RewardDataUpdate,
   LiquidityGaugeV4 as GaugeContract,
 } from "../../../generated/templates/LiquidityGauge/LiquidityGaugeV4";
-import { ArrakisVaultV1 as VaultV1Contract } from "../../../generated/templates/ArrakisVault/ArrakisVaultV1";
+import { ArrakisVaultV1 as VaultV1Contract } from "../../../generated/GaugeRegistry/ArrakisVaultV1";
 import {
   getOrCreateLiquidityGauge,
   removeRewardToken,

--- a/subgraphs/arrakis-finance/src/mappings/handlers/liquidityGauge.ts
+++ b/subgraphs/arrakis-finance/src/mappings/handlers/liquidityGauge.ts
@@ -10,6 +10,7 @@ import {
   RewardDataUpdate,
   LiquidityGaugeV4 as GaugeContract,
 } from "../../../generated/templates/LiquidityGauge/LiquidityGaugeV4";
+import { ArrakisVaultV1 as VaultV1Contract } from "../../../generated/templates/ArrakisVault/ArrakisVaultV1";
 import {
   getOrCreateLiquidityGauge,
   removeRewardToken,
@@ -23,10 +24,20 @@ import { RewardTokenType } from "../../common/constants";
 import { getOrCreateRewardToken, getOrCreateToken } from "../../common/getters";
 
 export function handleAddGauge(event: AddGauge): void {
+  const vaultAddress = event.params.vault;
+  const vaultContract = VaultV1Contract.bind(vaultAddress);
+  const poolCall = vaultContract.try_pool();
+  if (poolCall.reverted) {
+    log.warning(
+      "[handleAddGauge] Probably not a V1 vault: {}; ignoring creating gauge. V2 is not supported yet.",
+      [vaultAddress.toHexString()]
+    );
+    return;
+  }
+
   const gaugeAddress = event.params.gauge;
   LiquidityGaugeTemplate.create(gaugeAddress);
 
-  const vaultAddress = event.params.vault;
   const gauge = getOrCreateLiquidityGauge(gaugeAddress);
   gauge.vault = vaultAddress.toHexString();
   gauge.save();


### PR DESCRIPTION
- Error: 
  - `vaultContract.pool() failed for vault: 0x5ee3148bfc8b449b9e565178927b1a6028adc49a`
- Cause:
  - Arrakis Finance team has been testing out V2 contracts privately.
  - The vault in the log above is a V2 vault and does not have read method `pool`.
  - V2 will have a different Vault Factory contract but a common Gauge Registry contract.
- Fix: 
  - For now we will skip creating gauge for V2 vaults. We shall  add support for V2 as it's rolled out.
- Deployments:
  - https://okgraph.xyz/?q=dhruv-chauhan%2Farrakis-finance-optimism
  - https://okgraph.xyz/?q=dhruv-chauhan%2Farrakis-finance-polygon
  - https://okgraph.xyz/?q=dhruv-chauhan%2Farrakis-finance-ethereum