### PR TITLE
fix(#patch); pancakeswap-v2-swap; add check for token.decimals

### DIFF
--- a/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.json
+++ b/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.json
@@ -5,7 +5,7 @@
     "address": "0xca143ce32fe78f1f7019d7d551a6402fc5350c73",
     "startBlock": 6809737
   },
-  "graftEnabled": true,
-  "subgraphId": "Qmcye3y4H9FkUqf3UVXocTYJoA7FxGGpaqbzvxLtnbktAi",
-  "graftStartBlock": 27671763
+  "graftEnabled": false,
+  "subgraphId": "",
+  "graftStartBlock": 0
 }

--- a/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.json
+++ b/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.json
@@ -5,7 +5,7 @@
     "address": "0xca143ce32fe78f1f7019d7d551a6402fc5350c73",
     "startBlock": 6809737
   },
-  "graftEnabled": false,
-  "subgraphId": "",
-  "graftStartBlock": 0
+  "graftEnabled": true,
+  "subgraphId": "Qmcye3y4H9FkUqf3UVXocTYJoA7FxGGpaqbzvxLtnbktAi",
+  "graftStartBlock": 27671763
 }

--- a/subgraphs/uniswap-forks-swap/src/common/constants.ts
+++ b/subgraphs/uniswap-forks-swap/src/common/constants.ts
@@ -105,3 +105,6 @@ export const MS_PER_YEAR = DAYS_PER_YEAR.times(
 );
 
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export const EXPONENT_MIN = -6143;
+export const EXPONENT_MAX = 6144;

--- a/subgraphs/uniswap-forks-swap/src/common/creators.ts
+++ b/subgraphs/uniswap-forks-swap/src/common/creators.ts
@@ -11,6 +11,8 @@ import {
   BIGDECIMAL_FIFTY_PERCENT,
   BIGINT_NEG_ONE,
   BIGINT_ZERO,
+  EXPONENT_MIN,
+  EXPONENT_MAX,
 } from "./constants";
 import {
   getLiquidityPool,
@@ -96,10 +98,10 @@ export function createSwap(
   const token1 = getOrCreateToken(pool.inputTokens[1]);
 
   if (
-    token0.decimals < -6143 ||
-    token0.decimals > 6144 ||
-    token0.decimals < -6143 ||
-    token1.decimals > 6144
+    token0.decimals < EXPONENT_MIN ||
+    token0.decimals > EXPONENT_MAX ||
+    token0.decimals < EXPONENT_MIN ||
+    token1.decimals > EXPONENT_MAX
   ) {
     // If decimals for any of the input tokens are not in range [-6143, 6144]. Ignore it.
     // https://github.com/messari/subgraphs/issues/2375

--- a/subgraphs/uniswap-forks-swap/src/common/creators.ts
+++ b/subgraphs/uniswap-forks-swap/src/common/creators.ts
@@ -95,6 +95,21 @@ export function createSwap(
   const token0 = getOrCreateToken(pool.inputTokens[0]);
   const token1 = getOrCreateToken(pool.inputTokens[1]);
 
+  if (
+    token0.decimals < -6143 ||
+    token0.decimals > 6144 ||
+    token0.decimals < -6143 ||
+    token1.decimals > 6144
+  ) {
+    // If decimals for any of the input tokens are not in range [-6143, 6144]. Ignore it.
+    // https://github.com/messari/subgraphs/issues/2375
+    log.error(
+      "Decimals for token(s) out of range - Invalid Swap: token0: {} token1: {}",
+      [token0.id, token1.id]
+    );
+    return;
+  }
+
   // totals for volume updates
   const amount0 = amount0In.minus(amount0Out);
   const amount1 = amount1In.minus(amount1Out);


### PR DESCRIPTION
- Issue: converting raw amount to token decimal terms fails 
  - with error, `big decimal exponent 6145 is outside the -6143 to 6144 range`
  - for token, https://bscscan.com/address/0x6a204b19b8273f346381B476BCAAd6B7b0D71fbd
- Fix: ignore swap events if token decimals out of range [-6143, 6144]
- Deployment: https://okgraph.xyz/?q=dhruv-chauhan%2Fpancakeswap-v2-swap