### PR TITLE
chore(); remove magic number checker

### DIFF
--- a/subgraphs/.eslintrc.js
+++ b/subgraphs/.eslintrc.js
@@ -55,15 +55,6 @@ module.exports = {
       },
     ],
 
-    // disallow magic numbers: https://eslint.org/docs/latest/rules/no-magic-numbers
-    "@typescript-eslint/no-magic-numbers": [
-      "error",
-      {
-        ignoreArrayIndexes: true,
-        ignore: [-1, 0, 1, 2],
-      },
-    ],
-
     // CUSTOM RULES, find them in subgraphs/_eslint-rules
     // -----------------------------------------------
 

--- a/subgraphs/_reference_/src/common/tokens.ts
+++ b/subgraphs/_reference_/src/common/tokens.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prefer-const */
 import { ERC20 } from "../../generated/UniswapV2Factory/ERC20";
 import { ERC20SymbolBytes } from "../../generated/UniswapV2Factory/ERC20SymbolBytes";
 import { ERC20NameBytes } from "../../generated/UniswapV2Factory/ERC20NameBytes";
@@ -9,25 +8,25 @@ export const INVALID_TOKEN_DECIMALS = 0;
 export const UNKNOWN_TOKEN_VALUE = "unknown";
 
 export function fetchTokenSymbol(tokenAddress: Address): string {
-  let contract = ERC20.bind(tokenAddress);
-  let contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress);
+  const contract = ERC20.bind(tokenAddress);
+  const contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress);
 
   // try types string and bytes32 for symbol
   let symbolValue = UNKNOWN_TOKEN_VALUE;
-  let symbolResult = contract.try_symbol();
+  const symbolResult = contract.try_symbol();
   if (!symbolResult.reverted) {
     return symbolResult.value;
   }
 
   // non-standard ERC20 implementation
-  let symbolResultBytes = contractSymbolBytes.try_symbol();
+  const symbolResultBytes = contractSymbolBytes.try_symbol();
   if (!symbolResultBytes.reverted) {
     // for broken pairs that have no symbol function exposed
     if (!isNullEthValue(symbolResultBytes.value.toHexString())) {
       symbolValue = symbolResultBytes.value.toString();
     } else {
       // try with the static definition
-      let staticTokenDefinition =
+      const staticTokenDefinition =
         StaticTokenDefinition.fromAddress(tokenAddress);
       if (staticTokenDefinition != null) {
         symbolValue = staticTokenDefinition.symbol;
@@ -39,25 +38,25 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
 }
 
 export function fetchTokenName(tokenAddress: Address): string {
-  let contract = ERC20.bind(tokenAddress);
-  let contractNameBytes = ERC20NameBytes.bind(tokenAddress);
+  const contract = ERC20.bind(tokenAddress);
+  const contractNameBytes = ERC20NameBytes.bind(tokenAddress);
 
   // try types string and bytes32 for name
   let nameValue = UNKNOWN_TOKEN_VALUE;
-  let nameResult = contract.try_name();
+  const nameResult = contract.try_name();
   if (!nameResult.reverted) {
     return nameResult.value;
   }
 
   // non-standard ERC20 implementation
-  let nameResultBytes = contractNameBytes.try_name();
+  const nameResultBytes = contractNameBytes.try_name();
   if (!nameResultBytes.reverted) {
     // for broken exchanges that have no name function exposed
     if (!isNullEthValue(nameResultBytes.value.toHexString())) {
       nameValue = nameResultBytes.value.toString();
     } else {
       // try with the static definition
-      let staticTokenDefinition =
+      const staticTokenDefinition =
         StaticTokenDefinition.fromAddress(tokenAddress);
       if (staticTokenDefinition != null) {
         nameValue = staticTokenDefinition.name;
@@ -69,17 +68,17 @@ export function fetchTokenName(tokenAddress: Address): string {
 }
 
 export function fetchTokenDecimals(tokenAddress: Address): i32 {
-  let contract = ERC20.bind(tokenAddress);
+  const contract = ERC20.bind(tokenAddress);
 
   // try types uint8 for decimals
-  let decimalResult = contract.try_decimals();
+  const decimalResult = contract.try_decimals();
   if (!decimalResult.reverted) {
-    let decimalValue = decimalResult.value;
+    const decimalValue = decimalResult.value;
     return decimalValue.toI32();
   }
 
   // try with the static definition
-  let staticTokenDefinition = StaticTokenDefinition.fromAddress(tokenAddress);
+  const staticTokenDefinition = StaticTokenDefinition.fromAddress(tokenAddress);
   if (staticTokenDefinition != null) {
     return staticTokenDefinition.decimals as i32;
   } else {
@@ -111,10 +110,10 @@ class StaticTokenDefinition {
 
   // Get all tokens with a static defintion
   static getStaticDefinitions(): Array<StaticTokenDefinition> {
-    let staticDefinitions = new Array<StaticTokenDefinition>(INT_SIX);
+    const staticDefinitions = new Array<StaticTokenDefinition>(INT_SIX);
 
     // Add DGD
-    let tokenDGD = new StaticTokenDefinition(
+    const tokenDGD = new StaticTokenDefinition(
       Address.fromString("0xe0b7927c4af23765cb51314a0e0521a9645f0e2a"),
       "DGD",
       "DGD",
@@ -123,7 +122,7 @@ class StaticTokenDefinition {
     staticDefinitions.push(tokenDGD);
 
     // Add AAVE
-    let tokenAAVE = new StaticTokenDefinition(
+    const tokenAAVE = new StaticTokenDefinition(
       Address.fromString("0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9"),
       "AAVE",
       "Aave Token",
@@ -132,7 +131,7 @@ class StaticTokenDefinition {
     staticDefinitions.push(tokenAAVE);
 
     // Add LIF
-    let tokenLIF = new StaticTokenDefinition(
+    const tokenLIF = new StaticTokenDefinition(
       Address.fromString("0xeb9951021698b42e4399f9cbb6267aa35f82d59d"),
       "LIF",
       "Lif",
@@ -141,7 +140,7 @@ class StaticTokenDefinition {
     staticDefinitions.push(tokenLIF);
 
     // Add SVD
-    let tokenSVD = new StaticTokenDefinition(
+    const tokenSVD = new StaticTokenDefinition(
       Address.fromString("0xbdeb4b83251fb146687fa19d1c660f99411eefe3"),
       "SVD",
       "savedroid",
@@ -150,7 +149,7 @@ class StaticTokenDefinition {
     staticDefinitions.push(tokenSVD);
 
     // Add TheDAO
-    let tokenTheDAO = new StaticTokenDefinition(
+    const tokenTheDAO = new StaticTokenDefinition(
       Address.fromString("0xbb9bc244d798123fde783fcc1c72d3bb8c189413"),
       "TheDAO",
       "TheDAO",
@@ -159,7 +158,7 @@ class StaticTokenDefinition {
     staticDefinitions.push(tokenTheDAO);
 
     // Add HPB
-    let tokenHPB = new StaticTokenDefinition(
+    const tokenHPB = new StaticTokenDefinition(
       Address.fromString("0x38c6a68304cdefb9bec48bbfaaba5c5b47818bb2"),
       "HPB",
       "HPBCoin",
@@ -172,12 +171,12 @@ class StaticTokenDefinition {
 
   // Helper for hardcoded tokens
   static fromAddress(tokenAddress: Address): StaticTokenDefinition | null {
-    let staticDefinitions = this.getStaticDefinitions();
-    let tokenAddressHex = tokenAddress.toHexString();
+    const staticDefinitions = this.getStaticDefinitions();
+    const tokenAddressHex = tokenAddress.toHexString();
 
     // Search the definition using the address
     for (let i = 0; i < staticDefinitions.length; i++) {
-      let staticDefinition = staticDefinitions[i];
+      const staticDefinition = staticDefinitions[i];
       if (staticDefinition.address.toHexString() == tokenAddressHex) {
         return staticDefinition;
       }

--- a/subgraphs/_reference_/src/common/utils/datetime.ts
+++ b/subgraphs/_reference_/src/common/utils/datetime.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers */
 import { BigInt } from "@graphprotocol/graph-ts";
 import { SECONDS_PER_DAY } from "../constants";
 

--- a/subgraphs/_reference_/src/common/utils/strings.ts
+++ b/subgraphs/_reference_/src/common/utils/strings.ts
@@ -1,10 +1,8 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers */
 import { BigInt } from "@graphprotocol/graph-ts";
 
 export function hexToNumberString(hex: string): string {
   let hexNumber = BigInt.fromI32(0);
 
-  /* eslint-disable-next-line rulesdir/no-string-literals */
   if (hex.startsWith("0x")) {
     hex = hex.slice(2);
   }

--- a/subgraphs/_reference_/src/prices/config/arbitrum.ts
+++ b/subgraphs/_reference_/src/prices/config/arbitrum.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/aurora.ts
+++ b/subgraphs/_reference_/src/prices/config/aurora.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/avalanche.ts
+++ b/subgraphs/_reference_/src/prices/config/avalanche.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/bsc.ts
+++ b/subgraphs/_reference_/src/prices/config/bsc.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/celo.ts
+++ b/subgraphs/_reference_/src/prices/config/celo.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/cronos.ts
+++ b/subgraphs/_reference_/src/prices/config/cronos.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/fantom.ts
+++ b/subgraphs/_reference_/src/prices/config/fantom.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/fuse.ts
+++ b/subgraphs/_reference_/src/prices/config/fuse.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/gnosis.ts
+++ b/subgraphs/_reference_/src/prices/config/gnosis.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/harmony.ts
+++ b/subgraphs/_reference_/src/prices/config/harmony.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/moonbeam.ts
+++ b/subgraphs/_reference_/src/prices/config/moonbeam.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/optimism.ts
+++ b/subgraphs/_reference_/src/prices/config/optimism.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/polygon.ts
+++ b/subgraphs/_reference_/src/prices/config/polygon.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { BigInt, Address, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/config/template.ts
+++ b/subgraphs/_reference_/src/prices/config/template.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as constants from "../common/constants";
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Configurations, OracleConfig, OracleContract } from "../common/types";

--- a/subgraphs/_reference_/src/prices/routers/UniswapForksRouter.ts
+++ b/subgraphs/_reference_/src/prices/routers/UniswapForksRouter.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers */
 import * as utils from "../common/utils";
 import * as constants from "../common/constants";
 import { CustomPriceType } from "../common/types";

--- a/subgraphs/_reference_/src/sdk/protocols/bridge/chainIds.ts
+++ b/subgraphs/_reference_/src/sdk/protocols/bridge/chainIds.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers */
 import { BigInt, TypedMap } from "@graphprotocol/graph-ts";
 import { Network } from "../../util/constants";
 


### PR DESCRIPTION
I am proposing to remove the magic number lint checker rule. We added this in to try and button up our code more.

However, magic numbers are needed in a lot of cases when building subgraphs (such as block numbers, pricing mechanisms, configs). And there are too many use edge cases to try and create a custom rule (we will always be one step behind).

We ended up just ignoring the rule too many time. 