### PR TITLE
fix(#patch); Maker Governance; avoid lifting inactive spells

### DIFF
--- a/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
+++ b/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+
 import { BigInt, Bytes, Address, ethereum, log } from "@graphprotocol/graph-ts";
 import { LogNote, Etch } from "../../../generated/DSChief/DSChief";
 import { VoteDelegate } from "../../../generated/DSChief/VoteDelegate";

--- a/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
+++ b/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
@@ -187,7 +187,7 @@ export function handleLift(event: LogNote): void {
   const spellID = Address.fromString(event.params.foo.toHexString().slice(26));
 
   const spell = Spell.load(spellID.toHexString());
-  if (!spell) return;
+  if (!spell || spell.state != SpellState.ACTIVE) return;
   spell.state = SpellState.LIFTED;
   spell.liftedTxnHash = event.transaction.hash.toHexString();
   spell.liftedBlock = event.block.number;


### PR DESCRIPTION
### Description

The correct progression for a maker proposal/spell is active->lifted->scheduled->cast. But a few older proposals were getting lifted after casting, resulting in the end state being inaccurate.