### PR TITLE
Add spark-lend on gnosis

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3666,10 +3666,6 @@
           "hosted-service": {
             "slug": "spark-lend-gnosis",
             "query-id": "spark-lend-gnosis"
-          },
-          "decentralized-network": {
-            "slug": "not-deployed",
-            "query-id": "not-deployed"
           }
         }
       }

--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3646,6 +3646,32 @@
             "query-id": "GbKdmBe4ycCYCQLQSjqGg6UHYoYfbyJyq5WrG35pv1si"
           }
         }
+      },
+      "spark-lend-gnosis": {
+        "network": "gnosis",
+        "status": "prod",
+        "versions": {
+          "schema": "3.1.0",
+          "subgraph": "2.0.5",
+          "methodology": "1.0.0"
+        },
+        "files": {
+          "template": "spark.lend.template.yaml"
+        },
+        "options": {
+          "prepare:yaml": true,
+          "prepare:constants": false
+        },
+        "services": {
+          "hosted-service": {
+            "slug": "spark-lend-gnosis",
+            "query-id": "spark-lend-gnosis"
+          },
+          "decentralized-network": {
+            "slug": "not-deployed",
+            "query-id": "not-deployed"
+          }
+        }
       }
     }
   },

--- a/subgraphs/aave-forks/protocols/spark-lend/config/deployments/spark-lend-gnosis/configurations.json
+++ b/subgraphs/aave-forks/protocols/spark-lend/config/deployments/spark-lend-gnosis/configurations.json
@@ -1,0 +1,22 @@
+{
+  "network": "gnosis",
+  "factory": {
+    "startBlock": "29817453",
+    "address": "0xA98DaCB3fC964A6A0d2ce3B77294241585EAbA6d"
+  },
+  "lendingPoolConfigurator": {
+    "startBlock": "29817457",
+    "address": "0x2Fc8823E1b967D474b47Ae0aD041c2ED562ab588"
+  },
+  "lendingPool": {
+    "startBlock": "29817457",
+    "address": "0x2Dae5307c5E3FD1CF5A72Cb6F698f915860607e0"
+  },
+  "RewardsController": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "startBlock": "29817457"
+  },
+  "graftEnabled": false,
+  "subgraphId": "",
+  "graftStartBlock": ""
+}

--- a/subgraphs/aave-forks/protocols/spark-lend/src/constants.ts
+++ b/subgraphs/aave-forks/protocols/spark-lend/src/constants.ts
@@ -44,6 +44,11 @@ export function getNetworkSpecificConstant(): NetworkSpecificConstant {
       Address.fromString("0x03cfa0c4622ff84e50e75062683f44c9587e6cc1"),
       Network.MAINNET
     );
+  } else if (equalsIgnoreCase(network, Network.GNOSIS)) {
+    return new NetworkSpecificConstant(
+      Address.fromString("0xa98dacb3fc964a6a0d2ce3b77294241585eaba6d"),
+      Network.GNOSIS,
+    );
   } else {
     log.critical("[getNetworkSpecificConstant] Unsupported network: {}", [
       network,

--- a/subgraphs/aave-forks/src/constants.ts
+++ b/subgraphs/aave-forks/src/constants.ts
@@ -25,7 +25,7 @@ export namespace Network {
   export const OPTIMISM = "OPTIMISM";
   export const OSMOSIS = "OSMOSIS";
   export const MATIC = "MATIC"; // aka Polygon
-  export const XDAI = "XDAI"; // aka Gnosis Chain
+  export const GNOSIS = "GNOSIS"; // aka xDAI
 
   export const METIS = "ANDROMEDA";
   export const BASE = "BASE";

--- a/subgraphs/aave-forks/src/sdk/constants.ts
+++ b/subgraphs/aave-forks/src/sdk/constants.ts
@@ -30,7 +30,7 @@ export namespace Network {
   export const OPTIMISM = "OPTIMISM";
   export const OSMOSIS = "OSMOSIS";
   export const MATIC = "MATIC"; // aka Polygon
-  export const XDAI = "XDAI"; // aka Gnosis Chain
+  export const GNOSIS = "GNOSIS"; // aka xDAI
 }
 
 export namespace ProtocolType {


### PR DESCRIPTION
* Adds gnosis chain deployment of Spark Lend
* Renames xDAI to Gnosis constant (AFAIK it wasn't used anyway)


[Hosted service deployment](https://thegraph.com/hosted-service/subgraph/krzkaczor/spark-lend-gnosis)
[Sparklend Gnosis Deployment Info](https://github.com/marsfoundation/sparklend/pull/31/files#diff-41e7bb259a6845eb0ebd1ff79702654d67672ded6b28c8aff722d825120b229c)