### PR TITLE
fix(#patch); baseswap; fix pool tvl, fees

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -5300,7 +5300,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.0",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-forks/protocols/baseswap/README.md
+++ b/subgraphs/uniswap-forks/protocols/baseswap/README.md
@@ -8,9 +8,10 @@ When users make a token swap (trade) in the Exchange tab, a trading fee is charg
 
 ## Baseswap Trading Fees & Breakdown
 
-- 0.25% - Trade Fees
+- 0.25% - Trading Fees
+  - 0.17% - Supply Fees
+  - 0.08% - Protocol Fee
 - 0% - LP Reward for Liquidity Providers
-- 0.25% - Protocol Fee
 
 LP providers earn rewards for staking LP tokens
 
@@ -22,7 +23,7 @@ Sum across all Pools: `Liquidity Pool TVL`
 
 ### Total Revenue USD
 
-Sum across all Pools: `Pool Swap Trading Volume * Trading Fee`
+Sum across all Pools: `Pool Swap Trading Volume * Supply Fee`
 
 ### Protocol-Side Revenue USD
 
@@ -32,7 +33,7 @@ Sum across all Pools: `Pool Swap Trading Volume * Protocol Fee`
 
 Portion of the Total Revenue allocated to the Supply-Side (LPs).
 
-Sum across all Pools: `Pool Swap Trading Volume * Trading Fee`
+Sum across all Pools: `Pool Swap Trading Volume * Supply Fee`
 
 ### Total Unique Users
 

--- a/subgraphs/uniswap-forks/protocols/baseswap/config/deployments/baseswap-base/configurations.ts
+++ b/subgraphs/uniswap-forks/protocols/baseswap/config/deployments/baseswap-base/configurations.ts
@@ -46,11 +46,11 @@ export class BaseswapBaseConfigurations implements Configurations {
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getTradeFee(blockNumber: BigInt): BigDecimal {
-    return BigDecimal.fromString("0.25");
+    return BigDecimal.fromString("0.17");
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getProtocolFeeToOn(blockNumber: BigInt): BigDecimal {
-    return BigDecimal.fromString("0.25");
+    return BigDecimal.fromString("0.08");
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getLPFeeToOn(blockNumber: BigInt): BigDecimal {
@@ -84,12 +84,16 @@ export class BaseswapBaseConfigurations implements Configurations {
       "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22", // coinbase wsETH
       "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca", // usdc
       "0x50c5725949a6f0c72e6c4a641f24049a917db0cb", // dai
+      "0x65a2508c429a6078a7bc2f7df81ab575bd9d9275", // dai+
+      "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376", // usd+
     ];
   }
   getStableCoins(): string[] {
     return [
       "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca", // USDC
       "0x50c5725949a6f0c72e6c4a641f24049a917db0cb", // DAI
+      "0x65a2508c429a6078a7bc2f7df81ab575bd9d9275", // DAI+
+      "0xb79dd08ea68a908a97220c76d19a6aa9cbde4376", // USD+
     ];
   }
   getStableOraclePools(): string[] {
@@ -98,7 +102,9 @@ export class BaseswapBaseConfigurations implements Configurations {
     ];
   }
   getUntrackedPairs(): string[] {
-    return [];
+    return [
+      "0xda2e677649dd670dac5db2d0df06c97c0a92b40d", // Wrapped Ether/BaseHarryPotterObamaSonic10Inu
+    ];
   }
   getUntrackedTokens(): string[] {
     return [];

--- a/subgraphs/uniswap-forks/src/mappings/pool.ts
+++ b/subgraphs/uniswap-forks/src/mappings/pool.ts
@@ -1,3 +1,4 @@
+import { dataSource } from "@graphprotocol/graph-ts";
 import {
   Mint,
   Burn,
@@ -25,6 +26,7 @@ import {
 import {
   BIGINT_THOUSAND,
   BIGINT_ZERO,
+  Network,
   UsageType,
   ZERO_ADDRESS,
 } from "../common/constants";
@@ -41,6 +43,14 @@ export function handleTransfer(event: Transfer): void {
     event.params.to.toHexString() == ZERO_ADDRESS &&
     event.params.value.equals(BIGINT_THOUSAND) &&
     pool.outputTokenSupply! == BIGINT_ZERO
+  ) {
+    return;
+  }
+  // ignore initial liquidity lock up for baseswap BSWAP-ETH pool
+  if (
+    dataSource.network() == Network.BASE &&
+    event.transaction.hash.toHexString() ==
+      "0x8fe53fa234ff89bed2ca6cb2c5528f53a6e5e3df313279d694421f4cef8cc4b2"
   ) {
     return;
   }


### PR DESCRIPTION
1. TVL mismatch
  - For WETH/BSWAP, there was an initial liquidity lock up of ~$450k in the WETH/BSWAP for token's initial liquidity, which is not counted in pool's liquidity; ignoring [transaction](https://basescan.org/tx/0x8fe53fa234ff89bed2ca6cb2c5528f53a6e5e3df313279d694421f4cef8cc4b2).
  - For DAI+/USD+, DAI+ token was not whitelisted; added.
2. Revenues
  - Protocol incurs a total swap fee of 0.25% - 0.17% to supply side, 0.08% to treasury. Updated.

---
Deployment: https://okgraph.xyz/?q=dhruv-chauhan%2Fbaseswap-base