### PR TITLE
fix(#patch); uniswap-v2-ethereum; add broken ERC20 tokens

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -5428,7 +5428,7 @@
         "status": "dev",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.11",
+          "subgraph": "1.1.12",
           "methodology": "1.0.0"
         },
         "files": {
@@ -5488,7 +5488,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.0",
+          "subgraph": "1.1.1",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-forks-swap/protocols/uniswap-v2-swap/config/deployments/uniswap-v2-swap-ethereum/configurations.json
+++ b/subgraphs/uniswap-forks-swap/protocols/uniswap-v2-swap/config/deployments/uniswap-v2-swap-ethereum/configurations.json
@@ -6,6 +6,6 @@
     "startBlock": 10000834
   },
   "graftEnabled": false,
-  "subgraphId": "",
-  "graftStartBlock": 0
+  "subgraphId": "QmZA6EuUgDPd5KnsefSxJw7RwiYyfTa4FK413eqGtBXD5M",
+  "graftStartBlock": 18746197
 }

--- a/subgraphs/uniswap-forks-swap/protocols/uniswap-v2-swap/config/deployments/uniswap-v2-swap-ethereum/configurations.ts
+++ b/subgraphs/uniswap-forks-swap/protocols/uniswap-v2-swap/config/deployments/uniswap-v2-swap-ethereum/configurations.ts
@@ -33,6 +33,9 @@ export class UniswapV2MainnetConfigurations implements Configurations {
     return "0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f";
   }
   getBrokenERC20Tokens(): string[] {
-    return ["0x0000000000bf2686748e1c0255036e7617e7e8a5"];
+    return [
+      "0x0000000000bf2686748e1c0255036e7617e7e8a5",
+      "0x000000000000b91b6956fead1dda24c66aa6b972",
+    ];
   }
 }

--- a/subgraphs/uniswap-forks/protocols/uniswap-v2/config/deployments/uniswap-v2-ethereum/configurations.json
+++ b/subgraphs/uniswap-forks/protocols/uniswap-v2/config/deployments/uniswap-v2-ethereum/configurations.json
@@ -6,6 +6,6 @@
     "startBlock": 10000834
   },
   "graftEnabled": false,
-  "subgraphId": "QmXztbk3JGtTdqnRSuQEtw5hRHzBNaB323D81hRXnrJvuM",
-  "graftStartBlock": 13148001
+  "subgraphId": "QmbAreB7zPavfTrKQawXJLFqytcqq9bC5WxqBC2b6L5JLR",
+  "graftStartBlock": 17308396
 }

--- a/subgraphs/uniswap-forks/protocols/uniswap-v2/config/deployments/uniswap-v2-ethereum/configurations.ts
+++ b/subgraphs/uniswap-forks/protocols/uniswap-v2/config/deployments/uniswap-v2-ethereum/configurations.ts
@@ -208,7 +208,10 @@ export class UniswapV2MainnetConfigurations implements Configurations {
     ];
   }
   getBrokenERC20Tokens(): string[] {
-    return ["0x0000000000bf2686748e1c0255036e7617e7e8a5"];
+    return [
+      "0x0000000000bf2686748e1c0255036e7617e7e8a5",
+      "0x000000000000b91b6956fead1dda24c66aa6b972",
+    ];
   }
   getMinimumLiquidityThresholdTrackVolume(): BigDecimal {
     return MINIMUM_LIQUIDITY_FOUR_HUNDRED_THOUSAND;


### PR DESCRIPTION
- Issue: uniswap-v2-ethereum / uniswap-v2-swap-ethereum deployments are failing with message: `overflow converting 0x... to i32` inside `getOrCreateToken()` method.
- This is due to [token](https://etherscan.io/address/0x000000000000B91B6956FEAD1dda24c66Aa6b972) with unverified ABI.
- Previously seen: https://github.com/messari/subgraphs/pull/2341
- Deployments:
  - uniswap-v2-swap-ethereum: https://okgraph.xyz/?q=dhruv-chauhan%2Funiswap-v2-swap-ethereum
  - uniswap-v2-ethereum: https://okgraph.xyz/?q=dhruv-chauhan%2Funiswap-v2-ethereum