### PR TITLE
fix(); perps-schema; allow multiple liquidations per position

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2783,8 +2783,8 @@
         "network": "fantom",
         "status": "prod",
         "versions": {
-          "schema": "1.3.3",
-          "subgraph": "1.0.1",
+          "schema": "1.3.4",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -2809,8 +2809,8 @@
         "network": "optimism",
         "status": "prod",
         "versions": {
-          "schema": "1.3.3",
-          "subgraph": "1.0.1",
+          "schema": "1.3.4",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -2831,8 +2831,8 @@
         "network": "arbitrum",
         "status": "prod",
         "versions": {
-          "schema": "1.3.3",
-          "subgraph": "1.0.1",
+          "schema": "1.3.4",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -8945,8 +8945,8 @@
         "network": "arbitrum",
         "status": "prod",
         "versions": {
-          "schema": "1.3.3",
-          "subgraph": "1.1.3",
+          "schema": "1.3.4",
+          "subgraph": "1.2.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -8971,8 +8971,8 @@
         "network": "avalanche",
         "status": "prod",
         "versions": {
-          "schema": "1.3.3",
-          "subgraph": "1.1.3",
+          "schema": "1.3.4",
+          "subgraph": "1.2.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -9178,7 +9178,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.1",
-          "subgraph": "1.0.1",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -9204,7 +9204,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.1",
-          "subgraph": "1.0.1",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -9298,7 +9298,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.1",
-          "subgraph": "1.0.0",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -9324,7 +9324,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.1",
-          "subgraph": "1.0.0",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -9350,7 +9350,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.1",
-          "subgraph": "1.0.0",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -9372,7 +9372,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.1",
-          "subgraph": "1.0.0",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -9398,7 +9398,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.1",
-          "subgraph": "1.0.0",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -9457,8 +9457,8 @@
         "network": "bsc",
         "status": "prod",
         "versions": {
-          "schema": "1.3.1",
-          "subgraph": "1.0.2",
+          "schema": "1.3.4",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {
@@ -9479,8 +9479,8 @@
         "network": "arbitrum",
         "status": "prod",
         "versions": {
-          "schema": "1.3.1",
-          "subgraph": "1.0.2",
+          "schema": "1.3.4",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "services": {

--- a/schema-derivatives-perpfutures.graphql
+++ b/schema-derivatives-perpfutures.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Derivatives Perpetual Futures
-# Version: 1.3.3
+# Version: 1.3.4
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -1892,7 +1892,7 @@ type Position @entity @regularPolling {
   collateralOutCount: Int!
 
   " Liquidation event related to this position (if exists) "
-  liquidation: Liquidate @derivedFrom(field: "position")
+  liquidation: [Liquidate!] @derivedFrom(field: "position")
 
   " Number of liquidations related to this position "
   liquidationCount: Int!

--- a/subgraphs/gains-trade/package.json
+++ b/subgraphs/gains-trade/package.json
@@ -5,11 +5,11 @@
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/deployments/${npm_config_id}/configurations.json configurations/configure.mustache > configurations/configure.ts"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.37.0",
-    "@graphprotocol/graph-ts": "^0.29.0",
+    "@graphprotocol/graph-cli": "^0.60.0",
+    "@graphprotocol/graph-ts": "^0.31.0",
     "mustache": "^4.2.0"
   },
   "devDependencies": {
-    "prettier": "^2.7.1"
+    "prettier": "^3.0.3"
   }
 }

--- a/subgraphs/gains-trade/schema.graphql
+++ b/subgraphs/gains-trade/schema.graphql
@@ -1886,7 +1886,7 @@ type Position @entity @regularPolling {
   collateralOutCount: Int!
 
   " Liquidation event related to this position (if exists) "
-  liquidation: Liquidate @derivedFrom(field: "position")
+  liquidation: [Liquidate!] @derivedFrom(field: "position")
 
   " Number of liquidations related to this position "
   liquidationCount: Int!

--- a/subgraphs/gmx-forks/package.json
+++ b/subgraphs/gmx-forks/package.json
@@ -6,7 +6,7 @@
     "deploy": "graph deploy --product hosted-service shashwats22/mummy-finance-arbitrum"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.51.1",
+    "@graphprotocol/graph-cli": "^0.60.0",
     "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {

--- a/subgraphs/gmx-forks/schema.graphql
+++ b/subgraphs/gmx-forks/schema.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Derivatives Perpetual Futures
-# Version: 1.3.3
+# Version: 1.3.4
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -1895,7 +1895,7 @@ type Position @entity @regularPolling {
   collateralOutCount: Int!
 
   " Liquidation event related to this position (if exists) "
-  liquidation: Liquidate @derivedFrom(field: "position")
+  liquidation: [Liquidate!] @derivedFrom(field: "position")
 
   " Number of liquidations related to this position "
   liquidationCount: Int!

--- a/subgraphs/level-finance/package.json
+++ b/subgraphs/level-finance/package.json
@@ -5,8 +5,8 @@
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/deployments/${npm_config_id}/configurations.json src/common/constants.mustache > src/common/constants.ts"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.54.0",
-    "@graphprotocol/graph-ts": "0.29.1"
+    "@graphprotocol/graph-cli": "^0.60.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
     "matchstick-as": "0.5.0"

--- a/subgraphs/level-finance/schema.graphql
+++ b/subgraphs/level-finance/schema.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Derivatives Perpetual Futures
-# Version: 1.3.3
+# Version: 1.3.4
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -1901,7 +1901,7 @@ type Position @entity @regularPolling {
   collateralOutCount: Int!
 
   " Liquidation event related to this position (if exists) "
-  liquidation: Liquidate @derivedFrom(field: "position")
+  liquidation: [Liquidate!] @derivedFrom(field: "position")
 
   " Number of liquidations related to this position "
   liquidationCount: Int!

--- a/subgraphs/mux-protocol/package.json
+++ b/subgraphs/mux-protocol/package.json
@@ -6,10 +6,10 @@
     "prepare:constants": "mustache protocols/${npm_config_protocol}/config/deployments/${npm_config_id}/configurations.json configurations/configure.mustache > configurations/configure.ts"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.39.0",
-    "@graphprotocol/graph-ts": "0.29.0"
+    "@graphprotocol/graph-cli": "^0.60.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "prettier": "^2.6.2"
+    "prettier": "^3.0.3"
   }
 }

--- a/subgraphs/mux-protocol/schema.graphql
+++ b/subgraphs/mux-protocol/schema.graphql
@@ -1876,7 +1876,7 @@ type Position @entity @regularPolling {
   collateralOutCount: Int!
 
   " Liquidation event related to this position (if exists) "
-  liquidation: Liquidate @derivedFrom(field: "position")
+  liquidation: [Liquidate!] @derivedFrom(field: "position")
 
   " Number of liquidations related to this position "
   liquidationCount: Int!


### PR DESCRIPTION
- Issue: 
  - For Gmx, the following [query](https://api.thegraph.com/subgraphs/id/QmYa7FVFgxc2vsGRnvfbcdfU6Q4NXkTwCvPMn3VVnca14T/graphql?query=%7B%0A++positions%7B%0A++++liquidation%7Bid%7D%0A++%7D%0A%7D) fails with message: `"message": "Ambiguous result for derived field 'liquidation': Multiple 'Liquidate' entities refer back via 'position'"`
  - Same is the case with mummy-finance, and level-finance.
- Fix:
  - On tracing a position, we figured that a position can be partially liquidated multiple times, so the assumption in the schema that a position shall only point to one liquidation event is not true. (Trace: [position_logs.md](https://github.com/messari/subgraphs/files/13230701/position_logs.md))
  - Since these liquidation events are getting created fine, it’s only the reference to the position that’s broken due to the constraint. Allowing multiple liquidation references for a position fixes this.
- Deployments:
  - [gmx-arbitrum](https://okgraph.xyz/?q=dhruv-chauhan%2Fgmx-arbitrum)
  - [mummy-finance-optimism](https://okgraph.xyz/?q=dhruv-chauhan%2Fmummy-finance-optimism)
  - [level-finance-bsc](https://okgraph.xyz/?q=dhruv-chauhan%2Flevel-finance-bsc)
  - [gains-trade-arbitrum](https://okgraph.xyz/?q=dhruv-chauhan%2Fgains-trade-arbitrum)
  - [mux-protocol-arbitrum](https://okgraph.xyz/?q=dhruv-chauhan%2Fmux-protocol-arbitrum)

