### PR TITLE
fix(#patch); pancakeswap-v2-swap; check if tokenContract.decimals return i32

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -4884,7 +4884,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.1",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -5462,7 +5462,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.2",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -5526,7 +5526,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.1",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -5556,7 +5556,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.0.0",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-forks-swap/src/common/constants.ts
+++ b/subgraphs/uniswap-forks-swap/src/common/constants.ts
@@ -94,6 +94,9 @@ export const BIGDECIMAL_TEN = new BigDecimal(BIGINT_TEN);
 export const BIGDECIMAL_HUNDRED = new BigDecimal(BIGINT_HUNDRED);
 
 export const BIGDECIMAL_FIFTY_PERCENT = new BigDecimal(BIGINT_FIFTY);
+export const MAX_INT32 = BigInt.fromI32(2)
+  .times(BigInt.fromI32(31))
+  .minus(BIGINT_ONE);
 export const MAX_UINT = BigInt.fromI32(2).times(BigInt.fromI32(255));
 export const DAYS_PER_YEAR = new BigDecimal(BigInt.fromI32(365));
 export const SECONDS_PER_DAY = 60 * 60 * 24;

--- a/subgraphs/uniswap-forks-swap/src/common/creators.ts
+++ b/subgraphs/uniswap-forks-swap/src/common/creators.ts
@@ -41,6 +41,21 @@ export function createLiquidityPool(
   // create the tokens and tokentracker
   const token0 = getOrCreateToken(token0Address);
   const token1 = getOrCreateToken(token1Address);
+  if (
+    token0.decimals < EXPONENT_MIN ||
+    token0.decimals > EXPONENT_MAX ||
+    token0.decimals < EXPONENT_MIN ||
+    token1.decimals > EXPONENT_MAX
+  ) {
+    // If decimals for any of the input tokens are not in range [-6143, 6144]. Ignore it.
+    // https://github.com/messari/subgraphs/issues/2375
+    log.error(
+      "Decimals for token(s) out of range - Ignore creating pair: token0: {} token1: {}",
+      [token0.id, token1.id]
+    );
+    return;
+  }
+
   const LPtoken = getOrCreateLPToken(poolAddress, token0, token1);
 
   const pool = new LiquidityPool(poolAddress);
@@ -96,21 +111,6 @@ export function createSwap(
 
   const token0 = getOrCreateToken(pool.inputTokens[0]);
   const token1 = getOrCreateToken(pool.inputTokens[1]);
-
-  if (
-    token0.decimals < EXPONENT_MIN ||
-    token0.decimals > EXPONENT_MAX ||
-    token0.decimals < EXPONENT_MIN ||
-    token1.decimals > EXPONENT_MAX
-  ) {
-    // If decimals for any of the input tokens are not in range [-6143, 6144]. Ignore it.
-    // https://github.com/messari/subgraphs/issues/2375
-    log.error(
-      "Decimals for token(s) out of range - Invalid Swap: token0: {} token1: {}",
-      [token0.id, token1.id]
-    );
-    return;
-  }
 
   // totals for volume updates
   const amount0 = amount0In.minus(amount0Out);

--- a/subgraphs/uniswap-forks-swap/src/common/getters.ts
+++ b/subgraphs/uniswap-forks-swap/src/common/getters.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 
 import { NetworkConfigs } from "../../configurations/configure";
 import { Versions } from "../versions";
@@ -7,6 +7,7 @@ import {
   BIGINT_ZERO,
   DEFAULT_DECIMALS,
   INT_ZERO,
+  MAX_INT32,
   ProtocolType,
 } from "./constants";
 
@@ -62,7 +63,10 @@ export function getOrCreateToken(address: string): Token {
       const symbolCall = erc20Contract.try_symbol();
       if (!symbolCall.reverted) symbol = symbolCall.value;
       const decimalsCall = erc20Contract.try_decimals();
-      if (!decimalsCall.reverted) decimals = decimalsCall.value;
+      if (!decimalsCall.reverted)
+        decimals = BigInt.fromString(decimalsCall.value.toString()).isI32()
+          ? decimalsCall.value
+          : MAX_INT32.toI32();
     }
 
     token.name = name;


### PR DESCRIPTION
- Issue: 
  - Decimals for [token - CoinToken](https://bscscan.com/address/0xFBBd78a1Bf76E43D5FC8f1f880F72718040ACbE5) is set to `1370893090329243333764287979126883543363385161129`, which exceeds i32 range.
- Fix:
  - While creating pair, check if `tokenContract.decimals.i32()`. If not, set decimals to MAX_INT32 and further ignore creating pair.
- Deployment: https://okgraph.xyz/?q=dhruv-chauhan%2Fpancakeswap-v2-swap