### PR TITLE
feat(#major); abracadabra; subgraph optimizations

### DIFF
--- a/subgraphs/abracadabra/package-lock.json
+++ b/subgraphs/abracadabra/package-lock.json
@@ -6,37 +6,104 @@
     "": {
       "name": "abracadabra",
       "dependencies": {
-        "@graphprotocol/graph-cli": "0.42.4",
-        "@graphprotocol/graph-ts": "0.29.3",
-        "prettier": "^2.7.1"
+        "@graphprotocol/graph-cli": "^0.64.0",
+        "@graphprotocol/graph-ts": "^0.32.0"
+      },
+      "devDependencies": {
+        "prettier": "^3.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.23.4",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -80,6 +147,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -99,15 +174,15 @@
         "node": ">=4"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz",
-      "integrity": "sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==",
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=12"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -522,42 +597,44 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli": {
-      "version": "0.42.4",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.42.4.tgz",
-      "integrity": "sha512-h6/OkmLSPqP8cji6AMXtq7AWHtgl4nC8wjunHhDBlQiLzdClky3jFe50/xAM9VBs2QV+oXhCflRq26qqO3XBXA==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.64.0.tgz",
+      "integrity": "sha512-JvEL3FvXEhRhEaCAk310h13UothElQgNPt0InjoXJUG+yNexsdJ6Rr1FYCC517Q/b7pfcczT6usSyOgnTgR7FA==",
       "dependencies": {
         "@float-capital/float-subgraph-uncrashable": "^0.0.0-alpha.4",
-        "@oclif/core": "2.0.7",
+        "@oclif/core": "2.8.6",
+        "@oclif/plugin-autocomplete": "^2.3.6",
+        "@oclif/plugin-not-found": "^2.4.0",
+        "@whatwg-node/fetch": "^0.8.4",
         "assemblyscript": "0.19.23",
         "binary-install-raw": "0.0.13",
         "chalk": "3.0.0",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
-        "docker-compose": "0.23.4",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "docker-compose": "0.23.19",
         "dockerode": "2.5.8",
-        "fs-extra": "9.0.0",
-        "glob": "7.1.6",
-        "gluegun": "git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep",
+        "fs-extra": "9.1.0",
+        "glob": "9.3.5",
+        "gluegun": "5.1.2",
         "graphql": "15.5.0",
         "immutable": "4.2.1",
-        "ipfs-http-client": "34.0.0",
-        "jayson": "3.6.6",
-        "js-yaml": "3.13.1",
-        "node-fetch": "2.6.0",
+        "ipfs-http-client": "55.0.0",
+        "jayson": "4.0.0",
+        "js-yaml": "3.14.1",
         "prettier": "1.19.1",
         "request": "2.88.2",
-        "semver": "7.3.5",
+        "semver": "7.4.0",
         "sync-request": "6.1.0",
-        "tmp-promise": "3.0.2",
+        "tmp-promise": "3.0.3",
         "web3-eth-abi": "1.7.0",
         "which": "2.0.2",
-        "yaml": "1.9.2"
+        "yaml": "1.10.2"
       },
       "bin": {
-        "graph": "dist/bin.js"
+        "graph": "bin/run"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/assemblyscript": {
@@ -586,10 +663,57 @@
         "wasm-opt": "bin/wasm-opt"
       }
     },
+    "node_modules/@graphprotocol/graph-cli/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@graphprotocol/graph-cli/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@graphprotocol/graph-cli/node_modules/long": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
       "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+    },
+    "node_modules/@graphprotocol/graph-cli/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@graphprotocol/graph-cli/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/prettier": {
       "version": "1.19.1",
@@ -603,11 +727,59 @@
       }
     },
     "node_modules/@graphprotocol/graph-ts": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.29.3.tgz",
-      "integrity": "sha512-FXBLGlunOSwjiUXYEz1J9J/I2D/myldyib/9v0R+gn/NJaYqUkXD39UmIuRxqj9cBzB/FYojHzoHidIG5nYZDw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.32.0.tgz",
+      "integrity": "sha512-YfKLT2w+ItXD/VPYQiAKtINQONVsAOkcqVFMHlhUy0fcEBVWuFBT53hJNI0/l5ujQa4TSxtzrKW/7EABAdgI8g==",
       "dependencies": {
         "assemblyscript": "0.19.10"
+      }
+    },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "dependencies": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@ipld/dag-json": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
+      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
+      "dependencies": {
+        "cborg": "^1.5.4",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@ipld/dag-pb": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "dependencies": {
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -643,9 +815,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.7.tgz",
-      "integrity": "sha512-pj7hIH8SBeH3qha47fmyqdaBdNVEqesRgnKFh8Ytdb4S41/4BYOiQuyQGuvnKgvicH6DMxp4FbM9EQEW46V9xw==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.6.tgz",
+      "integrity": "sha512-1QlPaHMhOORySCXkQyzjsIsy2GYTilOw3LkjeHkCgsPJQjAT4IclVytJusWktPbYNys9O+O4V23J44yomQvnBQ==",
       "dependencies": {
         "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
@@ -653,9 +825,9 @@
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -671,7 +843,8 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -706,144 +879,274 @@
         "node": ">=8"
       }
     },
-    "node_modules/@oclif/core/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+    "node_modules/@oclif/plugin-autocomplete": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-2.3.10.tgz",
+      "integrity": "sha512-Ow1AR8WtjzlyCtiWWPgzMyT8SbcDJFr47009riLioHa+MHX2BCDtVn2DVnN/E6b9JlPV5ptQpjefoRSNWBesmg==",
       "dependencies": {
-        "ms": "2.1.2"
+        "@oclif/core": "^2.15.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "node": ">=12.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+    "node_modules/@oclif/plugin-autocomplete/node_modules/@oclif/core": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.15.0.tgz",
+      "integrity": "sha512-fNEMG5DzJHhYmI3MgpByTvltBOMyFcnRIUMxbiz2ai8rhaYgaTHMG3Q38HcosfIvtw9nCjxpcQtC8MN8QtVCcA==",
       "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
+        "@types/cli-progress": "^3.11.0",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.12.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.8",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
+        "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+    "node_modules/@oclif/plugin-autocomplete/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
         "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@oclif/core/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+    "node_modules/@oclif/plugin-autocomplete/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=8"
       }
     },
-    "node_modules/@oclif/core/node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+    "node_modules/@oclif/plugin-not-found": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-2.4.3.tgz",
+      "integrity": "sha512-nIyaR4y692frwh7wIHZ3fb+2L6XEecQwRDIb4zbEam0TvaVmBQWZoColQyWA84ljFBPZ8XWiQyTz+ixSwdRkqg==",
+      "dependencies": {
+        "@oclif/core": "^2.15.0",
+        "chalk": "^4",
+        "fast-levenshtein": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
-    "node_modules/@oclif/core/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    "node_modules/@oclif/plugin-not-found/node_modules/@oclif/core": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.15.0.tgz",
+      "integrity": "sha512-fNEMG5DzJHhYmI3MgpByTvltBOMyFcnRIUMxbiz2ai8rhaYgaTHMG3Q38HcosfIvtw9nCjxpcQtC8MN8QtVCcA==",
+      "dependencies": {
+        "@types/cli-progress": "^3.11.0",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.12.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.8",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
+        "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oclif/plugin-not-found/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@oclif/plugin-not-found/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@rescript/std": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@rescript/std/-/std-9.0.0.tgz",
       "integrity": "sha512-zGzFsgtZ44mgL4Xef2gOy1hrRVdrs9mcxCOOKZrIPsmbZW14yTkaF591GXxpQvjXiHtgZ/iA9qLyWH6oSReIxQ=="
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.0",
@@ -854,9 +1157,9 @@
       }
     },
     "node_modules/@types/cli-progress": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.0.tgz",
-      "integrity": "sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.5.tgz",
+      "integrity": "sha512-D4PbNRbviKyppS5ivBGyFO29POlySLmA2HyUFE4p5QGazAMM3CwkKWcvTl8gvElSuxRh6FPKL8XmidX873ou4g==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -870,21 +1173,11 @@
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
       }
     },
     "node_modules/@types/form-data": {
@@ -895,10 +1188,15 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.182",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "node_modules/@types/node": {
       "version": "12.20.55",
@@ -906,9 +1204,9 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
     },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.0",
@@ -922,11 +1220,6 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.3",
@@ -944,6 +1237,35 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@whatwg-node/events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
+      "integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA=="
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
+      "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "@whatwg-node/node-fetch": "^0.3.6",
+        "busboy": "^1.6.0",
+        "urlpattern-polyfill": "^8.0.0",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
+      "integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
+      "dependencies": {
+        "@whatwg-node/events": "^0.0.3",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "fast-url-parser": "^1.1.3",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -953,6 +1275,25 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -971,9 +1312,9 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "engines": {
         "node": ">=6"
       }
@@ -1019,10 +1360,19 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
     },
+    "node_modules/any-signal": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
+      "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.3"
+      }
+    },
     "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -1032,18 +1382,22 @@
       }
     },
     "node_modules/apisauce": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-1.1.5.tgz",
-      "integrity": "sha512-gKC8qb/bDJsPsnEXLZnXJ7gVx7dh87CEVNeIwv1dvaffnXoh5GHwac5pWR1P2broLiVj/fqFMQvLDDt/RhjiqA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-2.1.6.tgz",
+      "integrity": "sha512-MdxR391op/FucS2YQRfB/NMRyCnHEPDd4h17LRIuVYi0BpGmMhpxc0shbOpfs5ahABuBEffNCGal5EcsydbBWg==",
       "dependencies": {
-        "axios": "^0.21.2",
-        "ramda": "^0.25.0"
+        "axios": "^0.21.4"
       }
     },
     "node_modules/app-module-path": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
       "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ=="
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -1066,11 +1420,6 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "node_modules/asmcrypto.js": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
-      "integrity": "sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA=="
-    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -1079,15 +1428,17 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
       "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/assemblyscript": {
@@ -1115,13 +1466,18 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "engines": {
+        "node": ">=8"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1202,14 +1558,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
-    "node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1239,82 +1587,23 @@
         "wasm-opt": "bin/wasm-opt"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/bl": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
-      "integrity": "sha512-jrCW5ZhfQ/Vt07WX1Ngs+yn9BDqPL/gw28S7s9H6QK/gupnizNzJAss5akW20ISgOrbLTlXOOCTJeNUQqruAWQ==",
-      "dependencies": {
-        "readable-stream": "^3.0.1"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
       "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
+    "node_modules/blob-to-it": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
+      "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
+      "dependencies": {
+        "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
     "node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/borc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "dependencies": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/borc/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1340,6 +1629,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+    },
+    "node_modules/browser-readablestream-to-it": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
+      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -1373,9 +1667,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -1392,7 +1686,7 @@
       ],
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-alloc": {
@@ -1424,10 +1718,16 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
     },
-    "node_modules/builtin-status-codes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -1449,14 +1749,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
@@ -1474,6 +1766,14 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
+    "node_modules/cborg": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz",
+      "integrity": "sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug==",
+      "bin": {
+        "cborg": "cli.js"
+      }
+    },
     "node_modules/chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -1486,24 +1786,41 @@
         "node": ">=8"
       }
     },
-    "node_modules/chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
-        "anymatch": "~3.1.1",
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "engines": {
         "node": ">= 8.10.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chownr": {
@@ -1512,33 +1829,6 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/cids": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "class-is": "^1.1.0",
-        "multibase": "~0.6.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/cids/node_modules/multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
       }
     },
     "node_modules/cipher-base": {
@@ -1550,11 +1840,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/class-is": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
-    },
     "node_modules/clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -1562,17 +1847,6 @@
       "dependencies": {
         "escape-string-regexp": "4.0.0"
       },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clean-stack/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
       },
@@ -1602,31 +1876,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/cli-progress/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-progress/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cli-spinners": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
-      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "engines": {
         "node": ">=6"
       },
@@ -1635,15 +1888,15 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dependencies": {
         "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
+        "string-width": "^4.2.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
         "colors": "^1.1.2"
@@ -1674,9 +1927,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -1722,18 +1975,18 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/create-hash": {
@@ -1761,6 +2014,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1786,9 +2044,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1801,20 +2059,15 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "dependencies": {
         "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delay": {
@@ -1836,15 +2089,13 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1857,10 +2108,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/dns-over-http-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^3.0.0",
+        "receptacle": "^1.3.2"
+      }
+    },
     "node_modules/docker-compose": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.4.tgz",
-      "integrity": "sha512-yWdXby9uQ8o4syOfvoSJ9ZlTnLipvUmDn59uaYY5VGIUSUAfMPPGqE1DE3pOCnfSg9Tl9UOOFO0PCSAzuIHmuA==",
+      "version": "0.23.19",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.19.tgz",
+      "integrity": "sha512-v5vNLIdUqwj4my80wxFDkNH+4S85zsRuH29SO7dCWVWPCMt/ohZBsGN6g6KXWifT0pzQ7uOxqEKCYCDPJ8Vz4g==",
+      "dependencies": {
+        "yaml": "^1.10.2"
+      },
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -1921,19 +2185,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "dependencies": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1944,12 +2195,28 @@
       }
     },
     "node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron-fetch": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
+      "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
+      "dependencies": {
+        "encoding": "^0.1.13"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/elliptic": {
@@ -1971,6 +2238,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1980,20 +2255,20 @@
       }
     },
     "node_modules/enquirer": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.4.tgz",
-      "integrity": "sha512-pkYrrDZumL2VS6VBGDhqbajCM2xpkUNLuKfGPjfKaSIBKYopQbqEFyrOkRMIb2HDR/rO1kGhEt/5twBwtzKBXw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dependencies": {
-        "ansi-colors": "^3.2.1"
+        "ansi-colors": "^4.1.1"
       },
       "engines": {
         "node": ">=8.6"
       }
     },
     "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -2017,11 +2292,14 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/esprima": {
@@ -2136,29 +2414,26 @@
       }
     },
     "node_modules/execa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
         "is-stream": "^2.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
       },
       "engines": {
-        "node": "^8.12.0 || >=9.7.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
-    },
-    "node_modules/explain-error": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
-      "integrity": "sha512-/wSgNMxFusiYRy1rd19LT2SQlIXDppHpumpWo06wxjflD1OYxDLbl6rMVw+U3bxD5Nuhex4TKqv9Aem4D0lVzQ=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2181,15 +2456,25 @@
         "node": "> 0.1.90"
       }
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2206,6 +2491,43 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "node_modules/fast-levenshtein": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
+      "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
+      "dependencies": {
+        "fastest-levenshtein": "^1.0.7"
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "dependencies": {
+        "punycode": "^1.3.2"
+      }
+    },
+    "node_modules/fast-url-parser/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -2213,11 +2535,6 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -2256,11 +2573,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/flatmap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
-      "integrity": "sha512-OuR+o7kHVe+x9RtIujPay7Uw3bvDZBZFSBXClEphZuSDLmZTqMdclasf4vFSsogC8baDz0eaC2NdO/2dlXHBKQ=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.1",
@@ -2308,29 +2620,26 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/fs-jetpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-2.4.0.tgz",
-      "integrity": "sha512-S/o9Dd7K9A7gicVU32eT8G0kHcmSu0rCVdP79P0MWInKFb8XpTc8Syhoo66k9no+HDshtlh4pUJTws8X+8fdFQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-4.3.1.tgz",
+      "integrity": "sha512-dbeOK84F6BiQzk2yqqCVwCPWTxAvVGJ3fMQc6E2wuEohS28mR6yHngbrKuVCK1KHRx/ccByDylqu4H5PCP2urQ==",
       "dependencies": {
         "minimatch": "^3.0.2",
         "rimraf": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/fs-jetpack/node_modules/rimraf": {
@@ -2360,6 +2669,19 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2378,6 +2700,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2395,14 +2722,11 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2466,20 +2790,20 @@
       }
     },
     "node_modules/gluegun": {
-      "version": "4.3.1",
-      "resolved": "git+ssh://git@github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a",
-      "license": "MIT",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/gluegun/-/gluegun-5.1.2.tgz",
+      "integrity": "sha512-Cwx/8S8Z4YQg07a6AFsaGnnnmd8mN17414NcPS3OoDtZRwxgsvwRNJNg69niD6fDa8oNwslCG0xH7rEpRNNE/g==",
       "dependencies": {
-        "apisauce": "^1.0.1",
+        "apisauce": "^2.1.5",
         "app-module-path": "^2.2.0",
-        "cli-table3": "~0.5.0",
-        "colors": "1.3.3",
-        "cosmiconfig": "6.0.0",
-        "cross-spawn": "^7.0.0",
-        "ejs": "^2.6.1",
-        "enquirer": "2.3.4",
-        "execa": "^3.0.0",
-        "fs-jetpack": "^2.2.2",
+        "cli-table3": "0.6.0",
+        "colors": "1.4.0",
+        "cosmiconfig": "7.0.1",
+        "cross-spawn": "7.0.3",
+        "ejs": "3.1.6",
+        "enquirer": "2.3.6",
+        "execa": "5.1.1",
+        "fs-jetpack": "4.3.1",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.lowercase": "^4.3.0",
@@ -2495,21 +2819,48 @@
         "lodash.trimstart": "^4.5.1",
         "lodash.uppercase": "^4.3.0",
         "lodash.upperfirst": "^4.3.1",
-        "ora": "^4.0.0",
+        "ora": "4.0.2",
         "pluralize": "^8.0.0",
-        "ramdasauce": "^2.1.0",
-        "semver": "^7.0.0",
-        "which": "^2.0.0",
-        "yargs-parser": "^16.1.0"
+        "semver": "7.3.5",
+        "which": "2.0.2",
+        "yargs-parser": "^21.0.0"
       },
       "bin": {
         "gluegun": "bin/gluegun"
       }
     },
+    "node_modules/gluegun/node_modules/ejs": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+      "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+      "dependencies": {
+        "jake": "^10.6.1"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gluegun/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphql": {
       "version": "15.5.0",
@@ -2613,11 +2964,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "node_modules/hi-base32": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
-      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -2670,11 +3016,11 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=10.17.0"
       }
     },
     "node_modules/hyperlinker": {
@@ -2683,6 +3029,17 @@
       "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -2705,9 +3062,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
       "engines": {
         "node": ">= 4"
       }
@@ -2754,280 +3111,143 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
-    },
-    "node_modules/ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
-      "engines": {
-        "node": ">=4"
+    "node_modules/interface-datastore": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
+      "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "dependencies": {
+        "interface-store": "^2.0.2",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
       }
     },
-    "node_modules/ipfs-block": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
-      "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
-      "dependencies": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0"
-      },
+    "node_modules/interface-store": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
       "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/ipfs-core-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.9.0.tgz",
+      "integrity": "sha512-VJ8vJSHvI1Zm7/SxsZo03T+zzpsg8pkgiIi5hfwSJlsrJ1E2v68QPlnLshGHUSYw89Oxq0IbETYl2pGTFHTWfg==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dependencies": {
+        "interface-datastore": "^6.0.2",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13"
+      }
+    },
+    "node_modules/ipfs-core-utils": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.13.0.tgz",
+      "integrity": "sha512-HP5EafxU4/dLW3U13CFsgqVO5Ika8N4sRSIb/dTg16NjLOozMH31TXV0Grtu2ZWo1T10ahTzMvrfT5f4mhioXw==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dependencies": {
+        "any-signal": "^2.1.2",
+        "blob-to-it": "^1.0.1",
+        "browser-readablestream-to-it": "^1.0.1",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.9.0",
+        "ipfs-unixfs": "^6.0.3",
+        "ipfs-utils": "^9.0.2",
+        "it-all": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-peekable": "^1.0.2",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "multiformats": "^9.4.13",
+        "nanoid": "^3.1.23",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^2.0.0",
+        "uint8arrays": "^3.0.0"
       }
     },
     "node_modules/ipfs-http-client": {
-      "version": "34.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-34.0.0.tgz",
-      "integrity": "sha512-4RCkk8ix4Dqn6sxqFVwuXWCZ1eLFPsVaj6Ijvu1fs9VYgxgVudsW9PWwarlr4mw1xUCmPWYyXnEbGgzBrfMy0Q==",
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-55.0.0.tgz",
+      "integrity": "sha512-GpvEs7C7WL9M6fN/kZbjeh4Y8YN7rY8b18tVWZnKxRsVwM25cIFrRI8CwNt3Ugin9yShieI3i9sPyzYGMrLNnQ==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
       "dependencies": {
+        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-json": "^8.0.1",
+        "@ipld/dag-pb": "^2.1.3",
         "abort-controller": "^3.0.0",
-        "async": "^2.6.1",
-        "bignumber.js": "^9.0.0",
-        "bl": "^3.0.0",
-        "bs58": "^4.0.1",
-        "buffer": "^5.4.2",
-        "cids": "~0.7.1",
-        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "end-of-stream": "^1.4.1",
-        "err-code": "^2.0.0",
-        "explain-error": "^1.0.4",
-        "flatmap": "0.0.3",
-        "glob": "^7.1.3",
-        "ipfs-block": "~0.8.1",
-        "ipfs-utils": "~0.0.3",
-        "ipld-dag-cbor": "~0.15.0",
-        "ipld-dag-pb": "~0.17.3",
-        "ipld-raw": "^4.0.0",
-        "is-ipfs": "~0.6.1",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "iso-stream-http": "~0.1.2",
-        "iso-url": "~0.4.6",
-        "iterable-ndjson": "^1.1.0",
-        "just-kebab-case": "^1.1.0",
-        "just-map-keys": "^1.1.0",
-        "kind-of": "^6.0.2",
-        "ky": "^0.11.2",
-        "ky-universal": "^0.2.2",
-        "lru-cache": "^5.1.1",
-        "multiaddr": "^6.0.6",
-        "multibase": "~0.6.0",
-        "multicodec": "~0.5.1",
-        "multihashes": "~0.4.14",
-        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.3",
-        "peer-info": "~0.15.1",
-        "promise-nodeify": "^3.0.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "pull-to-stream": "~0.1.1",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^3.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^2.0.1",
-        "through2": "^3.0.1"
+        "any-signal": "^2.1.2",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.9.0",
+        "ipfs-core-utils": "^0.13.0",
+        "ipfs-utils": "^9.0.2",
+        "it-first": "^1.0.6",
+        "it-last": "^1.0.4",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13",
+        "native-abort-controller": "^1.0.3",
+        "parse-duration": "^1.0.0",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^3.0.0"
       },
       "engines": {
-        "node": ">=8.3.0",
+        "node": ">=14.0.0",
         "npm": ">=3.0.0"
       }
     },
-    "node_modules/ipfs-http-client/node_modules/concat-stream": {
-      "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/hugomrdias/concat-stream.git#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-      "license": "MIT",
+    "node_modules/ipfs-unixfs": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
+      "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2"
+        "err-code": "^3.0.1",
+        "protobufjs": "^6.10.2"
       },
       "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ipfs-http-client/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-utils": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.0.4.tgz",
-      "integrity": "sha512-7cZf6aGj2FG3XJWhCNwn4mS93Q0GEWjtBZvEHqzgI43U2qzNDCyzfS1pei1Y5F+tw/zDJ5U4XG0G9reJxR53Ig==",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
+      "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
       "dependencies": {
-        "buffer": "^5.2.1",
-        "is-buffer": "^2.0.3",
+        "any-signal": "^3.0.0",
+        "browser-readablestream-to-it": "^1.0.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
         "is-electron": "^2.2.0",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "kind-of": "^6.0.2",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/ipfs-utils/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "iso-url": "^1.1.5",
+        "it-all": "^1.0.4",
+        "it-glob": "^1.0.1",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "^2.6.8",
+        "react-native-fetch-api": "^3.0.0",
+        "stream-to-it": "^0.2.2"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipld-dag-cbor": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.3.tgz",
-      "integrity": "sha512-m23nG7ZyoVFnkK55/bLAErc7EfiMgaEQlqHWDTGzPI+O5r6bPfp+qbL5zTVSIT8tpbHmu174dwerVtLoVgeVyA==",
-      "deprecated": "This module has been superseded by @ipld/dag-cbor and multiformats",
-      "dependencies": {
-        "borc": "^2.1.2",
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
-        "is-circular": "^1.0.2",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor/node_modules/cids": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-      "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "class-is": "^1.1.0",
-        "multibase": "^1.0.0",
-        "multicodec": "^1.0.1",
-        "multihashes": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor/node_modules/multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/ipld-dag-cbor/node_modules/multihashes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/ipld-dag-pb": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.17.4.tgz",
-      "integrity": "sha512-YwCxETEMuXVspOKOhjIOHJvKvB/OZfCDkpSFiYBQN2/JQjM9y/RFCYzIQGm0wg7dCFLrhvfjAZLTSaKs65jzWA==",
-      "deprecated": "This module has been superseded by @ipld/dag-pb and multiformats",
-      "dependencies": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0",
-        "multicodec": "~0.5.1",
-        "multihashing-async": "~0.7.0",
-        "protons": "^1.0.1",
-        "stable": "~0.1.8"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-dag-pb/node_modules/err-code": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-      "integrity": "sha512-CJAN+O0/yA1CKfRn9SXOGctSpEM7DCon/r/5r2eXFMY2zCCJBasFhcM5I+1kh3Ap11FsQCX+vGHceNPvpWKhoA=="
-    },
-    "node_modules/ipld-dag-pb/node_modules/multihashing-async": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.7.0.tgz",
-      "integrity": "sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "buffer": "^5.2.1",
-        "err-code": "^1.1.2",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-raw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-4.0.1.tgz",
-      "integrity": "sha512-WjIdtZ06jJEar8zh+BHB84tE6ZdbS/XNa7+XCArOYfmeJ/c01T9VQpeMwdJQYn5c3s5UvvCu7y4VIi3vk2g1bA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "cids": "~0.7.0",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
-      }
-    },
-    "node_modules/ipld-raw/node_modules/multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
-      }
+    "node_modules/ipfs-utils/node_modules/any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3045,33 +3265,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-circular": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
-    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -3087,9 +3280,9 @@
       }
     },
     "node_modules/is-electron": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
-      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3100,11 +3293,11 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3136,38 +3329,6 @@
       }
     },
     "node_modules/is-ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
-      "integrity": "sha512-9MTn0dteHETtyUx8pxqMwg5hMBi3pvlyglJ+b79KOCca0po23337LbVV2Hl4xmMvfw++ljnO0/+5G6G+0Szh6g==",
-      "dependencies": {
-        "ip-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-ipfs": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.3.tgz",
-      "integrity": "sha512-HyRot1dvLcxImtDqPxAaY1miO6WsiP/z7Yxpg2qpaLWv5UdhAPtLvHJ4kMLM0w8GSl8AFsVF23PHe1LzuWrUlQ==",
-      "dependencies": {
-        "bs58": "^4.0.1",
-        "cids": "~0.7.0",
-        "mafmt": "^7.0.0",
-        "multiaddr": "^7.2.1",
-        "multibase": "~0.6.0",
-        "multihashes": "~0.4.13"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/is-ip": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
       "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
@@ -3178,98 +3339,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-ipfs/node_modules/multiaddr": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-      "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
-        "class-is": "^1.1.0",
-        "is-ip": "^3.1.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/cids": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-      "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "class-is": "^1.1.0",
-        "multibase": "^1.0.0",
-        "multicodec": "^1.0.1",
-        "multihashes": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/cids/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/multibase": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/multihashes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multiaddr/node_modules/multihashes/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/is-ipfs/node_modules/multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3278,15 +3347,13 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-promise": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-      "integrity": "sha512-mjWH5XxnhMA8cFnDchr6qRP9S/kLntKuEfIYku+PaN1CnS8v+OG9O/BKpRCVRJvpIkgAZm0Pf5Is3iSSOILlcg=="
-    },
-    "node_modules/is-pull-stream": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/is-pull-stream/-/is-pull-stream-0.0.0.tgz",
-      "integrity": "sha512-NWLwqCc95I6m8FZDYLAmVJc9Xgk8O+8pPOoDKFTC293FH4S7FBcbLCw3WWPCdiT8uUSdzPy47VM08WPDMJJrag=="
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -3325,83 +3392,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "node_modules/iso-random-stream": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.2.tgz",
-      "integrity": "sha512-7y0tsBBgQs544iTYjyrMp5xvgrbYR8b+plQq1Bryp+03p0LssrxC9C1M0oHv4QESDt7d95c74XvMk/yawKqX+A==",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/iso-random-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/iso-random-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/iso-stream-http": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/iso-stream-http/-/iso-stream-http-0.1.2.tgz",
-      "integrity": "sha512-oHEDNOysIMTNypbg2f1SlydqRBvjl4ZbSE9+0awVxnkx3K2stGTFwB/kpVqnB6UEfF8QD36kAjDwZvqyXBLMnQ==",
-      "dependencies": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "node_modules/iso-stream-http/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/iso-url": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/isomorphic-ws": {
@@ -3417,23 +3413,75 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
-    "node_modules/iterable-ndjson": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
-      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+    "node_modules/it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+    },
+    "node_modules/it-first": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "node_modules/it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
       "dependencies": {
-        "string_decoder": "^1.2.0"
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/it-last": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
+      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+    },
+    "node_modules/it-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+    },
+    "node_modules/it-peekable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
+      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+    },
+    "node_modules/it-to-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+      "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/it-to-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/jake": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
-      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
       "dependencies": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
       },
       "bin": {
         "jake": "bin/cli.js"
@@ -3441,11 +3489,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/jake/node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/jake/node_modules/chalk": {
       "version": "4.1.2",
@@ -3462,14 +3505,23 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/jake/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jayson": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.6.6.tgz",
-      "integrity": "sha512-f71uvrAWTtrwoww6MKcl9phQTC+56AopLyEenWvKVAIMz+q0oVGj6tenLZ7Z6UiPBkJtKLj4kt0tACllFQruGQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.0.0.tgz",
+      "integrity": "sha512-v2RNpDCMu45fnLzSk47vx7I+QUaOsox6f5X0CUlabAFwxoP+8MfAY0NQRFwOEYXIxm8Ih5y6OaEa5KYiQMkyAA==",
       "dependencies": {
         "@types/connect": "^3.4.33",
-        "@types/express-serve-static-core": "^4.17.9",
-        "@types/lodash": "^4.14.159",
         "@types/node": "^12.12.54",
         "@types/ws": "^7.4.4",
         "commander": "^2.20.3",
@@ -3479,7 +3531,6 @@
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
         "JSONStream": "^1.3.5",
-        "lodash": "^4.17.20",
         "uuid": "^8.3.2",
         "ws": "^7.4.5"
       },
@@ -3516,9 +3567,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3552,14 +3603,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
-    "node_modules/json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
-      "dependencies": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -3569,14 +3612,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/jsonparse": {
@@ -3616,16 +3651,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/just-kebab-case": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/just-kebab-case/-/just-kebab-case-1.1.0.tgz",
-      "integrity": "sha512-QkuwuBMQ9BQHMUEkAtIA4INLrkmnnveqlFB1oFi09gbU0wBdZo6tTnyxNWMR84zHxBuwK7GLAwqN8nrvVxOLTA=="
-    },
-    "node_modules/just-map-keys": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/just-map-keys/-/just-map-keys-1.2.1.tgz",
-      "integrity": "sha512-Dmyz1Cy2SWM+PpqDPB1kdDglyexdzMthnAsvOIE9w4OPj8NDRuY1mh20x/JfG5w6fCGw9F0WmcofJhYZ4MiuyA=="
-    },
     "node_modules/keccak": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
@@ -3653,130 +3678,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/keypair": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.4.tgz",
-      "integrity": "sha512-zwhgOhhniaL7oxMgUMKKw5219PWWABMO+dgMnzJOQ2/5L3XJtTJGhW2PEXlxXj9zaccdReZJZ83+4NPhVfNVDg=="
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ky": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.11.2.tgz",
-      "integrity": "sha512-5Aou5BWue5/mkPqIRqzSWW+0Hkl403pr/2AIrCKYw7cVl/Xoe8Xe4KLBO0PRjbz7GnRe1/8wW1KhqQNFFE7/GQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ky-universal": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.2.2.tgz",
-      "integrity": "sha512-fb32o/fKy/ux2ALWa9HU2hvGtfOq7/vn2nH0FpVE+jwNzyTeORlAbj3Fiw+WLMbUlmVqZIWupnLZ2USHvqwZHw==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "ky": ">=0.10.0"
-      }
-    },
-    "node_modules/libp2p-crypto": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.4.tgz",
-      "integrity": "sha512-II8HxKc9jbmQp34pprlluNxsBCWJDjHRPYJzuRy7ragztNip9Zb7uJ4lCje6gGzz4DNAcHkAUn+GqCIK1592iA==",
-      "dependencies": {
-        "asmcrypto.js": "^2.3.2",
-        "asn1.js": "^5.0.1",
-        "async": "^2.6.1",
-        "bn.js": "^4.11.8",
-        "browserify-aes": "^1.2.0",
-        "bs58": "^4.0.1",
-        "iso-random-stream": "^1.1.0",
-        "keypair": "^1.0.1",
-        "libp2p-crypto-secp256k1": "~0.3.0",
-        "multihashing-async": "~0.5.1",
-        "node-forge": "^0.10.0",
-        "pem-jwk": "^2.0.0",
-        "protons": "^1.0.1",
-        "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.10.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/libp2p-crypto-secp256k1": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.1.tgz",
-      "integrity": "sha512-evrfK/CeUSd/lcELUdDruyPBvxDmLairth75S32OLl3H+++2m2fV24JEtxzdFS9JH3xEFw0h6JFO8DBa1bP9dA==",
-      "deprecated": "Included in libp2p-crypto, use it instead. https://github.com/libp2p/js-libp2p-crypto",
-      "dependencies": {
-        "async": "^2.6.2",
-        "bs58": "^4.0.1",
-        "multihashing-async": "~0.6.0",
-        "nodeify": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "secp256k1": "^3.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/libp2p-crypto-secp256k1/node_modules/multihashing-async": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
-      "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/libp2p-crypto/node_modules/multihashing-async": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
-      "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -3901,6 +3806,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/log-symbols/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -3925,137 +3838,21 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "node_modules/looper": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-      "integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg=="
-    },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/mafmt": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
-      "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
-      "dependencies": {
-        "multiaddr": "^7.3.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/cids": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-      "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "class-is": "^1.1.0",
-        "multibase": "^1.0.0",
-        "multicodec": "^1.0.1",
-        "multihashes": "^1.0.1"
+        "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
+        "node": ">=10"
       }
     },
-    "node_modules/mafmt/node_modules/cids/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mafmt/node_modules/is-ip": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-      "dependencies": {
-        "ip-regex": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mafmt/node_modules/multiaddr": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-      "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
-        "class-is": "^1.1.0",
-        "is-ip": "^3.1.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/multibase": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/multihashes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/mafmt/node_modules/multihashes/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -4065,6 +3862,17 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/merge-stream": {
@@ -4156,11 +3964,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/minizlib": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
@@ -4172,11 +3975,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -4195,128 +3993,65 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multiaddr": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
-      "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
+      "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
+      "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr",
       "dependencies": {
-        "bs58": "^4.0.1",
-        "class-is": "^1.1.0",
-        "hi-base32": "~0.5.0",
-        "ip": "^1.1.5",
-        "is-ip": "^2.0.0",
-        "varint": "^5.0.0"
+        "dns-over-http-resolver": "^1.2.3",
+        "err-code": "^3.0.1",
+        "is-ip": "^3.1.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
       }
     },
-    "node_modules/multibase": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-      "deprecated": "This module has been superseded by the multiformats module",
+    "node_modules/multiaddr-to-uri": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-8.0.0.tgz",
+      "integrity": "sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==",
+      "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr-to-uri",
       "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
+        "multiaddr": "^10.0.0"
       }
     },
-    "node_modules/multicodec": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
-      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "varint": "^5.0.0"
-      }
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
-    "node_modules/multihashes": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "node_modules/multihashes/node_modules/multibase": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      }
-    },
-    "node_modules/multihashing-async": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-      "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "buffer": "^5.4.3",
-        "err-code": "^2.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^1.0.1",
-        "murmurhash3js-revisited": "^3.0.0"
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/multihashing-async/node_modules/multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
+    "node_modules/native-abort-controller": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
+      "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
+      "peerDependencies": {
+        "abort-controller": "*"
       }
     },
-    "node_modules/multihashing-async/node_modules/multihashes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-      "dependencies": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/murmurhash3js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
-      "integrity": "sha512-KL8QYUaxq7kUbcl0Yto51rMcYt7E/4N4BG3/c96Iqw1PQrTRspu8Cpx4TZ4Nunib1d4bEkIH3gjCYlP2RLBdow==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/murmurhash3js-revisited": {
+    "node_modules/native-fetch": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
-      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==",
-      "engines": {
-        "node": ">=8.0.0"
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "peerDependencies": {
+        "node-fetch": "*"
       }
-    },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
-    },
-    "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
     },
     "node_modules/natural-orderby": {
       "version": "2.0.3",
@@ -4326,44 +4061,28 @@
         "node": "*"
       }
     },
-    "node_modules/ndjson": {
-      "version": "1.5.0",
-      "resolved": "git+ssh://git@github.com/hugomrdias/ndjson.git#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.0",
-        "split2": "^3.1.0",
-        "through2": "^3.0.0"
-      },
-      "bin": {
-        "ndjson": "cli.js"
-      }
-    },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "engines": {
-        "node": ">= 6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-gyp-build": {
@@ -4374,15 +4093,6 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/nodeify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
-      "integrity": "sha512-n7C2NyEze8GCo/z73KdbjRsBiLbv6eBn1FxwYKQ23IqGo7pQY3mhQan61Sv7eEDJCiyUjTVrVkXTzJCo1dW7Aw==",
-      "dependencies": {
-        "is-promise": "~1.0.0",
-        "promise": "~1.3.0"
       }
     },
     "node_modules/normalize-path": {
@@ -4476,41 +4186,121 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "dependencies": {
-        "wordwrap": "~0.0.2"
-      }
-    },
     "node_modules/ora": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
-      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.2.tgz",
+      "integrity": "sha512-YUOZbamht5mfLxPmk4M35CD/5DuOkAacxlEUbStVXpBAt4fyhBf+vZHI/HRkI++QUp3sNoeA2Gw4C+hi4eGSig==",
       "dependencies": {
-        "chalk": "^3.0.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^3.1.0",
         "cli-spinners": "^2.2.0",
         "is-interactive": "^1.0.0",
         "log-symbols": "^3.0.0",
-        "mute-stream": "0.0.8",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^5.2.0",
         "wcwidth": "^1.0.1"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/ora/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "dependencies": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
       }
     },
     "node_modules/parent-module": {
@@ -4528,6 +4318,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+    },
+    "node_modules/parse-duration": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -4547,81 +4342,12 @@
       }
     },
     "node_modules/password-prompt": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
-      "integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
+      "integrity": "sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==",
       "dependencies": {
-        "ansi-escapes": "^3.1.0",
-        "cross-spawn": "^6.0.5"
-      }
-    },
-    "node_modules/password-prompt/node_modules/ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/password-prompt/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/password-prompt/node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/password-prompt/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/password-prompt/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/password-prompt/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/password-prompt/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
+        "ansi-escapes": "^4.3.2",
+        "cross-spawn": "^7.0.3"
       }
     },
     "node_modules/path-is-absolute": {
@@ -4638,6 +4364,37 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-type": {
@@ -4661,62 +4418,6 @@
       },
       "engines": {
         "node": ">=0.12"
-      }
-    },
-    "node_modules/peer-id": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.5.tgz",
-      "integrity": "sha512-3xVWrtIvNm9/OPzaQBgXDrfWNx63AftgFQkvqO6YSZy7sP3Fuadwwbn54F/VO9AnpyW/26i0WRQz9FScivXrmw==",
-      "dependencies": {
-        "async": "^2.6.3",
-        "class-is": "^1.1.0",
-        "libp2p-crypto": "~0.16.1",
-        "multihashes": "~0.4.15"
-      },
-      "bin": {
-        "peer-id": "src/bin.js"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/peer-info": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
-      "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
-      "deprecated": "No longer supported for js-libp2p0.28.0 or later",
-      "dependencies": {
-        "mafmt": "^6.0.2",
-        "multiaddr": "^6.0.3",
-        "peer-id": "~0.12.2",
-        "unique-by": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/peer-info/node_modules/mafmt": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
-      "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
-      "dependencies": {
-        "multiaddr": "^6.1.0"
-      }
-    },
-    "node_modules/pem-jwk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
-      "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
-      "dependencies": {
-        "asn1.js": "^5.0.1"
-      },
-      "bin": {
-        "pem-jwk": "bin/pem-jwk.js"
-      },
-      "engines": {
-        "node": ">=5.10.0"
       }
     },
     "node_modules/performance-now": {
@@ -4744,14 +4445,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -4762,44 +4464,37 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "node_modules/promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
-      "integrity": "sha512-R9WrbTF3EPkVtWjp7B7umQGVndpsi+rsDAfrR4xAALQpFLa/+2OriecLhawxzvii2gd9+DZFwROWDuUUaqS5yA==",
+    "node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
       "dependencies": {
-        "is-promise": "~1"
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
-    "node_modules/promise-nodeify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/promise-nodeify/-/promise-nodeify-3.0.1.tgz",
-      "integrity": "sha512-ghsSuzZXJX8iO7WVec2z7GI+Xk/EyiD+JZK7AZKhUqYfpLa/Zs4ylUD+CwwnKlG6G3HnkUPMAi6PO7zeqGKssg==",
-      "engines": {
-        "node": ">=6",
-        "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/promisify-es6": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
-      "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA==",
-      "deprecated": "Unmaintained"
-    },
-    "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
-    },
-    "node_modules/protons": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
-      "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
-      "deprecated": "This module is no longer maintained",
+    "node_modules/protobufjs/node_modules/@types/node": {
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
       "dependencies": {
-        "buffer": "^5.5.0",
-        "protocol-buffers-schema": "^3.3.1",
-        "signed-varint": "^2.0.1",
-        "varint": "^5.0.0"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/psl": {
@@ -4807,55 +4502,28 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
-    "node_modules/pull-defer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
-    },
-    "node_modules/pull-stream": {
-      "version": "3.6.14",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
-    },
-    "node_modules/pull-to-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.1.tgz",
-      "integrity": "sha512-thZkMv6F9PILt9zdvpI2gxs19mkDrlixYKX6cOBxAW16i1NZH+yLAmF4r8QfJ69zuQh27e01JZP9y27tsH021w==",
-      "dependencies": {
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pull-to-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "dependencies": {
+        "tslib": "^2.6.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/qs": {
@@ -4891,30 +4559,20 @@
         }
       ]
     },
-    "node_modules/ramda": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
-    },
-    "node_modules/ramdasauce": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ramdasauce/-/ramdasauce-2.1.3.tgz",
-      "integrity": "sha512-Ml3CPim4SKwmg5g9UI77lnRSeKr/kQw7YhQ6rfdMcBYy6DMlwmkEwQqjygJ3OhxPR+NfFfpjKl3Tf8GXckaqqg==",
-      "dependencies": {
-        "ramda": "^0.24.1"
-      }
-    },
-    "node_modules/ramdasauce/node_modules/ramda": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-      "integrity": "sha512-HEm619G8PaZMfkqCa23qiOe7r3R0brPu7ZgOsgKUsnvLhd0qhc/vTjkUovomgPWa5ECBa08fJZixth9LaoBo5w=="
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react-native-fetch-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
+      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+      "dependencies": {
+        "p-defer": "^3.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -4945,14 +4603,22 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/redeyed": {
@@ -4962,11 +4628,6 @@
       "dependencies": {
         "esprima": "~4.0.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/request": {
       "version": "2.88.2",
@@ -5036,6 +4697,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -5083,34 +4749,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
-    },
-    "node_modules/rsa-pem-to-jwk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
-      "integrity": "sha512-ZlVavEvTnD8Rzh/pdB8NH4VF5GNEtF6biGQcTtC4GKFMsbZR08oHtOYefbhCN+JnJIuMItiCDCMycdcMrw6blA==",
-      "dependencies": {
-        "object-assign": "^2.0.0",
-        "rsa-unpack": "0.0.6"
-      }
-    },
-    "node_modules/rsa-pem-to-jwk/node_modules/object-assign": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-      "integrity": "sha512-CdsOUYIh5wIiozhJ3rLQgmUTgcyzFwZZrqhkKhODMoGtPKM+wt0h0CNIoauJWMsS9822EdzPsF/6mb4nLvPN5g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rsa-unpack": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/rsa-unpack/-/rsa-unpack-0.0.6.tgz",
-      "integrity": "sha512-HRrl8GHjjPziPFRDJPq/v5OxZ3IPdksV5h3cime/oHgcgM1k1toO5OdtzClgBqRf5dF6IgptOB0g/zFb0w5zQw==",
-      "dependencies": {
-        "optimist": "~0.3.5"
-      },
-      "bin": {
-        "rsa-unpack": "bin/cmd.js"
-      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -5163,29 +4801,10 @@
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
-    "node_modules/secp256k1": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.5.2",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5195,22 +4814,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -5266,20 +4869,28 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
-    "node_modules/signed-varint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
-      "integrity": "sha512-abgDPg1106vuZZOvw7cFwdCABddfJRz5akcCcchzTbhyhYnsG31y4AlZEgp315T7W3nQq5P4xeOm186ZiPVFzw==",
-      "dependencies": {
-        "varint": "~5.0.0"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/source-map": {
@@ -5303,27 +4914,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
-    },
-    "node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
-    "node_modules/split2/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -5359,19 +4949,20 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
-    },
-    "node_modules/stream-to-pull-stream": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
+    "node_modules/stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "dependencies": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
+        "get-iterator": "^1.0.2"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -5383,34 +4974,16 @@
       }
     },
     "node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -5445,14 +5018,17 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-hyperlinks": {
@@ -5462,6 +5038,17 @@
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -5566,49 +5153,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/then-request": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
@@ -5648,13 +5192,14 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
-    "node_modules/through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+    "node_modules/timeout-abort-controller": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-2.0.0.tgz",
+      "integrity": "sha512-2FAPXfzTPYEgw27bQGTHc0SzrbmnU2eso4qo172zMLZzaGqeu09PFa5B2FCUHM1tflgRqPgn5KQgp6+Vex4uNA==",
       "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.4",
+        "retimer": "^3.0.0"
       }
     },
     "node_modules/tmp": {
@@ -5669,9 +5214,9 @@
       }
     },
     "node_modules/tmp-promise": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.2.tgz",
-      "integrity": "sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "dependencies": {
         "tmp": "^0.2.0"
       }
@@ -5704,10 +5249,57 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -5719,11 +5311,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
@@ -5741,18 +5328,36 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
-    "node_modules/unique-by": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
-      "integrity": "sha512-rJRXK5V0zL6TiSzhoGNpJp5dr+TZBLoPJFC06rLn17Ug++7Aa0Qnve5v+skXeQxx6/sI7rBsSesa6MAcmFi8Ew==",
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
       "engines": {
-        "node": ">= 0.10.x"
+        "node": ">=14.17"
       }
     },
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -5765,18 +5370,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/ursa-optional": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.2.tgz",
-      "integrity": "sha512-TKdwuLboBn7M34RcvVTuQyhvrA8gYKapuVdm0nBP0mnBc7oECOfUQZrY91cefL3/nm64ZyrejSRrhTVdX7NG/A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.14.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+    "node_modules/urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ=="
     },
     "node_modules/utf8": {
       "version": "3.0.0",
@@ -5796,10 +5393,15 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
     "node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "node_modules/verror": {
       "version": "1.10.0",
@@ -5825,6 +5427,14 @@
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/web3-eth-abi": {
@@ -5856,6 +5466,32 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/webcrypto-core": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5881,34 +5517,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/widest-line/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -5926,36 +5538,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -5981,52 +5572,108 @@
       }
     },
     "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
-      "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      },
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
       }
     }
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "requires": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.23.4",
+        "chalk": "^2.4.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
     },
     "@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
@@ -6061,6 +5708,11 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -6076,12 +5728,12 @@
         }
       }
     },
-    "@babel/runtime": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz",
-      "integrity": "sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==",
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@ethersproject/abi": {
@@ -6323,36 +5975,38 @@
       }
     },
     "@graphprotocol/graph-cli": {
-      "version": "0.42.4",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.42.4.tgz",
-      "integrity": "sha512-h6/OkmLSPqP8cji6AMXtq7AWHtgl4nC8wjunHhDBlQiLzdClky3jFe50/xAM9VBs2QV+oXhCflRq26qqO3XBXA==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.64.0.tgz",
+      "integrity": "sha512-JvEL3FvXEhRhEaCAk310h13UothElQgNPt0InjoXJUG+yNexsdJ6Rr1FYCC517Q/b7pfcczT6usSyOgnTgR7FA==",
       "requires": {
         "@float-capital/float-subgraph-uncrashable": "^0.0.0-alpha.4",
-        "@oclif/core": "2.0.7",
+        "@oclif/core": "2.8.6",
+        "@oclif/plugin-autocomplete": "^2.3.6",
+        "@oclif/plugin-not-found": "^2.4.0",
+        "@whatwg-node/fetch": "^0.8.4",
         "assemblyscript": "0.19.23",
         "binary-install-raw": "0.0.13",
         "chalk": "3.0.0",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
-        "docker-compose": "0.23.4",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "docker-compose": "0.23.19",
         "dockerode": "2.5.8",
-        "fs-extra": "9.0.0",
-        "glob": "7.1.6",
-        "gluegun": "git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep",
+        "fs-extra": "9.1.0",
+        "glob": "9.3.5",
+        "gluegun": "5.1.2",
         "graphql": "15.5.0",
         "immutable": "4.2.1",
-        "ipfs-http-client": "34.0.0",
-        "jayson": "3.6.6",
-        "js-yaml": "3.13.1",
-        "node-fetch": "2.6.0",
+        "ipfs-http-client": "55.0.0",
+        "jayson": "4.0.0",
+        "js-yaml": "3.14.1",
         "prettier": "1.19.1",
         "request": "2.88.2",
-        "semver": "7.3.5",
+        "semver": "7.4.0",
         "sync-request": "6.1.0",
-        "tmp-promise": "3.0.2",
+        "tmp-promise": "3.0.3",
         "web3-eth-abi": "1.7.0",
         "which": "2.0.2",
-        "yaml": "1.9.2"
+        "yaml": "1.10.2"
       },
       "dependencies": {
         "assemblyscript": {
@@ -6370,10 +6024,42 @@
           "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-102.0.0-nightly.20211028.tgz",
           "integrity": "sha512-GCJBVB5exbxzzvyt8MGDv/MeUjs6gkXDvf4xOIItRBptYl0Tz5sm1o/uG95YK0L0VeG5ajDu3hRtkBP2kzqC5w=="
         },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "9.3.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+          "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "minimatch": "^8.0.2",
+            "minipass": "^4.2.4",
+            "path-scurry": "^1.6.1"
+          }
+        },
         "long": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
           "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+        },
+        "minimatch": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+          "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="
         },
         "prettier": {
           "version": "1.19.1",
@@ -6383,11 +6069,56 @@
       }
     },
     "@graphprotocol/graph-ts": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.29.3.tgz",
-      "integrity": "sha512-FXBLGlunOSwjiUXYEz1J9J/I2D/myldyib/9v0R+gn/NJaYqUkXD39UmIuRxqj9cBzB/FYojHzoHidIG5nYZDw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.32.0.tgz",
+      "integrity": "sha512-YfKLT2w+ItXD/VPYQiAKtINQONVsAOkcqVFMHlhUy0fcEBVWuFBT53hJNI0/l5ujQa4TSxtzrKW/7EABAdgI8g==",
       "requires": {
         "assemblyscript": "0.19.10"
+      }
+    },
+    "@ipld/dag-cbor": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "requires": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@ipld/dag-json": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
+      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
+      "requires": {
+        "cborg": "^1.5.4",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@ipld/dag-pb": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "requires": {
+        "multiformats": "^9.5.4"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "@nodelib/fs.scandir": {
@@ -6414,9 +6145,9 @@
       }
     },
     "@oclif/core": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.0.7.tgz",
-      "integrity": "sha512-pj7hIH8SBeH3qha47fmyqdaBdNVEqesRgnKFh8Ytdb4S41/4BYOiQuyQGuvnKgvicH6DMxp4FbM9EQEW46V9xw==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.6.tgz",
+      "integrity": "sha512-1QlPaHMhOORySCXkQyzjsIsy2GYTilOw3LkjeHkCgsPJQjAT4IclVytJusWktPbYNys9O+O4V23J44yomQvnBQ==",
       "requires": {
         "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
@@ -6424,9 +6155,9 @@
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -6442,7 +6173,8 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -6466,103 +6198,249 @@
               }
             }
           }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ejs": {
-          "version": "3.1.9",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-          "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
-          "requires": {
-            "jake": "^10.8.5"
-          }
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
+    },
+    "@oclif/plugin-autocomplete": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-2.3.10.tgz",
+      "integrity": "sha512-Ow1AR8WtjzlyCtiWWPgzMyT8SbcDJFr47009riLioHa+MHX2BCDtVn2DVnN/E6b9JlPV5ptQpjefoRSNWBesmg==",
+      "requires": {
+        "@oclif/core": "^2.15.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@oclif/core": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.15.0.tgz",
+          "integrity": "sha512-fNEMG5DzJHhYmI3MgpByTvltBOMyFcnRIUMxbiz2ai8rhaYgaTHMG3Q38HcosfIvtw9nCjxpcQtC8MN8QtVCcA==",
+          "requires": {
+            "@types/cli-progress": "^3.11.0",
+            "ansi-escapes": "^4.3.2",
+            "ansi-styles": "^4.3.0",
+            "cardinal": "^2.1.1",
+            "chalk": "^4.1.2",
+            "clean-stack": "^3.0.1",
+            "cli-progress": "^3.12.0",
+            "debug": "^4.3.4",
+            "ejs": "^3.1.8",
+            "get-package-type": "^0.1.0",
+            "globby": "^11.1.0",
+            "hyperlinker": "^1.0.0",
+            "indent-string": "^4.0.0",
+            "is-wsl": "^2.2.0",
+            "js-yaml": "^3.14.1",
+            "natural-orderby": "^2.0.3",
+            "object-treeify": "^1.1.33",
+            "password-prompt": "^1.1.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "supports-color": "^8.1.1",
+            "supports-hyperlinks": "^2.2.0",
+            "ts-node": "^10.9.1",
+            "tslib": "^2.5.0",
+            "widest-line": "^3.1.0",
+            "wordwrap": "^1.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "@oclif/plugin-not-found": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-2.4.3.tgz",
+      "integrity": "sha512-nIyaR4y692frwh7wIHZ3fb+2L6XEecQwRDIb4zbEam0TvaVmBQWZoColQyWA84ljFBPZ8XWiQyTz+ixSwdRkqg==",
+      "requires": {
+        "@oclif/core": "^2.15.0",
+        "chalk": "^4",
+        "fast-levenshtein": "^3.0.0"
+      },
+      "dependencies": {
+        "@oclif/core": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.15.0.tgz",
+          "integrity": "sha512-fNEMG5DzJHhYmI3MgpByTvltBOMyFcnRIUMxbiz2ai8rhaYgaTHMG3Q38HcosfIvtw9nCjxpcQtC8MN8QtVCcA==",
+          "requires": {
+            "@types/cli-progress": "^3.11.0",
+            "ansi-escapes": "^4.3.2",
+            "ansi-styles": "^4.3.0",
+            "cardinal": "^2.1.1",
+            "chalk": "^4.1.2",
+            "clean-stack": "^3.0.1",
+            "cli-progress": "^3.12.0",
+            "debug": "^4.3.4",
+            "ejs": "^3.1.8",
+            "get-package-type": "^0.1.0",
+            "globby": "^11.1.0",
+            "hyperlinker": "^1.0.0",
+            "indent-string": "^4.0.0",
+            "is-wsl": "^2.2.0",
+            "js-yaml": "^3.14.1",
+            "natural-orderby": "^2.0.3",
+            "object-treeify": "^1.1.33",
+            "password-prompt": "^1.1.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "supports-color": "^8.1.1",
+            "supports-hyperlinks": "^2.2.0",
+            "ts-node": "^10.9.1",
+            "tslib": "^2.5.0",
+            "widest-line": "^3.1.0",
+            "wordwrap": "^1.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
+      "requires": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
+      }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@rescript/std": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@rescript/std/-/std-9.0.0.tgz",
       "integrity": "sha512-zGzFsgtZ44mgL4Xef2gOy1hrRVdrs9mcxCOOKZrIPsmbZW14yTkaF591GXxpQvjXiHtgZ/iA9qLyWH6oSReIxQ=="
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "@types/bn.js": {
       "version": "5.1.0",
@@ -6573,9 +6451,9 @@
       }
     },
     "@types/cli-progress": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.0.tgz",
-      "integrity": "sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.5.tgz",
+      "integrity": "sha512-D4PbNRbviKyppS5ivBGyFO29POlySLmA2HyUFE4p5QGazAMM3CwkKWcvTl8gvElSuxRh6FPKL8XmidX873ou4g==",
       "requires": {
         "@types/node": "*"
       }
@@ -6589,21 +6467,11 @@
       }
     },
     "@types/connect": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
-      "requires": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
       }
     },
     "@types/form-data": {
@@ -6614,10 +6482,15 @@
         "@types/node": "*"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.182",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+    "@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "@types/node": {
       "version": "12.20.55",
@@ -6625,9 +6498,9 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
     },
     "@types/pbkdf2": {
       "version": "3.1.0",
@@ -6641,11 +6514,6 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
-    },
-    "@types/range-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/secp256k1": {
       "version": "4.0.3",
@@ -6663,6 +6531,35 @@
         "@types/node": "*"
       }
     },
+    "@whatwg-node/events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
+      "integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA=="
+    },
+    "@whatwg-node/fetch": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
+      "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
+      "requires": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "@whatwg-node/node-fetch": "^0.3.6",
+        "busboy": "^1.6.0",
+        "urlpattern-polyfill": "^8.0.0",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "@whatwg-node/node-fetch": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
+      "integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
+      "requires": {
+        "@whatwg-node/events": "^0.0.3",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "fast-url-parser": "^1.1.3",
+        "tslib": "^2.3.1"
+      }
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -6670,6 +6567,16 @@
       "requires": {
         "event-target-shim": "^5.0.0"
       }
+    },
+    "acorn": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w=="
+    },
+    "acorn-walk": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -6683,9 +6590,9 @@
       }
     },
     "ansi-colors": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -6713,28 +6620,41 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
     },
+    "any-signal": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
+      "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.3"
+      }
+    },
     "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
     },
     "apisauce": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-1.1.5.tgz",
-      "integrity": "sha512-gKC8qb/bDJsPsnEXLZnXJ7gVx7dh87CEVNeIwv1dvaffnXoh5GHwac5pWR1P2broLiVj/fqFMQvLDDt/RhjiqA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-2.1.6.tgz",
+      "integrity": "sha512-MdxR391op/FucS2YQRfB/NMRyCnHEPDd4h17LRIuVYi0BpGmMhpxc0shbOpfs5ahABuBEffNCGal5EcsydbBWg==",
       "requires": {
-        "axios": "^0.21.2",
-        "ramda": "^0.25.0"
+        "axios": "^0.21.4"
       }
     },
     "app-module-path": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
       "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ=="
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -6754,11 +6674,6 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "asmcrypto.js": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
-      "integrity": "sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA=="
-    },
     "asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -6767,15 +6682,14 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+    "asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
       }
     },
     "assemblyscript": {
@@ -6792,13 +6706,15 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
     },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+    },
     "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -6861,11 +6777,6 @@
         }
       }
     },
-    "bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6886,77 +6797,23 @@
       "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-101.0.0-nightly.20210723.tgz",
       "integrity": "sha512-eioJNqhHlkguVSbblHOtLqlhtC882SOEPKmNFZaDuz1hzQjolxZ+eu3/kaS10n3sGPONsIZsO7R9fR00UyhEUA=="
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "bl": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
-      "integrity": "sha512-jrCW5ZhfQ/Vt07WX1Ngs+yn9BDqPL/gw28S7s9H6QK/gupnizNzJAss5akW20ISgOrbLTlXOOCTJeNUQqruAWQ==",
-      "requires": {
-        "readable-stream": "^3.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
       "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
+    "blob-to-it": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
+      "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
+      "requires": {
+        "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
     "bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "borc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "requires": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -6979,6 +6836,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+    },
+    "browser-readablestream-to-it": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
+      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -7012,12 +6874,12 @@
       }
     },
     "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-alloc": {
@@ -7049,10 +6911,13 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
     },
-    "builtin-status-codes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -7068,11 +6933,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
-    "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-    },
     "cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
@@ -7087,6 +6947,11 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
+    "cborg": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz",
+      "integrity": "sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug=="
+    },
     "chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -7094,50 +6959,37 @@
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
-    },
-    "cids": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-      "requires": {
-        "buffer": "^5.5.0",
-        "class-is": "^1.1.0",
-        "multibase": "~0.6.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15"
-      },
-      "dependencies": {
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        }
-      }
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -7148,24 +7000,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "class-is": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
-    },
     "clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
       "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
       "requires": {
         "escape-string-regexp": "4.0.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        }
       }
     },
     "cli-cursor": {
@@ -7182,38 +7022,21 @@
       "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "requires": {
         "string-width": "^4.2.3"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
       }
     },
     "cli-spinners": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
-      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="
     },
     "cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "requires": {
         "colors": "^1.1.2",
         "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
+        "string-width": "^4.2.0"
       }
     },
     "clone": {
@@ -7235,9 +7058,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -7274,15 +7097,15 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "requires": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       }
     },
     "create-hash": {
@@ -7310,6 +7133,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7329,22 +7157,17 @@
       }
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
-    },
     "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "requires": {
         "clone": "^1.0.2"
       }
@@ -7359,15 +7182,10 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
-    },
-    "detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -7377,10 +7195,23 @@
         "path-type": "^4.0.0"
       }
     },
+    "dns-over-http-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "requires": {
+        "debug": "^4.3.1",
+        "native-fetch": "^3.0.0",
+        "receptacle": "^1.3.2"
+      }
+    },
     "docker-compose": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.4.tgz",
-      "integrity": "sha512-yWdXby9uQ8o4syOfvoSJ9ZlTnLipvUmDn59uaYY5VGIUSUAfMPPGqE1DE3pOCnfSg9Tl9UOOFO0PCSAzuIHmuA=="
+      "version": "0.23.19",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.19.tgz",
+      "integrity": "sha512-v5vNLIdUqwj4my80wxFDkNH+4S85zsRuH29SO7dCWVWPCMt/ohZBsGN6g6KXWifT0pzQ7uOxqEKCYCDPJ8Vz4g==",
+      "requires": {
+        "yaml": "^1.10.2"
+      }
     },
     "docker-modem": {
       "version": "1.0.9",
@@ -7434,16 +7265,6 @@
         "tar-fs": "~1.16.3"
       }
     },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -7454,9 +7275,20 @@
       }
     },
     "ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "requires": {
+        "jake": "^10.8.5"
+      }
+    },
+    "electron-fetch": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
+      "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
+      "requires": {
+        "encoding": "^0.1.13"
+      }
     },
     "elliptic": {
       "version": "6.5.4",
@@ -7477,6 +7309,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -7486,17 +7326,17 @@
       }
     },
     "enquirer": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.4.tgz",
-      "integrity": "sha512-pkYrrDZumL2VS6VBGDhqbajCM2xpkUNLuKfGPjfKaSIBKYopQbqEFyrOkRMIb2HDR/rO1kGhEt/5twBwtzKBXw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "requires": {
-        "ansi-colors": "^3.2.1"
+        "ansi-colors": "^4.1.1"
       }
     },
     "err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -7520,9 +7360,9 @@
       }
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "esprima": {
       "version": "4.0.1",
@@ -7621,26 +7461,20 @@
       }
     },
     "execa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "requires": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
         "is-stream": "^2.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
       }
-    },
-    "explain-error": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
-      "integrity": "sha512-/wSgNMxFusiYRy1rd19LT2SQlIXDppHpumpWo06wxjflD1OYxDLbl6rMVw+U3bxD5Nuhex4TKqv9Aem4D0lVzQ=="
     },
     "extend": {
       "version": "3.0.2",
@@ -7657,15 +7491,25 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ=="
     },
+    "fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -7679,6 +7523,42 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "fast-levenshtein": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
+      "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
+      "requires": {
+        "fastest-levenshtein": "^1.0.7"
+      }
+    },
+    "fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "requires": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+        }
+      }
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="
+    },
     "fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -7686,11 +7566,6 @@
       "requires": {
         "reusify": "^1.0.4"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filelist": {
       "version": "1.0.4",
@@ -7726,11 +7601,6 @@
         "to-regex-range": "^5.0.1"
       }
     },
-    "flatmap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
-      "integrity": "sha512-OuR+o7kHVe+x9RtIujPay7Uw3bvDZBZFSBXClEphZuSDLmZTqMdclasf4vFSsogC8baDz0eaC2NdO/2dlXHBKQ=="
-    },
     "follow-redirects": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
@@ -7757,20 +7627,20 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       }
     },
     "fs-jetpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-2.4.0.tgz",
-      "integrity": "sha512-S/o9Dd7K9A7gicVU32eT8G0kHcmSu0rCVdP79P0MWInKFb8XpTc8Syhoo66k9no+HDshtlh4pUJTws8X+8fdFQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-4.3.1.tgz",
+      "integrity": "sha512-dbeOK84F6BiQzk2yqqCVwCPWTxAvVGJ3fMQc6E2wuEohS28mR6yHngbrKuVCK1KHRx/ccByDylqu4H5PCP2urQ==",
       "requires": {
         "minimatch": "^3.0.2",
         "rimraf": "^2.6.3"
@@ -7799,6 +7669,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7814,6 +7690,11 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -7825,12 +7706,9 @@
       "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg=="
     },
     "get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "requires": {
-        "pump": "^3.0.0"
-      }
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
     },
     "getpass": {
       "version": "0.1.7",
@@ -7875,19 +7753,20 @@
       }
     },
     "gluegun": {
-      "version": "git+ssh://git@github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a",
-      "from": "gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/gluegun/-/gluegun-5.1.2.tgz",
+      "integrity": "sha512-Cwx/8S8Z4YQg07a6AFsaGnnnmd8mN17414NcPS3OoDtZRwxgsvwRNJNg69niD6fDa8oNwslCG0xH7rEpRNNE/g==",
       "requires": {
-        "apisauce": "^1.0.1",
+        "apisauce": "^2.1.5",
         "app-module-path": "^2.2.0",
-        "cli-table3": "~0.5.0",
-        "colors": "1.3.3",
-        "cosmiconfig": "6.0.0",
-        "cross-spawn": "^7.0.0",
-        "ejs": "^2.6.1",
-        "enquirer": "2.3.4",
-        "execa": "^3.0.0",
-        "fs-jetpack": "^2.2.2",
+        "cli-table3": "0.6.0",
+        "colors": "1.4.0",
+        "cosmiconfig": "7.0.1",
+        "cross-spawn": "7.0.3",
+        "ejs": "3.1.6",
+        "enquirer": "2.3.6",
+        "execa": "5.1.1",
+        "fs-jetpack": "4.3.1",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.lowercase": "^4.3.0",
@@ -7903,18 +7782,35 @@
         "lodash.trimstart": "^4.5.1",
         "lodash.uppercase": "^4.3.0",
         "lodash.upperfirst": "^4.3.1",
-        "ora": "^4.0.0",
+        "ora": "4.0.2",
         "pluralize": "^8.0.0",
-        "ramdasauce": "^2.1.0",
-        "semver": "^7.0.0",
-        "which": "^2.0.0",
-        "yargs-parser": "^16.1.0"
+        "semver": "7.3.5",
+        "which": "2.0.2",
+        "yargs-parser": "^21.0.0"
+      },
+      "dependencies": {
+        "ejs": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+          "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+          "requires": {
+            "jake": "^10.6.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "graphql": {
       "version": "15.5.0",
@@ -7990,11 +7886,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hi-base32": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
-      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -8042,14 +7933,22 @@
       }
     },
     "human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "hyperlinker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
       "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ=="
+    },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
     },
     "ieee754": {
       "version": "1.2.1",
@@ -8057,9 +7956,9 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg=="
     },
     "immutable": {
       "version": "4.2.1",
@@ -8094,235 +7993,125 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
+    "interface-datastore": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
+      "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "requires": {
+        "interface-store": "^2.0.2",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "interface-store": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
     },
     "ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
-    "ipfs-block": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
-      "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
+    "ipfs-core-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.9.0.tgz",
+      "integrity": "sha512-VJ8vJSHvI1Zm7/SxsZo03T+zzpsg8pkgiIi5hfwSJlsrJ1E2v68QPlnLshGHUSYw89Oxq0IbETYl2pGTFHTWfg==",
       "requires": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0"
+        "interface-datastore": "^6.0.2",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13"
+      }
+    },
+    "ipfs-core-utils": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.13.0.tgz",
+      "integrity": "sha512-HP5EafxU4/dLW3U13CFsgqVO5Ika8N4sRSIb/dTg16NjLOozMH31TXV0Grtu2ZWo1T10ahTzMvrfT5f4mhioXw==",
+      "requires": {
+        "any-signal": "^2.1.2",
+        "blob-to-it": "^1.0.1",
+        "browser-readablestream-to-it": "^1.0.1",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.9.0",
+        "ipfs-unixfs": "^6.0.3",
+        "ipfs-utils": "^9.0.2",
+        "it-all": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-peekable": "^1.0.2",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "multiformats": "^9.4.13",
+        "nanoid": "^3.1.23",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^2.0.0",
+        "uint8arrays": "^3.0.0"
       }
     },
     "ipfs-http-client": {
-      "version": "34.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-34.0.0.tgz",
-      "integrity": "sha512-4RCkk8ix4Dqn6sxqFVwuXWCZ1eLFPsVaj6Ijvu1fs9VYgxgVudsW9PWwarlr4mw1xUCmPWYyXnEbGgzBrfMy0Q==",
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-55.0.0.tgz",
+      "integrity": "sha512-GpvEs7C7WL9M6fN/kZbjeh4Y8YN7rY8b18tVWZnKxRsVwM25cIFrRI8CwNt3Ugin9yShieI3i9sPyzYGMrLNnQ==",
       "requires": {
+        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-json": "^8.0.1",
+        "@ipld/dag-pb": "^2.1.3",
         "abort-controller": "^3.0.0",
-        "async": "^2.6.1",
-        "bignumber.js": "^9.0.0",
-        "bl": "^3.0.0",
-        "bs58": "^4.0.1",
-        "buffer": "^5.4.2",
-        "cids": "~0.7.1",
-        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "end-of-stream": "^1.4.1",
-        "err-code": "^2.0.0",
-        "explain-error": "^1.0.4",
-        "flatmap": "0.0.3",
-        "glob": "^7.1.3",
-        "ipfs-block": "~0.8.1",
-        "ipfs-utils": "~0.0.3",
-        "ipld-dag-cbor": "~0.15.0",
-        "ipld-dag-pb": "~0.17.3",
-        "ipld-raw": "^4.0.0",
-        "is-ipfs": "~0.6.1",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "iso-stream-http": "~0.1.2",
-        "iso-url": "~0.4.6",
-        "iterable-ndjson": "^1.1.0",
-        "just-kebab-case": "^1.1.0",
-        "just-map-keys": "^1.1.0",
-        "kind-of": "^6.0.2",
-        "ky": "^0.11.2",
-        "ky-universal": "^0.2.2",
-        "lru-cache": "^5.1.1",
-        "multiaddr": "^6.0.6",
-        "multibase": "~0.6.0",
-        "multicodec": "~0.5.1",
-        "multihashes": "~0.4.14",
-        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.3",
-        "peer-info": "~0.15.1",
-        "promise-nodeify": "^3.0.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "pull-to-stream": "~0.1.1",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^3.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^2.0.1",
-        "through2": "^3.0.1"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "git+ssh://git@github.com/hugomrdias/concat-stream.git#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-          "from": "concat-stream@github:hugomrdias/concat-stream#feat/smaller",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
+        "any-signal": "^2.1.2",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.9.0",
+        "ipfs-core-utils": "^0.13.0",
+        "ipfs-utils": "^9.0.2",
+        "it-first": "^1.0.6",
+        "it-last": "^1.0.4",
+        "merge-options": "^3.0.4",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.13",
+        "native-abort-controller": "^1.0.3",
+        "parse-duration": "^1.0.0",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "ipfs-unixfs": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
+      "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+      "requires": {
+        "err-code": "^3.0.1",
+        "protobufjs": "^6.10.2"
       }
     },
     "ipfs-utils": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.0.4.tgz",
-      "integrity": "sha512-7cZf6aGj2FG3XJWhCNwn4mS93Q0GEWjtBZvEHqzgI43U2qzNDCyzfS1pei1Y5F+tw/zDJ5U4XG0G9reJxR53Ig==",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
+      "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
       "requires": {
-        "buffer": "^5.2.1",
-        "is-buffer": "^2.0.3",
+        "any-signal": "^3.0.0",
+        "browser-readablestream-to-it": "^1.0.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
         "is-electron": "^2.2.0",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "kind-of": "^6.0.2",
-        "readable-stream": "^3.4.0"
+        "iso-url": "^1.1.5",
+        "it-all": "^1.0.4",
+        "it-glob": "^1.0.1",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "^2.6.8",
+        "react-native-fetch-api": "^3.0.0",
+        "stream-to-it": "^0.2.2"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "ipld-dag-cbor": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.3.tgz",
-      "integrity": "sha512-m23nG7ZyoVFnkK55/bLAErc7EfiMgaEQlqHWDTGzPI+O5r6bPfp+qbL5zTVSIT8tpbHmu174dwerVtLoVgeVyA==",
-      "requires": {
-        "borc": "^2.1.2",
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
-        "is-circular": "^1.0.2",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
-      }
-    },
-    "ipld-dag-pb": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.17.4.tgz",
-      "integrity": "sha512-YwCxETEMuXVspOKOhjIOHJvKvB/OZfCDkpSFiYBQN2/JQjM9y/RFCYzIQGm0wg7dCFLrhvfjAZLTSaKs65jzWA==",
-      "requires": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0",
-        "multicodec": "~0.5.1",
-        "multihashing-async": "~0.7.0",
-        "protons": "^1.0.1",
-        "stable": "~0.1.8"
-      },
-      "dependencies": {
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha512-CJAN+O0/yA1CKfRn9SXOGctSpEM7DCon/r/5r2eXFMY2zCCJBasFhcM5I+1kh3Ap11FsQCX+vGHceNPvpWKhoA=="
-        },
-        "multihashing-async": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.7.0.tgz",
-          "integrity": "sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.2.1",
-            "err-code": "^1.1.2",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
-      }
-    },
-    "ipld-raw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-4.0.1.tgz",
-      "integrity": "sha512-WjIdtZ06jJEar8zh+BHB84tE6ZdbS/XNa7+XCArOYfmeJ/c01T9VQpeMwdJQYn5c3s5UvvCu7y4VIi3vk2g1bA==",
-      "requires": {
-        "cids": "~0.7.0",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
-      },
-      "dependencies": {
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
+        "any-signal": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+          "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
         }
       }
     },
@@ -8339,25 +8128,15 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
-    },
-    "is-circular": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
-    },
     "is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
     },
     "is-electron": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
-      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -8365,9 +8144,9 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.3",
@@ -8388,116 +8167,11 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
     },
     "is-ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
-      "integrity": "sha512-9MTn0dteHETtyUx8pxqMwg5hMBi3pvlyglJ+b79KOCca0po23337LbVV2Hl4xmMvfw++ljnO0/+5G6G+0Szh6g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
       "requires": {
-        "ip-regex": "^2.0.0"
-      }
-    },
-    "is-ipfs": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.3.tgz",
-      "integrity": "sha512-HyRot1dvLcxImtDqPxAaY1miO6WsiP/z7Yxpg2qpaLWv5UdhAPtLvHJ4kMLM0w8GSl8AFsVF23PHe1LzuWrUlQ==",
-      "requires": {
-        "bs58": "^4.0.1",
-        "cids": "~0.7.0",
-        "mafmt": "^7.0.0",
-        "multiaddr": "^7.2.1",
-        "multibase": "~0.6.0",
-        "multihashes": "~0.4.13"
-      },
-      "dependencies": {
-        "ip-regex": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-          "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
-        },
-        "is-ip": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-          "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-          "requires": {
-            "ip-regex": "^4.0.0"
-          }
-        },
-        "multiaddr": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "cids": "~0.8.0",
-            "class-is": "^1.1.0",
-            "is-ip": "^3.1.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "cids": {
-              "version": "0.8.3",
-              "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-              "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-              "requires": {
-                "buffer": "^5.6.0",
-                "class-is": "^1.1.0",
-                "multibase": "^1.0.0",
-                "multicodec": "^1.0.1",
-                "multihashes": "^1.0.1"
-              },
-              "dependencies": {
-                "multibase": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-                  "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-                  "requires": {
-                    "base-x": "^3.0.8",
-                    "buffer": "^5.5.0"
-                  }
-                }
-              }
-            },
-            "multibase": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            },
-            "multihashes": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-              "requires": {
-                "buffer": "^5.6.0",
-                "multibase": "^1.0.1",
-                "varint": "^5.0.0"
-              },
-              "dependencies": {
-                "multibase": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-                  "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-                  "requires": {
-                    "base-x": "^3.0.8",
-                    "buffer": "^5.5.0"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        }
+        "ip-regex": "^4.0.0"
       }
     },
     "is-number": {
@@ -8505,15 +8179,10 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
-    "is-promise": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-      "integrity": "sha512-mjWH5XxnhMA8cFnDchr6qRP9S/kLntKuEfIYku+PaN1CnS8v+OG9O/BKpRCVRJvpIkgAZm0Pf5Is3iSSOILlcg=="
-    },
-    "is-pull-stream": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/is-pull-stream/-/is-pull-stream-0.0.0.tgz",
-      "integrity": "sha512-NWLwqCc95I6m8FZDYLAmVJc9Xgk8O+8pPOoDKFTC293FH4S7FBcbLCw3WWPCdiT8uUSdzPy47VM08WPDMJJrag=="
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
     "is-stream": {
       "version": "2.0.1",
@@ -8543,62 +8212,10 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "iso-random-stream": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.2.tgz",
-      "integrity": "sha512-7y0tsBBgQs544iTYjyrMp5xvgrbYR8b+plQq1Bryp+03p0LssrxC9C1M0oHv4QESDt7d95c74XvMk/yawKqX+A==",
-      "requires": {
-        "buffer": "^6.0.3",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "iso-stream-http": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/iso-stream-http/-/iso-stream-http-0.1.2.tgz",
-      "integrity": "sha512-oHEDNOysIMTNypbg2f1SlydqRBvjl4ZbSE9+0awVxnkx3K2stGTFwB/kpVqnB6UEfF8QD36kAjDwZvqyXBLMnQ==",
-      "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "iso-url": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
     },
     "isomorphic-ws": {
       "version": "4.0.1",
@@ -8611,30 +8228,76 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
-    "iterable-ndjson": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
-      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+    "it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+    },
+    "it-first": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
       "requires": {
-        "string_decoder": "^1.2.0"
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "it-last": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
+      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+    },
+    "it-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+    },
+    "it-peekable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
+      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+    },
+    "it-to-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+      "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "requires": {
+        "buffer": "^6.0.3",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "jake": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
-      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
       "requires": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
       },
       "dependencies": {
-        "async": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8643,17 +8306,23 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
     "jayson": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.6.6.tgz",
-      "integrity": "sha512-f71uvrAWTtrwoww6MKcl9phQTC+56AopLyEenWvKVAIMz+q0oVGj6tenLZ7Z6UiPBkJtKLj4kt0tACllFQruGQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.0.0.tgz",
+      "integrity": "sha512-v2RNpDCMu45fnLzSk47vx7I+QUaOsox6f5X0CUlabAFwxoP+8MfAY0NQRFwOEYXIxm8Ih5y6OaEa5KYiQMkyAA==",
       "requires": {
         "@types/connect": "^3.4.33",
-        "@types/express-serve-static-core": "^4.17.9",
-        "@types/lodash": "^4.14.159",
         "@types/node": "^12.12.54",
         "@types/ws": "^7.4.4",
         "commander": "^2.20.3",
@@ -8663,7 +8332,6 @@
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
         "JSONStream": "^1.3.5",
-        "lodash": "^4.17.20",
         "uuid": "^8.3.2",
         "ws": "^7.4.5"
       },
@@ -8690,9 +8358,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -8723,14 +8391,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -8738,13 +8398,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      },
-      "dependencies": {
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-        }
       }
     },
     "jsonparse": {
@@ -8772,16 +8425,6 @@
         "verror": "1.10.0"
       }
     },
-    "just-kebab-case": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/just-kebab-case/-/just-kebab-case-1.1.0.tgz",
-      "integrity": "sha512-QkuwuBMQ9BQHMUEkAtIA4INLrkmnnveqlFB1oFi09gbU0wBdZo6tTnyxNWMR84zHxBuwK7GLAwqN8nrvVxOLTA=="
-    },
-    "just-map-keys": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/just-map-keys/-/just-map-keys-1.2.1.tgz",
-      "integrity": "sha512-Dmyz1Cy2SWM+PpqDPB1kdDglyexdzMthnAsvOIE9w4OPj8NDRuY1mh20x/JfG5w6fCGw9F0WmcofJhYZ4MiuyA=="
-    },
     "keccak": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
@@ -8804,103 +8447,10 @@
         }
       }
     },
-    "keypair": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.4.tgz",
-      "integrity": "sha512-zwhgOhhniaL7oxMgUMKKw5219PWWABMO+dgMnzJOQ2/5L3XJtTJGhW2PEXlxXj9zaccdReZJZ83+4NPhVfNVDg=="
-    },
-    "kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-    },
-    "ky": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.11.2.tgz",
-      "integrity": "sha512-5Aou5BWue5/mkPqIRqzSWW+0Hkl403pr/2AIrCKYw7cVl/Xoe8Xe4KLBO0PRjbz7GnRe1/8wW1KhqQNFFE7/GQ=="
-    },
-    "ky-universal": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.2.2.tgz",
-      "integrity": "sha512-fb32o/fKy/ux2ALWa9HU2hvGtfOq7/vn2nH0FpVE+jwNzyTeORlAbj3Fiw+WLMbUlmVqZIWupnLZ2USHvqwZHw==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "^2.3.0"
-      }
-    },
-    "libp2p-crypto": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.4.tgz",
-      "integrity": "sha512-II8HxKc9jbmQp34pprlluNxsBCWJDjHRPYJzuRy7ragztNip9Zb7uJ4lCje6gGzz4DNAcHkAUn+GqCIK1592iA==",
-      "requires": {
-        "asmcrypto.js": "^2.3.2",
-        "asn1.js": "^5.0.1",
-        "async": "^2.6.1",
-        "bn.js": "^4.11.8",
-        "browserify-aes": "^1.2.0",
-        "bs58": "^4.0.1",
-        "iso-random-stream": "^1.1.0",
-        "keypair": "^1.0.1",
-        "libp2p-crypto-secp256k1": "~0.3.0",
-        "multihashing-async": "~0.5.1",
-        "node-forge": "^0.10.0",
-        "pem-jwk": "^2.0.0",
-        "protons": "^1.0.1",
-        "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.10.0"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
-          "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
-      }
-    },
-    "libp2p-crypto-secp256k1": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.1.tgz",
-      "integrity": "sha512-evrfK/CeUSd/lcELUdDruyPBvxDmLairth75S32OLl3H+++2m2fV24JEtxzdFS9JH3xEFw0h6JFO8DBa1bP9dA==",
-      "requires": {
-        "async": "^2.6.2",
-        "bs58": "^4.0.1",
-        "multihashing-async": "~0.6.0",
-        "nodeify": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "secp256k1": "^3.6.2"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
-          "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
-      }
-    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -9016,6 +8566,11 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -9036,116 +8591,18 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "looper": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-      "integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg=="
-    },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
       }
     },
-    "mafmt": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
-      "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
-      "requires": {
-        "multiaddr": "^7.3.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        },
-        "ip-regex": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-          "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
-        },
-        "is-ip": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-          "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-          "requires": {
-            "ip-regex": "^4.0.0"
-          }
-        },
-        "multiaddr": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "cids": "~0.8.0",
-            "class-is": "^1.1.0",
-            "is-ip": "^3.1.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        }
-      }
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -9155,6 +8612,14 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "requires": {
+        "is-plain-obj": "^2.1.0"
       }
     },
     "merge-stream": {
@@ -9223,13 +8688,6 @@
       "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
       "requires": {
         "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
       }
     },
     "minizlib": {
@@ -9239,13 +8697,6 @@
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
       }
     },
     "mkdirp": {
@@ -9259,129 +8710,52 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multiaddr": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
-      "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
+      "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
       "requires": {
-        "bs58": "^4.0.1",
-        "class-is": "^1.1.0",
-        "hi-base32": "~0.5.0",
-        "ip": "^1.1.5",
-        "is-ip": "^2.0.0",
-        "varint": "^5.0.0"
+        "dns-over-http-resolver": "^1.2.3",
+        "err-code": "^3.0.1",
+        "is-ip": "^3.1.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
       }
     },
-    "multibase": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+    "multiaddr-to-uri": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-8.0.0.tgz",
+      "integrity": "sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==",
       "requires": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
+        "multiaddr": "^10.0.0"
       }
     },
-    "multicodec": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
-      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
-      "requires": {
-        "varint": "^5.0.0"
-      }
+    "multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
-    "multihashes": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-      "requires": {
-        "buffer": "^5.5.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        }
-      }
+    "nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
-    "multihashing-async": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-      "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
-      "requires": {
-        "blakejs": "^1.1.0",
-        "buffer": "^5.4.3",
-        "err-code": "^2.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^1.0.1",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
-      }
+    "native-abort-controller": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
+      "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
+      "requires": {}
     },
-    "murmurhash3js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
-      "integrity": "sha512-KL8QYUaxq7kUbcl0Yto51rMcYt7E/4N4BG3/c96Iqw1PQrTRspu8Cpx4TZ4Nunib1d4bEkIH3gjCYlP2RLBdow=="
-    },
-    "murmurhash3js-revisited": {
+    "native-fetch": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
-      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
-    },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
-    },
-    "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "requires": {}
     },
     "natural-orderby": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
       "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q=="
-    },
-    "ndjson": {
-      "version": "git+ssh://git@github.com/hugomrdias/ndjson.git#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-      "from": "ndjson@github:hugomrdias/ndjson#feat/readable-stream3",
-      "requires": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.0",
-        "split2": "^3.1.0",
-        "through2": "^3.0.0"
-      }
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-addon-api": {
       "version": "2.0.2",
@@ -9389,28 +8763,17 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-    },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-gyp-build": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
       "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
-    },
-    "nodeify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
-      "integrity": "sha512-n7C2NyEze8GCo/z73KdbjRsBiLbv6eBn1FxwYKQ23IqGo7pQY3mhQan61Sv7eEDJCiyUjTVrVkXTzJCo1dW7Aw==",
-      "requires": {
-        "is-promise": "~1.0.0",
-        "promise": "~1.3.0"
-      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -9477,33 +8840,97 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "requires": {
-        "wordwrap": "~0.0.2"
-      }
-    },
     "ora": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
-      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.2.tgz",
+      "integrity": "sha512-YUOZbamht5mfLxPmk4M35CD/5DuOkAacxlEUbStVXpBAt4fyhBf+vZHI/HRkI++QUp3sNoeA2Gw4C+hi4eGSig==",
       "requires": {
-        "chalk": "^3.0.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^3.1.0",
         "cli-spinners": "^2.2.0",
         "is-interactive": "^1.0.0",
         "log-symbols": "^3.0.0",
-        "mute-stream": "0.0.8",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^5.2.0",
         "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
-    "p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
+    "p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "requires": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -9518,6 +8945,11 @@
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
     },
+    "parse-duration": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -9530,62 +8962,12 @@
       }
     },
     "password-prompt": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
-      "integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
+      "integrity": "sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==",
       "requires": {
-        "ansi-escapes": "^3.1.0",
-        "cross-spawn": "^6.0.5"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
+        "ansi-escapes": "^4.3.2",
+        "cross-spawn": "^7.0.3"
       }
     },
     "path-is-absolute": {
@@ -9597,6 +8979,27 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "requires": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+          "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag=="
+        },
+        "minipass": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+          "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ=="
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -9615,46 +9018,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "peer-id": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.5.tgz",
-      "integrity": "sha512-3xVWrtIvNm9/OPzaQBgXDrfWNx63AftgFQkvqO6YSZy7sP3Fuadwwbn54F/VO9AnpyW/26i0WRQz9FScivXrmw==",
-      "requires": {
-        "async": "^2.6.3",
-        "class-is": "^1.1.0",
-        "libp2p-crypto": "~0.16.1",
-        "multihashes": "~0.4.15"
-      }
-    },
-    "peer-info": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
-      "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
-      "requires": {
-        "mafmt": "^6.0.2",
-        "multiaddr": "^6.0.3",
-        "peer-id": "~0.12.2",
-        "unique-by": "^1.0.0"
-      },
-      "dependencies": {
-        "mafmt": {
-          "version": "6.0.10",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
-          "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
-          "requires": {
-            "multiaddr": "^6.1.0"
-          }
-        }
-      }
-    },
-    "pem-jwk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
-      "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
-      "requires": {
-        "asn1.js": "^5.0.1"
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -9671,47 +9034,44 @@
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
-      "integrity": "sha512-R9WrbTF3EPkVtWjp7B7umQGVndpsi+rsDAfrR4xAALQpFLa/+2OriecLhawxzvii2gd9+DZFwROWDuUUaqS5yA==",
+    "protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "requires": {
-        "is-promise": "~1"
-      }
-    },
-    "promise-nodeify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/promise-nodeify/-/promise-nodeify-3.0.1.tgz",
-      "integrity": "sha512-ghsSuzZXJX8iO7WVec2z7GI+Xk/EyiD+JZK7AZKhUqYfpLa/Zs4ylUD+CwwnKlG6G3HnkUPMAi6PO7zeqGKssg=="
-    },
-    "promisify-es6": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
-      "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA=="
-    },
-    "protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
-    },
-    "protons": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
-      "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
-      "requires": {
-        "buffer": "^5.5.0",
-        "protocol-buffers-schema": "^3.3.1",
-        "signed-varint": "^2.0.1",
-        "varint": "^5.0.0"
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "20.10.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+          "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "psl": {
@@ -9719,49 +9079,23 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
-    "pull-defer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
-    },
-    "pull-stream": {
-      "version": "3.6.14",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
-    },
-    "pull-to-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.1.tgz",
-      "integrity": "sha512-thZkMv6F9PILt9zdvpI2gxs19mkDrlixYKX6cOBxAW16i1NZH+yLAmF4r8QfJ69zuQh27e01JZP9y27tsH021w==",
-      "requires": {
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "requires": {
+        "tslib": "^2.6.1"
+      }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
     },
     "qs": {
       "version": "6.11.0",
@@ -9776,32 +9110,20 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
-    "ramda": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
-    },
-    "ramdasauce": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ramdasauce/-/ramdasauce-2.1.3.tgz",
-      "integrity": "sha512-Ml3CPim4SKwmg5g9UI77lnRSeKr/kQw7YhQ6rfdMcBYy6DMlwmkEwQqjygJ3OhxPR+NfFfpjKl3Tf8GXckaqqg==",
-      "requires": {
-        "ramda": "^0.24.1"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-          "integrity": "sha512-HEm619G8PaZMfkqCa23qiOe7r3R0brPu7ZgOsgKUsnvLhd0qhc/vTjkUovomgPWa5ECBa08fJZixth9LaoBo5w=="
-        }
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "react-native-fetch-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
+      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+      "requires": {
+        "p-defer": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -9834,11 +9156,19 @@
       }
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "requires": {
+        "ms": "^2.1.1"
       }
     },
     "redeyed": {
@@ -9848,11 +9178,6 @@
       "requires": {
         "esprima": "~4.0.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "request": {
       "version": "2.88.2",
@@ -9907,6 +9232,11 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -9944,30 +9274,6 @@
         }
       }
     },
-    "rsa-pem-to-jwk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
-      "integrity": "sha512-ZlVavEvTnD8Rzh/pdB8NH4VF5GNEtF6biGQcTtC4GKFMsbZR08oHtOYefbhCN+JnJIuMItiCDCMycdcMrw6blA==",
-      "requires": {
-        "object-assign": "^2.0.0",
-        "rsa-unpack": "0.0.6"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha512-CdsOUYIh5wIiozhJ3rLQgmUTgcyzFwZZrqhkKhODMoGtPKM+wt0h0CNIoauJWMsS9822EdzPsF/6mb4nLvPN5g=="
-        }
-      }
-    },
-    "rsa-unpack": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/rsa-unpack/-/rsa-unpack-0.0.6.tgz",
-      "integrity": "sha512-HRrl8GHjjPziPFRDJPq/v5OxZ3IPdksV5h3cime/oHgcgM1k1toO5OdtzClgBqRf5dF6IgptOB0g/zFb0w5zQw==",
-      "requires": {
-        "optimist": "~0.3.5"
-      }
-    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9991,42 +9297,12 @@
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
-    "secp256k1": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.5.2",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
       "requires": {
         "lru-cache": "^6.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
       }
     },
     "setimmediate": {
@@ -10071,18 +9347,20 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
-    "signed-varint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
-      "integrity": "sha512-abgDPg1106vuZZOvw7cFwdCABddfJRz5akcCcchzTbhyhYnsG31y4AlZEgp315T7W3nQq5P4xeOm186ZiPVFzw==",
-      "requires": {
-        "varint": "~5.0.0"
-      }
-    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -10102,26 +9380,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
-    },
-    "split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "requires": {
-        "readable-stream": "^3.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -10151,19 +9409,18 @@
         }
       }
     },
-    "stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
-    },
-    "stream-to-pull-stream": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
+    "stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "requires": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
+        "get-iterator": "^1.0.2"
       }
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -10174,27 +9431,13 @@
       }
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
@@ -10219,9 +9462,9 @@
       }
     },
     "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -10233,6 +9476,16 @@
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "sync-request": {
@@ -10264,13 +9517,6 @@
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
       }
     },
     "tar-fs": {
@@ -10331,40 +9577,6 @@
         }
       }
     },
-    "tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "then-request": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
@@ -10403,13 +9615,14 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
-    "through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+    "timeout-abort-controller": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-2.0.0.tgz",
+      "integrity": "sha512-2FAPXfzTPYEgw27bQGTHc0SzrbmnU2eso4qo172zMLZzaGqeu09PFa5B2FCUHM1tflgRqPgn5KQgp6+Vex4uNA==",
       "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "^1.0.4",
+        "retimer": "^3.0.0"
       }
     },
     "tmp": {
@@ -10421,9 +9634,9 @@
       }
     },
     "tmp-promise": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.2.tgz",
-      "integrity": "sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "requires": {
         "tmp": "^0.2.0"
       }
@@ -10450,10 +9663,35 @@
         "punycode": "^2.1.1"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
+    },
     "tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -10462,11 +9700,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type-fest": {
       "version": "0.21.3",
@@ -10478,15 +9711,29 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
-    "unique-by": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
-      "integrity": "sha512-rJRXK5V0zL6TiSzhoGNpJp5dr+TZBLoPJFC06rLn17Ug++7Aa0Qnve5v+skXeQxx6/sI7rBsSesa6MAcmFi8Ew=="
+    "typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "peer": true
+    },
+    "uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "requires": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -10496,14 +9743,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "ursa-optional": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.2.tgz",
-      "integrity": "sha512-TKdwuLboBn7M34RcvVTuQyhvrA8gYKapuVdm0nBP0mnBc7oECOfUQZrY91cefL3/nm64ZyrejSRrhTVdX7NG/A==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.14.2"
-      }
+    "urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ=="
     },
     "utf8": {
       "version": "3.0.0",
@@ -10520,10 +9763,15 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
     "varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "verror": {
       "version": "1.10.0",
@@ -10550,6 +9798,11 @@
         "defaults": "^1.0.3"
       }
     },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+    },
     "web3-eth-abi": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.0.tgz",
@@ -10573,6 +9826,32 @@
         "utf8": "3.0.0"
       }
     },
+    "webcrypto-core": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10587,29 +9866,12 @@
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "requires": {
         "string-width": "^4.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
       }
     },
     "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -10619,23 +9881,6 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
       }
     },
     "wrappy": {
@@ -10644,9 +9889,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "requires": {}
     },
     "xtend": {
@@ -10655,26 +9900,24 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
-      "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
-      "requires": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs-parser": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/subgraphs/abracadabra/package.json
+++ b/subgraphs/abracadabra/package.json
@@ -4,8 +4,10 @@
     "format": "npx prettier --write ."
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.42.4",
-    "@graphprotocol/graph-ts": "0.29.3",
-    "prettier": "^2.7.1"
+    "@graphprotocol/graph-cli": "^0.64.0",
+    "@graphprotocol/graph-ts": "^0.32.0"
+  },
+  "devDependencies": {
+    "prettier": "^3.1.1"
   }
 }

--- a/subgraphs/abracadabra/schema.graphql
+++ b/subgraphs/abracadabra/schema.graphql
@@ -288,6 +288,12 @@ type LendingProtocol implements Protocol @entity @regularPolling {
   " Sum of all historical liquidations in USD "
   cumulativeLiquidateUSD: BigDecimal!
 
+  " Sum of all historical withdrawals in USD "
+  cumulativeWithdrawUSD: BigDecimal!
+
+  " Sum of all historical repayments in USD "
+  cumulativeRepayUSD: BigDecimal!
+
   " Total supply of minted tokens in native amounts, with same ordering as mintedTokens. Only applies to CDP "
   mintedTokenSupplies: [BigInt!]
 
@@ -321,13 +327,19 @@ type LendingProtocol implements Protocol @entity @regularPolling {
   ##### Add ons #####
 
   marketIDList: [String!]!
+
+  " Helper field for taking daily snapshots "
+  _lastDailySnapshotTimestamp: BigInt!
+
+  " Helper field for taking hourly snapshots "
+  _lastHourlySnapshotTimestamp: BigInt!
 }
 
 ###############################
 ##### Protocol Timeseries #####
 ###############################
 
-type UsageMetricsDailySnapshot @entity @dailySnapshot {
+type UsageMetricsDailySnapshot @entity(immutable: true) @dailySnapshot {
   " ID is # of days since Unix epoch time "
   id: ID!
 
@@ -392,7 +404,7 @@ type UsageMetricsDailySnapshot @entity @dailySnapshot {
   timestamp: BigInt!
 }
 
-type UsageMetricsHourlySnapshot @entity @hourlySnapshot {
+type UsageMetricsHourlySnapshot @entity(immutable: true) @hourlySnapshot {
   " { # of hours since Unix epoch time } "
   id: ID!
 
@@ -430,7 +442,7 @@ type UsageMetricsHourlySnapshot @entity @hourlySnapshot {
   timestamp: BigInt!
 }
 
-type FinancialsDailySnapshot @entity @dailySnapshot {
+type FinancialsDailySnapshot @entity(immutable: true) @dailySnapshot {
   " ID is # of days since Unix epoch time "
   id: ID!
 
@@ -501,8 +513,14 @@ type FinancialsDailySnapshot @entity @dailySnapshot {
   " Total assets withdrawn on a given day, in USD. "
   dailyWithdrawUSD: BigDecimal!
 
+  " Sum of all historical withdrawals in USD "
+  cumulativeWithdrawUSD: BigDecimal!
+
   " Total assets repaid on a given day, in USD. "
   dailyRepayUSD: BigDecimal!
+
+  " Sum of all historical repayments in USD "
+  cumulativeRepayUSD: BigDecimal!
 }
 
 ###############################
@@ -577,6 +595,12 @@ type Market @entity @regularPolling {
 
   " Sum of all historical liquidations in USD "
   cumulativeLiquidateUSD: BigDecimal!
+
+  " Sum of all historical withdrawals in USD "
+  cumulativeWithdrawUSD: BigDecimal!
+
+  " Sum of all historical repayments in USD "
+  cumulativeRepayUSD: BigDecimal!
 
   ##### Token Balances #####
 
@@ -656,13 +680,19 @@ type Market @entity @regularPolling {
 
   " Market's price oracle "
   priceOracle: Bytes
+
+  " Helper field for taking daily snapshots "
+  _lastDailySnapshotTimestamp: BigInt!
+
+  " Helper field for taking hourly snapshots "
+  _lastHourlySnapshotTimestamp: BigInt!
 }
 
 #################################
 ##### Pool-Level Timeseries #####
 #################################
 
-type MarketDailySnapshot @entity @dailySnapshot {
+type MarketDailySnapshot @entity(immutable: true) @dailySnapshot {
   " { Smart contract address of the market }-{ # of days since Unix epoch time } "
   id: ID!
 
@@ -731,8 +761,14 @@ type MarketDailySnapshot @entity @dailySnapshot {
   " Total assets withdrawn on a given day, in USD. "
   dailyWithdrawUSD: BigDecimal!
 
+  " Sum of all historical withdrawals in USD "
+  cumulativeWithdrawUSD: BigDecimal!
+
   " Total assets repaid on a given day, in USD. "
   dailyRepayUSD: BigDecimal!
+
+  " Sum of all historical repayments in USD "
+  cumulativeRepayUSD: BigDecimal!
 
   ##### Token Balances #####
 
@@ -758,7 +794,7 @@ type MarketDailySnapshot @entity @dailySnapshot {
   rewardTokenEmissionsUSD: [BigDecimal!]
 }
 
-type MarketHourlySnapshot @entity @hourlySnapshot {
+type MarketHourlySnapshot @entity(immutable: true) @hourlySnapshot {
   " { Smart contract address of the market }-{ # of hours since Unix epoch time } "
   id: ID!
 
@@ -827,8 +863,14 @@ type MarketHourlySnapshot @entity @hourlySnapshot {
   " Total assets withdrawn on a given hour, in USD. "
   hourlyWithdrawUSD: BigDecimal!
 
+  " Sum of all historical withdrawals in USD "
+  cumulativeWithdrawUSD: BigDecimal!
+
   " Total assets repaid on a given hour, in USD. "
   hourlyRepayUSD: BigDecimal!
+
+  " Sum of all historical repayments in USD "
+  cumulativeRepayUSD: BigDecimal!
 
   ##### Token Balances #####
 
@@ -1254,4 +1296,22 @@ type PositionCounter @entity {
 type ActiveEventAccount @entity {
   "{ daily/hourly }-{ Address of the account }-{ Days/hours since Unix epoch }-{ EventType: Optional }"
   id: ID!
+}
+
+# Helper entity for calculating daily/hourly fields
+type _ActivityHelper @entity {
+  id: ID!
+
+  activeUsers: Int!
+  activeDepositors: Int!
+  activeBorrowers: Int!
+  activeLiquidators: Int!
+  activeLiquidatees: Int!
+
+  transactionCount: Int!
+  depositCount: Int!
+  borrowCount: Int!
+  liquidateCount: Int!
+  withdrawCount: Int!
+  repayCount: Int!
 }

--- a/subgraphs/abracadabra/schema.graphql
+++ b/subgraphs/abracadabra/schema.graphql
@@ -37,7 +37,7 @@ enum ProtocolType {
 
 type Token @entity @regularPolling {
   " Smart contract address of the token "
-  id: ID!
+  id: Bytes!
 
   " Name of the token, mirrored from the smart contract "
   name: String!
@@ -65,7 +65,7 @@ enum RewardTokenType {
 
 type RewardToken @entity @regularPolling {
   " { Reward token type }-{ Smart contract address of the reward token } "
-  id: ID!
+  id: Bytes!
 
   " Reference to the actual token "
   token: Token!
@@ -123,7 +123,7 @@ enum PositionSide {
 # to the IDs to differentiate.
 type InterestRate @entity @regularPolling {
   " { Interest rate side }-{ Interest rate type }-{ Market ID } "
-  id: ID!
+  id: Bytes!
 
   " Interest rate in percentage APY. E.g. 5.21% should be stored as 5.21 "
   rate: BigDecimal!
@@ -147,7 +147,7 @@ type InterestRate @entity @regularPolling {
 
 interface Protocol {
   " Smart contract address of the protocol's main contract (Factory, Registry, etc) "
-  id: ID!
+  id: Bytes!
 
   " Name of the protocol, including version. e.g. Uniswap v3 "
   name: String!
@@ -209,7 +209,7 @@ interface Protocol {
 
 type LendingProtocol implements Protocol @entity @regularPolling {
   " Smart contract address of the protocol's main contract (Factory, Registry, etc) "
-  id: ID!
+  id: Bytes!
 
   " Name of the protocol, including version. e.g. Aave v2 "
   name: String!
@@ -326,7 +326,7 @@ type LendingProtocol implements Protocol @entity @regularPolling {
 
   ##### Add ons #####
 
-  marketIDList: [String!]!
+  marketIDList: [Bytes!]!
 
   " Helper field for taking daily snapshots "
   _lastDailySnapshotTimestamp: BigInt!
@@ -341,7 +341,7 @@ type LendingProtocol implements Protocol @entity @regularPolling {
 
 type UsageMetricsDailySnapshot @entity(immutable: true) @dailySnapshot {
   " ID is # of days since Unix epoch time "
-  id: ID!
+  id: Bytes!
 
   " Protocol this snapshot is associated with "
   protocol: LendingProtocol!
@@ -406,7 +406,7 @@ type UsageMetricsDailySnapshot @entity(immutable: true) @dailySnapshot {
 
 type UsageMetricsHourlySnapshot @entity(immutable: true) @hourlySnapshot {
   " { # of hours since Unix epoch time } "
-  id: ID!
+  id: Bytes!
 
   " Protocol this snapshot is associated with "
   protocol: LendingProtocol!
@@ -444,7 +444,7 @@ type UsageMetricsHourlySnapshot @entity(immutable: true) @hourlySnapshot {
 
 type FinancialsDailySnapshot @entity(immutable: true) @dailySnapshot {
   " ID is # of days since Unix epoch time "
-  id: ID!
+  id: Bytes!
 
   " Protocol this snapshot is associated with "
   protocol: LendingProtocol!
@@ -529,7 +529,7 @@ type FinancialsDailySnapshot @entity(immutable: true) @dailySnapshot {
 
 type Market @entity @regularPolling {
   " Smart contract address of the market "
-  id: ID!
+  id: Bytes!
 
   " The protocol this pool belongs to "
   protocol: LendingProtocol!
@@ -694,7 +694,7 @@ type Market @entity @regularPolling {
 
 type MarketDailySnapshot @entity(immutable: true) @dailySnapshot {
   " { Smart contract address of the market }-{ # of days since Unix epoch time } "
-  id: ID!
+  id: Bytes!
 
   " The protocol this snapshot belongs to "
   protocol: LendingProtocol!
@@ -796,7 +796,7 @@ type MarketDailySnapshot @entity(immutable: true) @dailySnapshot {
 
 type MarketHourlySnapshot @entity(immutable: true) @hourlySnapshot {
   " { Smart contract address of the market }-{ # of hours since Unix epoch time } "
-  id: ID!
+  id: Bytes!
 
   " The protocol this snapshot belongs to "
   protocol: LendingProtocol!
@@ -902,7 +902,7 @@ type MarketHourlySnapshot @entity(immutable: true) @hourlySnapshot {
 
 type Account @entity @regularPolling {
   " { Account address } "
-  id: ID!
+  id: Bytes!
 
   " Number of positions this account has "
   positionCount: Int!
@@ -955,7 +955,7 @@ type Account @entity @regularPolling {
 
 type Position @entity @regularPolling {
   " { Account address }-{ Market address }-{ Position Side }-{ Counter } "
-  id: ID!
+  id: Bytes!
 
   count: Int
 
@@ -1034,7 +1034,7 @@ type Position @entity @regularPolling {
 # Note that we only take snapshot for open positions
 type PositionSnapshot @entity @hourlySnapshot {
   " { Position ID }-{ Transaction hash }-{ Log index } "
-  id: ID!
+  id: Bytes!
 
   " Transaction hash of the transaction that triggered this snapshot "
   hash: String!
@@ -1072,7 +1072,7 @@ contracts.
 """
 type Deposit @entity(immutable: true) @transaction {
   " { Transaction hash }-{ Log index } "
-  id: ID!
+  id: Bytes!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -1110,7 +1110,7 @@ type Deposit @entity(immutable: true) @transaction {
 
 type Withdraw @entity(immutable: true) @transaction {
   " { Transaction hash }-{ Log index }"
-  id: ID!
+  id: Bytes!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -1153,7 +1153,7 @@ type Withdraw @entity(immutable: true) @transaction {
 # For CDPs, use this for mint events
 type Borrow @entity(immutable: true) @transaction {
   " { Transaction hash }-{ Log index } "
-  id: ID!
+  id: Bytes!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -1192,7 +1192,7 @@ type Borrow @entity(immutable: true) @transaction {
 # For CDPs, use this for burn events
 type Repay @entity(immutable: true) @transaction {
   " { Transaction hash }-{ Log index } "
-  id: ID!
+  id: Bytes!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -1230,7 +1230,7 @@ type Repay @entity(immutable: true) @transaction {
 
 type Liquidate @entity(immutable: true) @transaction {
   " { Transaction hash }-{ Log index } "
-  id: ID!
+  id: Bytes!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -1275,18 +1275,18 @@ type Liquidate @entity(immutable: true) @transaction {
 # Helper entity for calculating daily/hourly active users
 type ActiveAccount @entity {
   " { daily/hourly }-{ Address of the account }-{ Days/hours since Unix epoch } "
-  id: ID!
+  id: Bytes!
 }
 
 type LiquidateProxy @entity {
   " { Transaction hash }-{ Log index } "
-  id: ID!
+  id: Bytes!
   amount: BigInt!
 }
 
 type PositionCounter @entity {
   " { Account address }-{ Market address }-{ Position Side } "
-  id: ID!
+  id: Bytes!
 
   " Next count "
   nextCount: Int!
@@ -1295,12 +1295,12 @@ type PositionCounter @entity {
 # Helper entity for calculating daily/hourly active users
 type ActiveEventAccount @entity {
   "{ daily/hourly }-{ Address of the account }-{ Days/hours since Unix epoch }-{ EventType: Optional }"
-  id: ID!
+  id: Bytes!
 }
 
 # Helper entity for calculating daily/hourly fields
 type _ActivityHelper @entity {
-  id: ID!
+  id: Bytes!
 
   activeUsers: Int!
   activeDepositors: Int!

--- a/subgraphs/abracadabra/schema.graphql
+++ b/subgraphs/abracadabra/schema.graphql
@@ -37,7 +37,7 @@ enum ProtocolType {
 
 type Token @entity @regularPolling {
   " Smart contract address of the token "
-  id: Bytes!
+  id: ID!
 
   " Name of the token, mirrored from the smart contract "
   name: String!
@@ -65,7 +65,7 @@ enum RewardTokenType {
 
 type RewardToken @entity @regularPolling {
   " { Reward token type }-{ Smart contract address of the reward token } "
-  id: Bytes!
+  id: ID!
 
   " Reference to the actual token "
   token: Token!
@@ -123,7 +123,7 @@ enum PositionSide {
 # to the IDs to differentiate.
 type InterestRate @entity @regularPolling {
   " { Interest rate side }-{ Interest rate type }-{ Market ID } "
-  id: Bytes!
+  id: ID!
 
   " Interest rate in percentage APY. E.g. 5.21% should be stored as 5.21 "
   rate: BigDecimal!
@@ -147,7 +147,7 @@ type InterestRate @entity @regularPolling {
 
 interface Protocol {
   " Smart contract address of the protocol's main contract (Factory, Registry, etc) "
-  id: Bytes!
+  id: ID!
 
   " Name of the protocol, including version. e.g. Uniswap v3 "
   name: String!
@@ -209,7 +209,7 @@ interface Protocol {
 
 type LendingProtocol implements Protocol @entity @regularPolling {
   " Smart contract address of the protocol's main contract (Factory, Registry, etc) "
-  id: Bytes!
+  id: ID!
 
   " Name of the protocol, including version. e.g. Aave v2 "
   name: String!
@@ -326,7 +326,7 @@ type LendingProtocol implements Protocol @entity @regularPolling {
 
   ##### Add ons #####
 
-  marketIDList: [Bytes!]!
+  marketIDList: [String!]!
 
   " Helper field for taking daily snapshots "
   _lastDailySnapshotTimestamp: BigInt!
@@ -341,7 +341,7 @@ type LendingProtocol implements Protocol @entity @regularPolling {
 
 type UsageMetricsDailySnapshot @entity(immutable: true) @dailySnapshot {
   " ID is # of days since Unix epoch time "
-  id: Bytes!
+  id: ID!
 
   " Protocol this snapshot is associated with "
   protocol: LendingProtocol!
@@ -406,7 +406,7 @@ type UsageMetricsDailySnapshot @entity(immutable: true) @dailySnapshot {
 
 type UsageMetricsHourlySnapshot @entity(immutable: true) @hourlySnapshot {
   " { # of hours since Unix epoch time } "
-  id: Bytes!
+  id: ID!
 
   " Protocol this snapshot is associated with "
   protocol: LendingProtocol!
@@ -444,7 +444,7 @@ type UsageMetricsHourlySnapshot @entity(immutable: true) @hourlySnapshot {
 
 type FinancialsDailySnapshot @entity(immutable: true) @dailySnapshot {
   " ID is # of days since Unix epoch time "
-  id: Bytes!
+  id: ID!
 
   " Protocol this snapshot is associated with "
   protocol: LendingProtocol!
@@ -529,7 +529,7 @@ type FinancialsDailySnapshot @entity(immutable: true) @dailySnapshot {
 
 type Market @entity @regularPolling {
   " Smart contract address of the market "
-  id: Bytes!
+  id: ID!
 
   " The protocol this pool belongs to "
   protocol: LendingProtocol!
@@ -694,7 +694,7 @@ type Market @entity @regularPolling {
 
 type MarketDailySnapshot @entity(immutable: true) @dailySnapshot {
   " { Smart contract address of the market }-{ # of days since Unix epoch time } "
-  id: Bytes!
+  id: ID!
 
   " The protocol this snapshot belongs to "
   protocol: LendingProtocol!
@@ -796,7 +796,7 @@ type MarketDailySnapshot @entity(immutable: true) @dailySnapshot {
 
 type MarketHourlySnapshot @entity(immutable: true) @hourlySnapshot {
   " { Smart contract address of the market }-{ # of hours since Unix epoch time } "
-  id: Bytes!
+  id: ID!
 
   " The protocol this snapshot belongs to "
   protocol: LendingProtocol!
@@ -902,7 +902,7 @@ type MarketHourlySnapshot @entity(immutable: true) @hourlySnapshot {
 
 type Account @entity @regularPolling {
   " { Account address } "
-  id: Bytes!
+  id: ID!
 
   " Number of positions this account has "
   positionCount: Int!
@@ -955,7 +955,7 @@ type Account @entity @regularPolling {
 
 type Position @entity @regularPolling {
   " { Account address }-{ Market address }-{ Position Side }-{ Counter } "
-  id: Bytes!
+  id: ID!
 
   count: Int
 
@@ -1034,7 +1034,7 @@ type Position @entity @regularPolling {
 # Note that we only take snapshot for open positions
 type PositionSnapshot @entity @hourlySnapshot {
   " { Position ID }-{ Transaction hash }-{ Log index } "
-  id: Bytes!
+  id: ID!
 
   " Transaction hash of the transaction that triggered this snapshot "
   hash: String!
@@ -1072,7 +1072,7 @@ contracts.
 """
 type Deposit @entity(immutable: true) @transaction {
   " { Transaction hash }-{ Log index } "
-  id: Bytes!
+  id: ID!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -1110,7 +1110,7 @@ type Deposit @entity(immutable: true) @transaction {
 
 type Withdraw @entity(immutable: true) @transaction {
   " { Transaction hash }-{ Log index }"
-  id: Bytes!
+  id: ID!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -1153,7 +1153,7 @@ type Withdraw @entity(immutable: true) @transaction {
 # For CDPs, use this for mint events
 type Borrow @entity(immutable: true) @transaction {
   " { Transaction hash }-{ Log index } "
-  id: Bytes!
+  id: ID!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -1192,7 +1192,7 @@ type Borrow @entity(immutable: true) @transaction {
 # For CDPs, use this for burn events
 type Repay @entity(immutable: true) @transaction {
   " { Transaction hash }-{ Log index } "
-  id: Bytes!
+  id: ID!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -1230,7 +1230,7 @@ type Repay @entity(immutable: true) @transaction {
 
 type Liquidate @entity(immutable: true) @transaction {
   " { Transaction hash }-{ Log index } "
-  id: Bytes!
+  id: ID!
 
   " Transaction hash of the transaction that emitted this event "
   hash: String!
@@ -1275,18 +1275,18 @@ type Liquidate @entity(immutable: true) @transaction {
 # Helper entity for calculating daily/hourly active users
 type ActiveAccount @entity {
   " { daily/hourly }-{ Address of the account }-{ Days/hours since Unix epoch } "
-  id: Bytes!
+  id: ID!
 }
 
 type LiquidateProxy @entity {
   " { Transaction hash }-{ Log index } "
-  id: Bytes!
+  id: ID!
   amount: BigInt!
 }
 
 type PositionCounter @entity {
   " { Account address }-{ Market address }-{ Position Side } "
-  id: Bytes!
+  id: ID!
 
   " Next count "
   nextCount: Int!
@@ -1295,12 +1295,12 @@ type PositionCounter @entity {
 # Helper entity for calculating daily/hourly active users
 type ActiveEventAccount @entity {
   "{ daily/hourly }-{ Address of the account }-{ Days/hours since Unix epoch }-{ EventType: Optional }"
-  id: Bytes!
+  id: ID!
 }
 
 # Helper entity for calculating daily/hourly fields
 type _ActivityHelper @entity {
-  id: Bytes!
+  id: ID!
 
   activeUsers: Int!
   activeDepositors: Int!

--- a/subgraphs/abracadabra/src/common/constants.ts
+++ b/subgraphs/abracadabra/src/common/constants.ts
@@ -83,6 +83,11 @@ export namespace PositionSide {
   export const BORROWER = "BORROWER";
 }
 
+export namespace ActivityInterval {
+  export const HOURLY = "HOURLY";
+  export const DAILY = "DAILY";
+}
+
 //////////////////////////////
 ///// Ethereum Addresses /////
 //////////////////////////////

--- a/subgraphs/abracadabra/src/common/getters.ts
+++ b/subgraphs/abracadabra/src/common/getters.ts
@@ -1,15 +1,11 @@
 import { Address, dataSource, ethereum, log } from "@graphprotocol/graph-ts";
 import {
   Token,
-  UsageMetricsDailySnapshot,
-  FinancialsDailySnapshot,
-  MarketDailySnapshot,
   LendingProtocol,
   Market,
   InterestRate,
-  UsageMetricsHourlySnapshot,
-  MarketHourlySnapshot,
   LiquidateProxy,
+  _ActivityHelper,
 } from "../../generated/schema";
 import { LogRepay } from "../../generated/templates/Cauldron/Cauldron";
 import { fetchTokenSymbol, fetchTokenName, fetchTokenDecimals } from "./tokens";
@@ -17,7 +13,6 @@ import {
   BIGDECIMAL_ZERO,
   Network,
   ProtocolType,
-  SECONDS_PER_DAY,
   LendingType,
   BIGINT_ONE,
   ETH_NETWORK,
@@ -43,7 +38,6 @@ import {
   InterestRateType,
   BIGDECIMAL_ONE,
   BIGINT_ZERO,
-  SECONDS_PER_HOUR,
   DEGENBOX_ADDRESS_MAINNET,
   DEGENBOX_ADDRESS_AVALANCHE,
   DEGENBOX_ADDRESS_ARBITRUM,
@@ -54,7 +48,6 @@ import {
   DEFAULT_DECIMALS,
 } from "./constants";
 import { Versions } from "../versions";
-import { getSnapshotRates } from "./utils/utils";
 
 export function getOrCreateToken(tokenAddress: Address): Token {
   let token = Token.load(tokenAddress.toHexString());
@@ -77,250 +70,6 @@ export function getOrCreateToken(tokenAddress: Address): Token {
     token.save();
   }
   return token;
-}
-
-///////////////////////////
-///////// Metrics /////////
-///////////////////////////
-
-export function getOrCreateUsageMetricsHourlySnapshot(
-  event: ethereum.Event
-): UsageMetricsHourlySnapshot {
-  // Number of hours since Unix epoch
-  const id: i64 = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
-
-  // Create unique id for the hour
-  let usageMetrics = UsageMetricsHourlySnapshot.load(id.toString());
-
-  if (!usageMetrics) {
-    const protocol = getOrCreateLendingProtocol();
-    usageMetrics = new UsageMetricsHourlySnapshot(id.toString());
-    usageMetrics.protocol = getOrCreateLendingProtocol().id;
-    usageMetrics.hourlyActiveUsers = 0;
-    usageMetrics.cumulativeUniqueUsers = protocol.cumulativeUniqueUsers;
-    usageMetrics.hourlyTransactionCount = 0;
-    usageMetrics.hourlyDepositCount = 0;
-    usageMetrics.hourlyBorrowCount = 0;
-    usageMetrics.hourlyWithdrawCount = 0;
-    usageMetrics.hourlyRepayCount = 0;
-    usageMetrics.hourlyLiquidateCount = 0;
-    usageMetrics.blockNumber = event.block.number;
-    usageMetrics.timestamp = event.block.timestamp;
-    usageMetrics.save();
-  }
-  return usageMetrics;
-}
-
-export function getOrCreateUsageMetricsDailySnapshot(
-  event: ethereum.Event
-): UsageMetricsDailySnapshot {
-  // Number of days since Unix epoch
-  const id: i64 = event.block.timestamp.toI64() / SECONDS_PER_DAY;
-
-  // Create unique id for the day
-  let usageMetrics = UsageMetricsDailySnapshot.load(id.toString());
-
-  if (!usageMetrics) {
-    const protocol = getOrCreateLendingProtocol();
-    usageMetrics = new UsageMetricsDailySnapshot(id.toString());
-    usageMetrics.protocol = getOrCreateLendingProtocol().id;
-    usageMetrics.dailyActiveUsers = 0;
-    usageMetrics.cumulativeUniqueUsers = protocol.cumulativeUniqueUsers;
-    usageMetrics.dailyTransactionCount = 0;
-    usageMetrics.dailyDepositCount = 0;
-    usageMetrics.dailyBorrowCount = 0;
-    usageMetrics.dailyWithdrawCount = 0;
-    usageMetrics.dailyRepayCount = 0;
-    usageMetrics.dailyLiquidateCount = 0;
-    usageMetrics.totalPoolCount = 0;
-    usageMetrics.blockNumber = event.block.number;
-    usageMetrics.timestamp = event.block.timestamp;
-
-    usageMetrics.dailyActiveDepositors = 0;
-    usageMetrics.dailyActiveBorrowers = 0;
-    usageMetrics.dailyActiveLiquidators = 0;
-    usageMetrics.dailyActiveLiquidatees = 0;
-    usageMetrics.cumulativeUniqueDepositors =
-      protocol.cumulativeUniqueDepositors;
-    usageMetrics.cumulativeUniqueBorrowers = protocol.cumulativeUniqueBorrowers;
-    usageMetrics.cumulativeUniqueLiquidators =
-      protocol.cumulativeUniqueLiquidators;
-    usageMetrics.cumulativeUniqueLiquidatees =
-      protocol.cumulativeUniqueLiquidatees;
-
-    usageMetrics.save();
-  }
-  return usageMetrics;
-}
-
-export function getOrCreateMarketHourlySnapshot(
-  event: ethereum.Event,
-  marketAddress: string
-): MarketHourlySnapshot | null {
-  const id: i64 = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
-  let marketMetrics = MarketHourlySnapshot.load(
-    marketAddress.concat("-").concat(id.toString())
-  );
-
-  if (!marketMetrics) {
-    const market = getMarket(marketAddress);
-    if (!market) {
-      return null;
-    }
-
-    marketMetrics = new MarketHourlySnapshot(
-      marketAddress.concat("-").concat(id.toString())
-    );
-    marketMetrics.protocol = getOrCreateLendingProtocol().id;
-    marketMetrics.market = marketAddress;
-    marketMetrics.inputTokenBalance = market.inputTokenBalance;
-    marketMetrics.outputTokenSupply = market.outputTokenSupply;
-    marketMetrics.outputTokenPriceUSD = market.outputTokenPriceUSD;
-    marketMetrics.totalValueLockedUSD = market.totalValueLockedUSD;
-    marketMetrics.totalDepositBalanceUSD = market.totalDepositBalanceUSD;
-    marketMetrics.hourlyDepositUSD = BIGDECIMAL_ZERO;
-    marketMetrics.cumulativeDepositUSD = market.cumulativeDepositUSD;
-    marketMetrics.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
-    marketMetrics.hourlyBorrowUSD = BIGDECIMAL_ZERO;
-    marketMetrics.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
-    marketMetrics.hourlyLiquidateUSD = BIGDECIMAL_ZERO;
-    marketMetrics.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
-    marketMetrics.cumulativeTotalRevenueUSD = market.cumulativeTotalRevenueUSD;
-    marketMetrics.cumulativeSupplySideRevenueUSD =
-      market.cumulativeSupplySideRevenueUSD;
-    marketMetrics.cumulativeProtocolSideRevenueUSD =
-      market.cumulativeProtocolSideRevenueUSD;
-
-    marketMetrics.inputTokenPriceUSD = market.inputTokenPriceUSD;
-    marketMetrics.exchangeRate = market.exchangeRate;
-    marketMetrics.rewardTokenEmissionsAmount =
-      market.rewardTokenEmissionsAmount;
-    marketMetrics.rewardTokenEmissionsUSD = market.rewardTokenEmissionsUSD;
-
-    marketMetrics.hourlyTotalRevenueUSD = BIGDECIMAL_ZERO;
-    marketMetrics.hourlySupplySideRevenueUSD = BIGDECIMAL_ZERO;
-    marketMetrics.hourlyProtocolSideRevenueUSD = BIGDECIMAL_ZERO;
-    marketMetrics.hourlyWithdrawUSD = BIGDECIMAL_ZERO;
-    marketMetrics.hourlyRepayUSD = BIGDECIMAL_ZERO;
-
-    marketMetrics.rates = getSnapshotRates(
-      market.rates,
-      (event.block.timestamp.toI32() / SECONDS_PER_HOUR).toString()
-    );
-    marketMetrics.blockNumber = event.block.number;
-    marketMetrics.timestamp = event.block.timestamp;
-    marketMetrics.save();
-  }
-
-  return marketMetrics;
-}
-
-export function getOrCreateMarketDailySnapshot(
-  event: ethereum.Event,
-  marketAddress: string
-): MarketDailySnapshot | null {
-  const id: i64 = event.block.timestamp.toI64() / SECONDS_PER_DAY;
-  let marketMetrics = MarketDailySnapshot.load(
-    marketAddress.concat("-").concat(id.toString())
-  );
-
-  if (!marketMetrics) {
-    const market = getMarket(marketAddress);
-    if (!market) {
-      return null;
-    }
-    marketMetrics = new MarketDailySnapshot(
-      marketAddress.concat("-").concat(id.toString())
-    );
-    marketMetrics.protocol = getOrCreateLendingProtocol().id;
-    marketMetrics.market = marketAddress;
-    marketMetrics.inputTokenBalance = market.inputTokenBalance;
-    marketMetrics.outputTokenSupply = market.outputTokenSupply;
-    marketMetrics.outputTokenPriceUSD = market.outputTokenPriceUSD;
-    marketMetrics.totalValueLockedUSD = market.totalValueLockedUSD;
-    marketMetrics.totalDepositBalanceUSD = market.totalDepositBalanceUSD;
-    marketMetrics.dailyDepositUSD = BIGDECIMAL_ZERO;
-    marketMetrics.cumulativeDepositUSD = market.cumulativeDepositUSD;
-    marketMetrics.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
-    marketMetrics.dailyBorrowUSD = BIGDECIMAL_ZERO;
-    marketMetrics.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
-    marketMetrics.dailyLiquidateUSD = BIGDECIMAL_ZERO;
-    marketMetrics.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
-    marketMetrics.cumulativeTotalRevenueUSD = market.cumulativeTotalRevenueUSD;
-    marketMetrics.cumulativeSupplySideRevenueUSD =
-      market.cumulativeSupplySideRevenueUSD;
-    marketMetrics.cumulativeProtocolSideRevenueUSD =
-      market.cumulativeProtocolSideRevenueUSD;
-
-    marketMetrics.inputTokenPriceUSD = market.inputTokenPriceUSD;
-    marketMetrics.exchangeRate = market.exchangeRate;
-    marketMetrics.rewardTokenEmissionsAmount =
-      market.rewardTokenEmissionsAmount;
-    marketMetrics.rewardTokenEmissionsUSD = market.rewardTokenEmissionsUSD;
-
-    marketMetrics.dailyTotalRevenueUSD = BIGDECIMAL_ZERO;
-    marketMetrics.dailySupplySideRevenueUSD = BIGDECIMAL_ZERO;
-    marketMetrics.dailyProtocolSideRevenueUSD = BIGDECIMAL_ZERO;
-    marketMetrics.dailyWithdrawUSD = BIGDECIMAL_ZERO;
-    marketMetrics.dailyRepayUSD = BIGDECIMAL_ZERO;
-
-    marketMetrics.rates = getSnapshotRates(
-      market.rates,
-      (event.block.timestamp.toI32() / SECONDS_PER_DAY).toString()
-    );
-    marketMetrics.blockNumber = event.block.number;
-    marketMetrics.timestamp = event.block.timestamp;
-    marketMetrics.save();
-  }
-
-  return marketMetrics;
-}
-
-export function getOrCreateFinancials(
-  event: ethereum.Event
-): FinancialsDailySnapshot {
-  // Number of days since Unix epoch
-  const id: i64 = event.block.timestamp.toI64() / SECONDS_PER_DAY;
-
-  let financialMetrics = FinancialsDailySnapshot.load(id.toString());
-
-  if (!financialMetrics) {
-    const protocol = getOrCreateLendingProtocol();
-    financialMetrics = new FinancialsDailySnapshot(id.toString());
-    financialMetrics.protocol = getOrCreateLendingProtocol().id;
-    financialMetrics.blockNumber = event.block.number;
-    financialMetrics.timestamp = event.block.timestamp;
-    financialMetrics.totalValueLockedUSD = protocol.totalValueLockedUSD;
-    financialMetrics.mintedTokenSupplies = protocol.mintedTokenSupplies;
-
-    // Revenue //
-    financialMetrics.dailySupplySideRevenueUSD = BIGDECIMAL_ZERO;
-    financialMetrics.cumulativeSupplySideRevenueUSD =
-      protocol.cumulativeSupplySideRevenueUSD;
-    financialMetrics.dailyProtocolSideRevenueUSD = BIGDECIMAL_ZERO;
-    financialMetrics.cumulativeProtocolSideRevenueUSD =
-      protocol.cumulativeProtocolSideRevenueUSD;
-    financialMetrics.dailyTotalRevenueUSD = BIGDECIMAL_ZERO;
-    financialMetrics.cumulativeTotalRevenueUSD =
-      protocol.cumulativeTotalRevenueUSD;
-
-    // Lending Activities //
-    financialMetrics.totalDepositBalanceUSD = protocol.totalDepositBalanceUSD;
-    financialMetrics.dailyDepositUSD = BIGDECIMAL_ZERO;
-    financialMetrics.cumulativeDepositUSD = protocol.cumulativeDepositUSD;
-    financialMetrics.totalBorrowBalanceUSD = protocol.totalBorrowBalanceUSD;
-    financialMetrics.dailyBorrowUSD = BIGDECIMAL_ZERO;
-    financialMetrics.cumulativeBorrowUSD = protocol.cumulativeBorrowUSD;
-    financialMetrics.dailyLiquidateUSD = BIGDECIMAL_ZERO;
-    financialMetrics.dailyWithdrawUSD = BIGDECIMAL_ZERO;
-    financialMetrics.protocolControlledValueUSD =
-      protocol.protocolControlledValueUSD;
-    financialMetrics.dailyRepayUSD = BIGDECIMAL_ZERO;
-
-    financialMetrics.cumulativeLiquidateUSD = protocol.cumulativeLiquidateUSD;
-    financialMetrics.save();
-  }
-  return financialMetrics;
 }
 
 ////////////////////////////
@@ -359,6 +108,8 @@ export function getOrCreateLendingProtocol(): LendingProtocol {
   protocol.cumulativeDepositUSD = BIGDECIMAL_ZERO;
   protocol.cumulativeBorrowUSD = BIGDECIMAL_ZERO;
   protocol.cumulativeLiquidateUSD = BIGDECIMAL_ZERO;
+  protocol.cumulativeWithdrawUSD = BIGDECIMAL_ZERO;
+  protocol.cumulativeRepayUSD = BIGDECIMAL_ZERO;
   protocol.protocolControlledValueUSD = BIGDECIMAL_ZERO;
   protocol.marketIDList = [];
   protocol.cumulativeUniqueDepositors = 0;
@@ -367,6 +118,8 @@ export function getOrCreateLendingProtocol(): LendingProtocol {
   protocol.cumulativeUniqueLiquidatees = 0;
   protocol.openPositionCount = 0;
   protocol.cumulativePositionCount = 0;
+  protocol._lastDailySnapshotTimestamp = BIGINT_ZERO;
+  protocol._lastHourlySnapshotTimestamp = BIGINT_ZERO;
 
   protocol.save();
   return protocol;
@@ -482,4 +235,29 @@ export function getOrCreateInterestRate(marketAddress: string): InterestRate {
   interestRate.rate = BIGDECIMAL_ONE;
   interestRate.save();
   return interestRate;
+}
+
+export function getOrCreateActivityHelper(id: string): _ActivityHelper {
+  let activity = _ActivityHelper.load(id);
+
+  if (!activity) {
+    activity = new _ActivityHelper(id);
+
+    activity.activeUsers = 0;
+    activity.activeDepositors = 0;
+    activity.activeBorrowers = 0;
+    activity.activeLiquidators = 0;
+    activity.activeLiquidatees = 0;
+
+    activity.transactionCount = 0;
+    activity.depositCount = 0;
+    activity.withdrawCount = 0;
+    activity.liquidateCount = 0;
+    activity.borrowCount = 0;
+    activity.repayCount = 0;
+
+    activity.save();
+  }
+
+  return activity;
 }

--- a/subgraphs/abracadabra/src/common/getters.ts
+++ b/subgraphs/abracadabra/src/common/getters.ts
@@ -1,4 +1,4 @@
-import { Address, dataSource, ethereum, log } from "@graphprotocol/graph-ts";
+import { Address, dataSource, log } from "@graphprotocol/graph-ts";
 import {
   Token,
   LendingProtocol,

--- a/subgraphs/abracadabra/src/common/metrics.ts
+++ b/subgraphs/abracadabra/src/common/metrics.ts
@@ -146,11 +146,10 @@ export function updateUsageMetrics(
   dailyActivity.save();
 }
 
-export function updateTVL(event: ethereum.Event): void {
+export function updateTVL(): void {
   // new user count handled in updateUsageMetrics
   // totalBorrowUSD handled updateTotalBorrowUSD
   const protocol = getOrCreateLendingProtocol();
-  log.warning(">> protocol.id: {}", [protocol.id.toHexString()]);
   const bentoBoxContract = DegenBox.bind(Address.fromBytes(protocol.id));
   const degenBoxContract = DegenBox.bind(
     Address.fromString(getDegenBoxAddress(dataSource.network()))
@@ -158,15 +157,12 @@ export function updateTVL(event: ethereum.Event): void {
   const marketIDList = protocol.marketIDList;
   let protocolTotalValueLockedUSD = BIGDECIMAL_ZERO;
   for (let i: i32 = 0; i < marketIDList.length; i++) {
-    log.warning(">> marketIDList: {}", [marketIDList[i].toHexString()]);
     const marketAddress = Address.fromBytes(marketIDList[i]);
     const market = getMarket(marketAddress);
     if (!market) {
       return;
     }
-    log.warning(">> market.inputToken: {}", [market.inputToken.toHexString()]);
     const inputToken = getOrCreateToken(Address.fromBytes(market.inputToken));
-    log.warning(">> inputToken.id: {}", [inputToken.id.toHexString()]);
     const bentoBoxCall: BigInt = readValue<BigInt>(
       bentoBoxContract.try_balanceOf(
         Address.fromBytes(inputToken.id),
@@ -193,7 +189,7 @@ export function updateTVL(event: ethereum.Event): void {
   protocol.save();
 }
 
-export function updateTotalBorrows(event: ethereum.Event): void {
+export function updateTotalBorrows(): void {
   // new user count handled in updateUsageMetrics
   const protocol = getOrCreateLendingProtocol();
   const marketIDList = protocol.marketIDList;

--- a/subgraphs/abracadabra/src/common/metrics.ts
+++ b/subgraphs/abracadabra/src/common/metrics.ts
@@ -29,7 +29,7 @@ import {
 } from "./getters";
 import { bigIntToBigDecimal, exponentToBigDecimal } from "./utils/numbers";
 import { DegenBox } from "../../generated/BentoBox/DegenBox";
-import { getSnapshotRates, readValue } from "./utils/utils";
+import { readValue } from "./utils/utils";
 import { getOrCreateAccount } from "../positions";
 import { Cauldron } from "../../generated/templates/Cauldron/Cauldron";
 
@@ -135,7 +135,7 @@ export function updateUsageMetrics(
   dailyActivity.save();
 }
 
-export function updateTVL(event: ethereum.Event): void {
+export function updateTVL(): void {
   // new user count handled in updateUsageMetrics
   // totalBorrowUSD handled updateTotalBorrowUSD
   const protocol = getOrCreateLendingProtocol();
@@ -178,7 +178,7 @@ export function updateTVL(event: ethereum.Event): void {
   protocol.save();
 }
 
-export function updateTotalBorrows(event: ethereum.Event): void {
+export function updateTotalBorrows(): void {
   // new user count handled in updateUsageMetrics
   const protocol = getOrCreateLendingProtocol();
   const marketIDList = protocol.marketIDList;

--- a/subgraphs/abracadabra/src/common/metrics.ts
+++ b/subgraphs/abracadabra/src/common/metrics.ts
@@ -5,6 +5,7 @@ import {
   ethereum,
   dataSource,
   log,
+  Bytes,
 } from "@graphprotocol/graph-ts";
 import { ActiveAccount, Market } from "../../generated/schema";
 import {
@@ -29,21 +30,19 @@ import {
 } from "./getters";
 import { bigIntToBigDecimal, exponentToBigDecimal } from "./utils/numbers";
 import { DegenBox } from "../../generated/BentoBox/DegenBox";
-import { getSnapshotRates, readValue } from "./utils/utils";
+import { readValue } from "./utils/utils";
 import { getOrCreateAccount } from "../positions";
 import { Cauldron } from "../../generated/templates/Cauldron/Cauldron";
 
 // Update FinancialsDailySnapshots entity
-export function updateFinancials(
-  event: ethereum.Event,
-  feesUSD: BigDecimal,
-  marketId: string
-): void {
+export function updateFinancials(feesUSD: BigDecimal, marketId: Address): void {
   // feesUSD is handled in handleLogWithdrawFees
   // totalValueLockedUSD is handled in updateTVL()
   const market = getMarket(marketId);
   if (!market) {
-    log.warning("[updateFinancials] Market not found: {}", [marketId]);
+    log.warning("[updateFinancials] Market not found: {}", [
+      marketId.toHexString(),
+    ]);
     return;
   }
 
@@ -80,24 +79,30 @@ export function updateUsageMetrics(
   // Number of days since Unix epoch
   const protocol = getOrCreateLendingProtocol();
 
-  const hourlyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
+  const hourlyId = event.block.timestamp.toI32() / SECONDS_PER_HOUR;
   const hourlyActivity = getOrCreateActivityHelper(
-    ActivityInterval.HOURLY.concat("-").concat(hourlyId.toString())
+    Bytes.fromUTF8(ActivityInterval.HOURLY)
+      .concat(Bytes.fromUTF8("-"))
+      .concat(Bytes.fromI32(hourlyId))
   );
-  const dailyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_DAY;
+  const dailyId = event.block.timestamp.toI32() / SECONDS_PER_DAY;
   const dailyActivity = getOrCreateActivityHelper(
-    ActivityInterval.DAILY.concat("-").concat(dailyId.toString())
+    Bytes.fromUTF8(ActivityInterval.DAILY)
+      .concat(Bytes.fromUTF8("-"))
+      .concat(Bytes.fromI32(dailyId))
   );
 
   hourlyActivity.transactionCount += 1;
   dailyActivity.transactionCount += 1;
 
-  getOrCreateAccount(from.toHexString(), protocol);
-  getOrCreateAccount(to.toHexString(), protocol);
+  getOrCreateAccount(from, protocol);
+  getOrCreateAccount(to, protocol);
 
   // Combine the id and the user address to generate a unique user id for the hour/day
-  const hourlyActiveAccountIdFrom =
-    "hourly-" + from.toHexString() + "-" + hourlyId.toString();
+  const hourlyActiveAccountIdFrom = Bytes.fromUTF8("hourly-")
+    .concat(from)
+    .concat(Bytes.fromUTF8("-"))
+    .concat(Bytes.fromI32(hourlyId));
   let hourlyActiveAccountFrom = ActiveAccount.load(hourlyActiveAccountIdFrom);
   if (!hourlyActiveAccountFrom) {
     hourlyActiveAccountFrom = new ActiveAccount(hourlyActiveAccountIdFrom);
@@ -105,8 +110,10 @@ export function updateUsageMetrics(
     hourlyActivity.activeUsers += 1;
   }
 
-  const hourlyActiveAccountIdTo =
-    "hourly-" + to.toHexString() + "-" + hourlyId.toString();
+  const hourlyActiveAccountIdTo = Bytes.fromUTF8("hourly-")
+    .concat(to)
+    .concat(Bytes.fromUTF8("-"))
+    .concat(Bytes.fromI32(hourlyId));
   let hourlyActiveAccountTo = ActiveAccount.load(hourlyActiveAccountIdTo);
   if (!hourlyActiveAccountTo) {
     hourlyActiveAccountTo = new ActiveAccount(hourlyActiveAccountIdTo);
@@ -114,8 +121,10 @@ export function updateUsageMetrics(
     hourlyActivity.activeUsers += 1;
   }
 
-  const dailyActiveAccountIdFrom =
-    "daily-" + from.toHexString() + "-" + dailyId.toString();
+  const dailyActiveAccountIdFrom = Bytes.fromUTF8("daily-")
+    .concat(from)
+    .concat(Bytes.fromUTF8("-"))
+    .concat(Bytes.fromI32(dailyId));
   let dailyActiveAccountFrom = ActiveAccount.load(dailyActiveAccountIdFrom);
   if (!dailyActiveAccountFrom) {
     dailyActiveAccountFrom = new ActiveAccount(dailyActiveAccountIdFrom);
@@ -123,8 +132,10 @@ export function updateUsageMetrics(
     dailyActivity.activeUsers += 1;
   }
 
-  const dailyActiveAccountIdTo =
-    "daily-" + to.toHexString() + "-" + dailyId.toString();
+  const dailyActiveAccountIdTo = Bytes.fromUTF8("daily-")
+    .concat(to)
+    .concat(Bytes.fromUTF8("-"))
+    .concat(Bytes.fromI32(dailyId));
   let dailyActiveAccountTo = ActiveAccount.load(dailyActiveAccountIdTo);
   if (!dailyActiveAccountTo) {
     dailyActiveAccountTo = new ActiveAccount(dailyActiveAccountIdTo);
@@ -139,30 +150,34 @@ export function updateTVL(event: ethereum.Event): void {
   // new user count handled in updateUsageMetrics
   // totalBorrowUSD handled updateTotalBorrowUSD
   const protocol = getOrCreateLendingProtocol();
-  const bentoBoxContract = DegenBox.bind(Address.fromString(protocol.id));
+  log.warning(">> protocol.id: {}", [protocol.id.toHexString()]);
+  const bentoBoxContract = DegenBox.bind(Address.fromBytes(protocol.id));
   const degenBoxContract = DegenBox.bind(
     Address.fromString(getDegenBoxAddress(dataSource.network()))
   );
   const marketIDList = protocol.marketIDList;
   let protocolTotalValueLockedUSD = BIGDECIMAL_ZERO;
   for (let i: i32 = 0; i < marketIDList.length; i++) {
-    const marketAddress = marketIDList[i];
+    log.warning(">> marketIDList: {}", [marketIDList[i].toHexString()]);
+    const marketAddress = Address.fromBytes(marketIDList[i]);
     const market = getMarket(marketAddress);
     if (!market) {
       return;
     }
-    const inputToken = getOrCreateToken(Address.fromString(market.inputToken));
+    log.warning(">> market.inputToken: {}", [market.inputToken.toHexString()]);
+    const inputToken = getOrCreateToken(Address.fromBytes(market.inputToken));
+    log.warning(">> inputToken.id: {}", [inputToken.id.toHexString()]);
     const bentoBoxCall: BigInt = readValue<BigInt>(
       bentoBoxContract.try_balanceOf(
-        Address.fromString(inputToken.id),
-        Address.fromString(marketAddress)
+        Address.fromBytes(inputToken.id),
+        marketAddress
       ),
       BIGINT_ZERO
     );
     const degenBoxCall: BigInt = readValue<BigInt>(
       degenBoxContract.try_balanceOf(
-        Address.fromString(inputToken.id),
-        Address.fromString(marketAddress)
+        Address.fromBytes(inputToken.id),
+        marketAddress
       ),
       BIGINT_ZERO
     );
@@ -190,7 +205,7 @@ export function updateTotalBorrows(event: ethereum.Event): void {
   let totalBorrowBalanceUSD = BIGDECIMAL_ZERO;
   for (let i: i32 = 0; i < marketIDList.length; i++) {
     const marketAddress = marketIDList[i];
-    const market = getMarket(marketAddress);
+    const market = getMarket(Address.fromBytes(marketAddress));
     if (!market) {
       return;
     }
@@ -209,9 +224,9 @@ export function updateTotalBorrows(event: ethereum.Event): void {
 }
 
 export function updateMarketStats(
-  marketId: string,
+  marketId: Address,
   eventType: string,
-  asset: string,
+  asset: Address,
   amount: BigInt,
   event: ethereum.Event
 ): void {
@@ -219,14 +234,18 @@ export function updateMarketStats(
   if (!market) {
     return;
   }
-  const token = getOrCreateToken(Address.fromString(asset));
-  const hourlyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
+  const token = getOrCreateToken(asset);
+  const hourlyId = event.block.timestamp.toI32() / SECONDS_PER_HOUR;
   const hourlyActivity = getOrCreateActivityHelper(
-    ActivityInterval.HOURLY.concat("-").concat(hourlyId.toString())
+    Bytes.fromUTF8(ActivityInterval.HOURLY)
+      .concat(Bytes.fromUTF8("-"))
+      .concat(Bytes.fromI32(hourlyId))
   );
-  const dailyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_DAY;
+  const dailyId = event.block.timestamp.toI32() / SECONDS_PER_DAY;
   const dailyActivity = getOrCreateActivityHelper(
-    ActivityInterval.DAILY.concat("-").concat(dailyId.toString())
+    Bytes.fromUTF8(ActivityInterval.DAILY)
+      .concat(Bytes.fromUTF8("-"))
+      .concat(Bytes.fromI32(dailyId))
   );
 
   const protocol = getOrCreateLendingProtocol();
@@ -277,7 +296,7 @@ export function updateMarketStats(
     protocol.cumulativeRepayUSD = protocol.cumulativeRepayUSD.plus(amountUSD);
   }
   market.inputTokenPriceUSD = getOrCreateToken(
-    Address.fromString(market.inputToken)
+    Address.fromBytes(market.inputToken)
   ).lastPriceUSD!;
   market.save();
   hourlyActivity.save();
@@ -287,14 +306,14 @@ export function updateMarketStats(
 
 // update borrow amount for the given market
 export function updateBorrowAmount(market: Market): void {
-  const couldronContract = Cauldron.bind(Address.fromString(market.id));
+  const couldronContract = Cauldron.bind(Address.fromBytes(market.id));
 
   // get total borrows
   const tryBorrowBalance = couldronContract.try_totalBorrow();
   if (tryBorrowBalance.reverted) {
     log.warning(
       "[updateBorrowAmount] Could not get borrow balance for market {}",
-      [market.id]
+      [market.id.toHexString()]
     );
     return;
   }

--- a/subgraphs/abracadabra/src/common/metrics.ts
+++ b/subgraphs/abracadabra/src/common/metrics.ts
@@ -146,10 +146,11 @@ export function updateUsageMetrics(
   dailyActivity.save();
 }
 
-export function updateTVL(): void {
+export function updateTVL(event: ethereum.Event): void {
   // new user count handled in updateUsageMetrics
   // totalBorrowUSD handled updateTotalBorrowUSD
   const protocol = getOrCreateLendingProtocol();
+  log.warning(">> protocol.id: {}", [protocol.id.toHexString()]);
   const bentoBoxContract = DegenBox.bind(Address.fromBytes(protocol.id));
   const degenBoxContract = DegenBox.bind(
     Address.fromString(getDegenBoxAddress(dataSource.network()))
@@ -157,12 +158,15 @@ export function updateTVL(): void {
   const marketIDList = protocol.marketIDList;
   let protocolTotalValueLockedUSD = BIGDECIMAL_ZERO;
   for (let i: i32 = 0; i < marketIDList.length; i++) {
+    log.warning(">> marketIDList: {}", [marketIDList[i].toHexString()]);
     const marketAddress = Address.fromBytes(marketIDList[i]);
     const market = getMarket(marketAddress);
     if (!market) {
       return;
     }
+    log.warning(">> market.inputToken: {}", [market.inputToken.toHexString()]);
     const inputToken = getOrCreateToken(Address.fromBytes(market.inputToken));
+    log.warning(">> inputToken.id: {}", [inputToken.id.toHexString()]);
     const bentoBoxCall: BigInt = readValue<BigInt>(
       bentoBoxContract.try_balanceOf(
         Address.fromBytes(inputToken.id),
@@ -189,7 +193,7 @@ export function updateTVL(): void {
   protocol.save();
 }
 
-export function updateTotalBorrows(): void {
+export function updateTotalBorrows(event: ethereum.Event): void {
   // new user count handled in updateUsageMetrics
   const protocol = getOrCreateLendingProtocol();
   const marketIDList = protocol.marketIDList;

--- a/subgraphs/abracadabra/src/common/metrics.ts
+++ b/subgraphs/abracadabra/src/common/metrics.ts
@@ -17,18 +17,15 @@ import {
   SECONDS_PER_HOUR,
   BIGINT_ZERO,
   EventType,
+  ActivityInterval,
 } from "./constants";
 import {
-  getOrCreateMarketDailySnapshot,
-  getOrCreateUsageMetricsHourlySnapshot,
-  getOrCreateUsageMetricsDailySnapshot,
-  getOrCreateFinancials,
   getOrCreateLendingProtocol,
   getMarket,
   getOrCreateToken,
   getMIMAddress,
-  getOrCreateMarketHourlySnapshot,
   getDegenBoxAddress,
+  getOrCreateActivityHelper,
 } from "./getters";
 import { bigIntToBigDecimal, exponentToBigDecimal } from "./utils/numbers";
 import { DegenBox } from "../../generated/BentoBox/DegenBox";
@@ -44,23 +41,6 @@ export function updateFinancials(
 ): void {
   // feesUSD is handled in handleLogWithdrawFees
   // totalValueLockedUSD is handled in updateTVL()
-  const financialsDailySnapshots = getOrCreateFinancials(event);
-  const marketHourlySnapshot = getOrCreateMarketHourlySnapshot(event, marketId);
-  if (!marketHourlySnapshot) {
-    log.warning(
-      "[updateFinancials] marketHourlySnapshot not found for market: {}",
-      [marketId]
-    );
-    return;
-  }
-  const marketDailySnapshot = getOrCreateMarketDailySnapshot(event, marketId);
-  if (!marketDailySnapshot) {
-    log.warning(
-      "[updateFinancials] marketDailySnapshot not found for market: {}",
-      [marketId]
-    );
-    return;
-  }
   const market = getMarket(marketId);
   if (!market) {
     log.warning("[updateFinancials] Market not found: {}", [marketId]);
@@ -89,61 +69,6 @@ export function updateFinancials(
   protocol.cumulativeProtocolSideRevenueUSD =
     protocol.cumulativeProtocolSideRevenueUSD.plus(protocolSideRevenueUSD);
 
-  financialsDailySnapshots.dailyTotalRevenueUSD =
-    financialsDailySnapshots.dailyTotalRevenueUSD.plus(totalRevenueUSD); // feesUSD comes from logAccrue which is accounted in MIM
-  financialsDailySnapshots.dailySupplySideRevenueUSD =
-    financialsDailySnapshots.dailySupplySideRevenueUSD.plus(
-      supplySideRevenueUSD
-    );
-  financialsDailySnapshots.dailyProtocolSideRevenueUSD =
-    financialsDailySnapshots.dailyProtocolSideRevenueUSD.plus(
-      protocolSideRevenueUSD
-    );
-
-  financialsDailySnapshots.cumulativeTotalRevenueUSD =
-    protocol.cumulativeTotalRevenueUSD;
-  financialsDailySnapshots.cumulativeSupplySideRevenueUSD =
-    protocol.cumulativeSupplySideRevenueUSD;
-  financialsDailySnapshots.cumulativeProtocolSideRevenueUSD =
-    protocol.cumulativeProtocolSideRevenueUSD;
-
-  marketDailySnapshot.dailyTotalRevenueUSD =
-    marketDailySnapshot.dailyTotalRevenueUSD.plus(totalRevenueUSD); // feesUSD comes from logAccrue which is accounted in MIM
-  marketDailySnapshot.dailySupplySideRevenueUSD =
-    marketDailySnapshot.dailySupplySideRevenueUSD.plus(supplySideRevenueUSD);
-  marketDailySnapshot.dailyProtocolSideRevenueUSD =
-    marketDailySnapshot.dailyProtocolSideRevenueUSD.plus(
-      protocolSideRevenueUSD
-    );
-
-  marketDailySnapshot.cumulativeTotalRevenueUSD =
-    market.cumulativeTotalRevenueUSD;
-  marketDailySnapshot.cumulativeSupplySideRevenueUSD =
-    market.cumulativeSupplySideRevenueUSD;
-  marketDailySnapshot.cumulativeProtocolSideRevenueUSD =
-    market.cumulativeProtocolSideRevenueUSD;
-
-  marketHourlySnapshot.hourlyTotalRevenueUSD =
-    marketHourlySnapshot.hourlyTotalRevenueUSD.plus(totalRevenueUSD); // feesUSD comes from logAccrue which is accounted in MIM
-  marketHourlySnapshot.hourlySupplySideRevenueUSD =
-    marketHourlySnapshot.hourlySupplySideRevenueUSD.plus(supplySideRevenueUSD);
-  marketHourlySnapshot.hourlyProtocolSideRevenueUSD =
-    marketHourlySnapshot.hourlyProtocolSideRevenueUSD.plus(
-      protocolSideRevenueUSD
-    );
-
-  marketHourlySnapshot.cumulativeTotalRevenueUSD =
-    market.cumulativeTotalRevenueUSD;
-  marketHourlySnapshot.cumulativeSupplySideRevenueUSD =
-    market.cumulativeSupplySideRevenueUSD;
-  marketHourlySnapshot.cumulativeProtocolSideRevenueUSD =
-    market.cumulativeProtocolSideRevenueUSD;
-
-  financialsDailySnapshots.cumulativeLiquidateUSD =
-    protocol.cumulativeLiquidateUSD;
-  financialsDailySnapshots.save();
-  marketDailySnapshot.save();
-  marketHourlySnapshot.save();
   protocol.save();
 }
 
@@ -153,26 +78,22 @@ export function updateUsageMetrics(
   to: Address
 ): void {
   // Number of days since Unix epoch
-  const hourlyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
-  const dailyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_DAY;
-  const usageHourlySnapshot = getOrCreateUsageMetricsHourlySnapshot(event);
-  const usageDailySnapshot = getOrCreateUsageMetricsDailySnapshot(event);
   const protocol = getOrCreateLendingProtocol();
 
-  // Update the block number and timestamp to that of the last transaction of that day
-  usageHourlySnapshot.blockNumber = event.block.number;
-  usageHourlySnapshot.timestamp = event.block.timestamp;
-  usageHourlySnapshot.hourlyTransactionCount += 1;
+  const hourlyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
+  const hourlyActivity = getOrCreateActivityHelper(
+    ActivityInterval.HOURLY.concat("-").concat(hourlyId.toString())
+  );
+  const dailyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_DAY;
+  const dailyActivity = getOrCreateActivityHelper(
+    ActivityInterval.DAILY.concat("-").concat(dailyId.toString())
+  );
 
-  usageDailySnapshot.blockNumber = event.block.number;
-  usageDailySnapshot.timestamp = event.block.timestamp;
-  usageDailySnapshot.dailyTransactionCount += 1;
+  hourlyActivity.transactionCount += 1;
+  dailyActivity.transactionCount += 1;
 
   getOrCreateAccount(from.toHexString(), protocol);
   getOrCreateAccount(to.toHexString(), protocol);
-
-  usageHourlySnapshot.cumulativeUniqueUsers = protocol.cumulativeUniqueUsers;
-  usageDailySnapshot.cumulativeUniqueUsers = protocol.cumulativeUniqueUsers;
 
   // Combine the id and the user address to generate a unique user id for the hour/day
   const hourlyActiveAccountIdFrom =
@@ -181,7 +102,7 @@ export function updateUsageMetrics(
   if (!hourlyActiveAccountFrom) {
     hourlyActiveAccountFrom = new ActiveAccount(hourlyActiveAccountIdFrom);
     hourlyActiveAccountFrom.save();
-    usageHourlySnapshot.hourlyActiveUsers += 1;
+    hourlyActivity.activeUsers += 1;
   }
 
   const hourlyActiveAccountIdTo =
@@ -190,7 +111,7 @@ export function updateUsageMetrics(
   if (!hourlyActiveAccountTo) {
     hourlyActiveAccountTo = new ActiveAccount(hourlyActiveAccountIdTo);
     hourlyActiveAccountTo.save();
-    usageHourlySnapshot.hourlyActiveUsers += 1;
+    hourlyActivity.activeUsers += 1;
   }
 
   const dailyActiveAccountIdFrom =
@@ -199,7 +120,7 @@ export function updateUsageMetrics(
   if (!dailyActiveAccountFrom) {
     dailyActiveAccountFrom = new ActiveAccount(dailyActiveAccountIdFrom);
     dailyActiveAccountFrom.save();
-    usageDailySnapshot.dailyActiveUsers += 1;
+    dailyActivity.activeUsers += 1;
   }
 
   const dailyActiveAccountIdTo =
@@ -208,69 +129,10 @@ export function updateUsageMetrics(
   if (!dailyActiveAccountTo) {
     dailyActiveAccountTo = new ActiveAccount(dailyActiveAccountIdTo);
     dailyActiveAccountTo.save();
-    usageDailySnapshot.dailyActiveUsers += 1;
+    dailyActivity.activeUsers += 1;
   }
-  usageDailySnapshot.totalPoolCount = protocol.totalPoolCount;
-  usageHourlySnapshot.save();
-  usageDailySnapshot.save();
-}
-
-// Update MarketDailySnapshot entity
-export function updateMarketMetrics(event: ethereum.Event): void {
-  const market = getMarket(event.address.toHexString());
-  if (!market) {
-    return;
-  }
-  const marketHourlySnapshot = getOrCreateMarketHourlySnapshot(
-    event,
-    market.id
-  );
-  const marketDailySnapshot = getOrCreateMarketDailySnapshot(event, market.id);
-  if (!marketHourlySnapshot || !marketDailySnapshot) {
-    return;
-  }
-  const protocol = getOrCreateLendingProtocol();
-
-  marketHourlySnapshot.protocol = protocol.id;
-  marketHourlySnapshot.market = market.id;
-  marketHourlySnapshot.rates = getSnapshotRates(
-    market.rates,
-    (event.block.timestamp.toI32() / SECONDS_PER_HOUR).toString()
-  );
-  marketHourlySnapshot.totalValueLockedUSD = market.totalValueLockedUSD;
-  marketHourlySnapshot.totalDepositBalanceUSD = market.totalDepositBalanceUSD;
-  marketHourlySnapshot.cumulativeDepositUSD = market.cumulativeDepositUSD;
-  marketHourlySnapshot.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
-  marketHourlySnapshot.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
-  marketHourlySnapshot.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
-  marketHourlySnapshot.inputTokenBalance = market.inputTokenBalance;
-  marketHourlySnapshot.inputTokenPriceUSD = market.inputTokenPriceUSD;
-  marketHourlySnapshot.outputTokenSupply = market.outputTokenSupply;
-  marketHourlySnapshot.outputTokenPriceUSD = market.outputTokenPriceUSD;
-  marketHourlySnapshot.blockNumber = event.block.number;
-  marketHourlySnapshot.timestamp = event.block.timestamp;
-
-  marketDailySnapshot.protocol = protocol.id;
-  marketDailySnapshot.market = market.id;
-  marketHourlySnapshot.rates = getSnapshotRates(
-    market.rates,
-    (event.block.timestamp.toI32() / SECONDS_PER_DAY).toString()
-  );
-  marketDailySnapshot.totalValueLockedUSD = market.totalValueLockedUSD;
-  marketDailySnapshot.totalDepositBalanceUSD = market.totalDepositBalanceUSD;
-  marketDailySnapshot.cumulativeDepositUSD = market.cumulativeDepositUSD;
-  marketDailySnapshot.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
-  marketDailySnapshot.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
-  marketDailySnapshot.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
-  marketDailySnapshot.inputTokenBalance = market.inputTokenBalance;
-  marketDailySnapshot.inputTokenPriceUSD = market.inputTokenPriceUSD;
-  marketDailySnapshot.outputTokenSupply = market.outputTokenSupply;
-  marketDailySnapshot.outputTokenPriceUSD = market.outputTokenPriceUSD;
-  marketDailySnapshot.blockNumber = event.block.number;
-  marketDailySnapshot.timestamp = event.block.timestamp;
-
-  marketHourlySnapshot.save();
-  marketDailySnapshot.save();
+  hourlyActivity.save();
+  dailyActivity.save();
 }
 
 export function updateTVL(event: ethereum.Event): void {
@@ -281,7 +143,6 @@ export function updateTVL(event: ethereum.Event): void {
   const degenBoxContract = DegenBox.bind(
     Address.fromString(getDegenBoxAddress(dataSource.network()))
   );
-  const financialsDailySnapshot = getOrCreateFinancials(event);
   const marketIDList = protocol.marketIDList;
   let protocolTotalValueLockedUSD = BIGDECIMAL_ZERO;
   for (let i: i32 = 0; i < marketIDList.length; i++) {
@@ -311,21 +172,15 @@ export function updateTVL(event: ethereum.Event): void {
     ).times(market.inputTokenPriceUSD);
     protocolTotalValueLockedUSD = protocolTotalValueLockedUSD.plus(marketTVL);
   }
-  financialsDailySnapshot.totalValueLockedUSD = protocolTotalValueLockedUSD;
-  financialsDailySnapshot.totalDepositBalanceUSD = protocolTotalValueLockedUSD;
-  financialsDailySnapshot.blockNumber = event.block.number;
-  financialsDailySnapshot.timestamp = event.block.timestamp;
   protocol.totalValueLockedUSD = protocolTotalValueLockedUSD;
   protocol.totalDepositBalanceUSD = protocolTotalValueLockedUSD;
 
-  financialsDailySnapshot.save();
   protocol.save();
 }
 
 export function updateTotalBorrows(event: ethereum.Event): void {
   // new user count handled in updateUsageMetrics
   const protocol = getOrCreateLendingProtocol();
-  const financialsDailySnapshots = getOrCreateFinancials(event);
   const marketIDList = protocol.marketIDList;
   let mimPriceUSD = getOrCreateToken(
     Address.fromString(getMIMAddress(dataSource.network()))
@@ -348,11 +203,8 @@ export function updateTotalBorrows(event: ethereum.Event): void {
       )
     );
   }
-  financialsDailySnapshots.mintedTokenSupplies = [protocolMintedTokenSupply];
-  financialsDailySnapshots.totalBorrowBalanceUSD = totalBorrowBalanceUSD;
   protocol.mintedTokenSupplies = [protocolMintedTokenSupply];
   protocol.totalBorrowBalanceUSD = totalBorrowBalanceUSD;
-  financialsDailySnapshots.save();
   protocol.save();
 }
 
@@ -368,30 +220,19 @@ export function updateMarketStats(
     return;
   }
   const token = getOrCreateToken(Address.fromString(asset));
-  const usageHourlySnapshot = getOrCreateUsageMetricsHourlySnapshot(event);
-  const usageDailySnapshot = getOrCreateUsageMetricsDailySnapshot(event);
-  const marketHourlySnapshot = getOrCreateMarketHourlySnapshot(
-    event,
-    market.id
+  const hourlyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
+  const hourlyActivity = getOrCreateActivityHelper(
+    ActivityInterval.HOURLY.concat("-").concat(hourlyId.toString())
   );
-  const marketDailySnapshot = getOrCreateMarketDailySnapshot(event, market.id);
-  if (!marketHourlySnapshot || !marketDailySnapshot) {
-    return;
-  }
-  const financialsDailySnapshot = getOrCreateFinancials(event);
+  const dailyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_DAY;
+  const dailyActivity = getOrCreateActivityHelper(
+    ActivityInterval.DAILY.concat("-").concat(dailyId.toString())
+  );
+
   const protocol = getOrCreateLendingProtocol();
   const priceUSD = token.lastPriceUSD;
   const amountUSD = bigIntToBigDecimal(amount, token.decimals).times(priceUSD!);
-  usageHourlySnapshot.blockNumber = event.block.number;
-  usageHourlySnapshot.timestamp = event.block.timestamp;
-  usageDailySnapshot.blockNumber = event.block.number;
-  usageDailySnapshot.timestamp = event.block.timestamp;
-  marketHourlySnapshot.blockNumber = event.block.number;
-  marketHourlySnapshot.timestamp = event.block.timestamp;
-  marketDailySnapshot.blockNumber = event.block.number;
-  marketDailySnapshot.timestamp = event.block.timestamp;
-  financialsDailySnapshot.blockNumber = event.block.number;
-  financialsDailySnapshot.timestamp = event.block.timestamp;
+
   if (eventType == EventType.DEPOSIT) {
     const inputTokenBalance = market.inputTokenBalance.plus(amount);
     market.inputTokenBalance = inputTokenBalance;
@@ -403,25 +244,11 @@ export function updateMarketStats(
       inputTokenBalance,
       token.decimals
     ).times(priceUSD!);
-    usageHourlySnapshot.hourlyDepositCount += 1;
-    usageDailySnapshot.dailyDepositCount += 1;
+    hourlyActivity.depositCount += 1;
+    dailyActivity.depositCount += 1;
     market.cumulativeDepositUSD = market.cumulativeDepositUSD.plus(amountUSD);
-    market.save();
-
-    marketHourlySnapshot.cumulativeDepositUSD =
-      marketHourlySnapshot.cumulativeDepositUSD.plus(amountUSD);
-    marketDailySnapshot.cumulativeDepositUSD =
-      marketDailySnapshot.cumulativeDepositUSD.plus(amountUSD);
-    financialsDailySnapshot.cumulativeDepositUSD =
-      financialsDailySnapshot.cumulativeDepositUSD.plus(amountUSD);
     protocol.cumulativeDepositUSD =
       protocol.cumulativeDepositUSD.plus(amountUSD);
-    marketHourlySnapshot.hourlyDepositUSD =
-      marketHourlySnapshot.hourlyDepositUSD.plus(amountUSD);
-    marketDailySnapshot.dailyDepositUSD =
-      marketDailySnapshot.dailyDepositUSD.plus(amountUSD);
-    financialsDailySnapshot.dailyDepositUSD =
-      financialsDailySnapshot.dailyDepositUSD.plus(amountUSD);
   } else if (eventType == EventType.WITHDRAW) {
     const inputTokenBalance = market.inputTokenBalance.minus(amount);
     market.inputTokenBalance = inputTokenBalance;
@@ -433,50 +260,28 @@ export function updateMarketStats(
       inputTokenBalance,
       token.decimals
     ).times(priceUSD!);
-    market.save();
-
-    marketDailySnapshot.dailyWithdrawUSD =
-      marketDailySnapshot.dailyWithdrawUSD.plus(amountUSD);
-    usageHourlySnapshot.hourlyWithdrawCount += 1;
-    usageDailySnapshot.dailyWithdrawCount += 1;
-    financialsDailySnapshot.dailyWithdrawUSD =
-      financialsDailySnapshot.dailyWithdrawUSD.plus(amountUSD);
+    hourlyActivity.withdrawCount += 1;
+    dailyActivity.withdrawCount += 1;
+    market.cumulativeWithdrawUSD = market.cumulativeWithdrawUSD.plus(amountUSD);
+    protocol.cumulativeWithdrawUSD =
+      protocol.cumulativeWithdrawUSD.plus(amountUSD);
   } else if (eventType == EventType.BORROW) {
-    usageHourlySnapshot.hourlyBorrowCount += 1;
-    usageDailySnapshot.dailyBorrowCount += 1;
+    hourlyActivity.borrowCount += 1;
+    dailyActivity.borrowCount += 1;
     market.cumulativeBorrowUSD = market.cumulativeBorrowUSD.plus(amountUSD);
-    market.save();
-
-    marketHourlySnapshot.cumulativeBorrowUSD =
-      marketHourlySnapshot.cumulativeBorrowUSD.plus(amountUSD);
-    marketDailySnapshot.cumulativeBorrowUSD =
-      marketDailySnapshot.cumulativeBorrowUSD.plus(amountUSD);
-    financialsDailySnapshot.cumulativeBorrowUSD =
-      financialsDailySnapshot.cumulativeBorrowUSD.plus(amountUSD);
     protocol.cumulativeBorrowUSD = protocol.cumulativeBorrowUSD.plus(amountUSD);
-    marketHourlySnapshot.hourlyBorrowUSD =
-      marketHourlySnapshot.hourlyBorrowUSD.plus(amountUSD);
-    marketDailySnapshot.dailyBorrowUSD =
-      marketDailySnapshot.dailyBorrowUSD.plus(amountUSD);
-    financialsDailySnapshot.dailyBorrowUSD =
-      financialsDailySnapshot.dailyBorrowUSD.plus(amountUSD);
   } else if (eventType == EventType.REPAY) {
-    marketDailySnapshot.dailyRepayUSD =
-      marketDailySnapshot.dailyRepayUSD.plus(amountUSD);
-    usageHourlySnapshot.hourlyRepayCount += 1;
-    usageDailySnapshot.dailyRepayCount += 1;
-    financialsDailySnapshot.dailyRepayUSD =
-      financialsDailySnapshot.dailyRepayUSD.plus(amountUSD);
+    hourlyActivity.repayCount += 1;
+    dailyActivity.repayCount += 1;
+    market.cumulativeRepayUSD = market.cumulativeRepayUSD.plus(amountUSD);
+    protocol.cumulativeRepayUSD = protocol.cumulativeRepayUSD.plus(amountUSD);
   }
   market.inputTokenPriceUSD = getOrCreateToken(
     Address.fromString(market.inputToken)
   ).lastPriceUSD!;
   market.save();
-  usageHourlySnapshot.save();
-  usageDailySnapshot.save();
-  marketHourlySnapshot.save();
-  marketDailySnapshot.save();
-  financialsDailySnapshot.save();
+  hourlyActivity.save();
+  dailyActivity.save();
   protocol.save();
 }
 

--- a/subgraphs/abracadabra/src/common/setters.ts
+++ b/subgraphs/abracadabra/src/common/setters.ts
@@ -74,6 +74,8 @@ export function createMarket(
     MarketEntity.cumulativeDepositUSD = BIGDECIMAL_ZERO;
     MarketEntity.cumulativeBorrowUSD = BIGDECIMAL_ZERO;
     MarketEntity.cumulativeLiquidateUSD = BIGDECIMAL_ZERO;
+    MarketEntity.cumulativeWithdrawUSD = BIGDECIMAL_ZERO;
+    MarketEntity.cumulativeRepayUSD = BIGDECIMAL_ZERO;
     MarketEntity.rates = [];
     MarketEntity.positionCount = 0;
     MarketEntity.openPositionCount = 0;
@@ -241,6 +243,8 @@ export function createMarket(
       MarketEntity.priceOracle = oracleCall.value;
     }
   }
+  MarketEntity._lastDailySnapshotTimestamp = BIGINT_ZERO;
+  MarketEntity._lastHourlySnapshotTimestamp = BIGINT_ZERO;
   MarketEntity.save();
   protocol.totalPoolCount = protocol.totalPoolCount + 1;
   protocol.save();

--- a/subgraphs/abracadabra/src/common/snapshots.ts
+++ b/subgraphs/abracadabra/src/common/snapshots.ts
@@ -1,0 +1,366 @@
+import { BigInt, ethereum } from "@graphprotocol/graph-ts";
+
+import {
+  ActivityInterval,
+  SECONDS_PER_DAY,
+  SECONDS_PER_HOUR,
+} from "./constants";
+import {
+  getMarket,
+  getOrCreateActivityHelper,
+  getOrCreateLendingProtocol,
+} from "./getters";
+import { getSnapshotRates } from "./utils/utils";
+
+import {
+  FinancialsDailySnapshot,
+  LendingProtocol,
+  Market,
+  MarketDailySnapshot,
+  MarketHourlySnapshot,
+  UsageMetricsDailySnapshot,
+  UsageMetricsHourlySnapshot,
+} from "../../generated/schema";
+
+export function takeProtocolSnapshots(event: ethereum.Event): void {
+  const protocol = getOrCreateLendingProtocol();
+  if (
+    protocol._lastDailySnapshotTimestamp
+      .plus(BigInt.fromI32(SECONDS_PER_DAY))
+      .lt(event.block.timestamp)
+  ) {
+    const dayID = event.block.timestamp.toI64() / SECONDS_PER_DAY;
+    takeUsageMetricsDailySnapshot(protocol, dayID, event);
+    takeFinancialsDailySnapshot(protocol, dayID, event);
+
+    protocol._lastDailySnapshotTimestamp = event.block.timestamp;
+    protocol.save();
+  }
+  if (
+    protocol._lastHourlySnapshotTimestamp
+      .plus(BigInt.fromI32(SECONDS_PER_HOUR))
+      .lt(event.block.timestamp)
+  ) {
+    const hourID = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
+    takeUsageMetricsHourlySnapshot(protocol, hourID, event);
+
+    protocol._lastHourlySnapshotTimestamp = event.block.timestamp;
+    protocol.save();
+  }
+}
+
+function takeFinancialsDailySnapshot(
+  protocol: LendingProtocol,
+  id: i64,
+  event: ethereum.Event
+): void {
+  const previousSnapshotID =
+    protocol._lastDailySnapshotTimestamp!.toI64() / SECONDS_PER_DAY;
+  const previousSnapshot = FinancialsDailySnapshot.load(
+    previousSnapshotID.toString()
+  );
+  const snapshot = new FinancialsDailySnapshot(id.toString());
+  snapshot.protocol = protocol.id;
+  snapshot.blockNumber = event.block.number;
+  snapshot.timestamp = event.block.timestamp;
+  snapshot.totalValueLockedUSD = protocol.totalValueLockedUSD;
+  snapshot.mintedTokenSupplies = protocol.mintedTokenSupplies;
+  snapshot.protocolControlledValueUSD = protocol.protocolControlledValueUSD;
+
+  // Revenue //
+  snapshot.dailySupplySideRevenueUSD = previousSnapshot
+    ? protocol.cumulativeSupplySideRevenueUSD.minus(
+        previousSnapshot.cumulativeSupplySideRevenueUSD
+      )
+    : protocol.cumulativeSupplySideRevenueUSD;
+  snapshot.cumulativeSupplySideRevenueUSD =
+    protocol.cumulativeSupplySideRevenueUSD;
+  snapshot.dailyProtocolSideRevenueUSD = previousSnapshot
+    ? protocol.cumulativeProtocolSideRevenueUSD.minus(
+        previousSnapshot.cumulativeProtocolSideRevenueUSD
+      )
+    : protocol.cumulativeProtocolSideRevenueUSD;
+  snapshot.cumulativeProtocolSideRevenueUSD =
+    protocol.cumulativeProtocolSideRevenueUSD;
+  snapshot.dailyTotalRevenueUSD = previousSnapshot
+    ? protocol.cumulativeTotalRevenueUSD.minus(
+        previousSnapshot.cumulativeTotalRevenueUSD
+      )
+    : protocol.cumulativeTotalRevenueUSD;
+  snapshot.cumulativeTotalRevenueUSD = protocol.cumulativeTotalRevenueUSD;
+
+  // Lending Activities //
+  snapshot.totalDepositBalanceUSD = protocol.totalDepositBalanceUSD;
+  snapshot.dailyDepositUSD = previousSnapshot
+    ? protocol.cumulativeDepositUSD.minus(previousSnapshot.cumulativeDepositUSD)
+    : protocol.cumulativeDepositUSD;
+  snapshot.cumulativeDepositUSD = protocol.cumulativeDepositUSD;
+  snapshot.totalBorrowBalanceUSD = protocol.totalBorrowBalanceUSD;
+  snapshot.dailyBorrowUSD = previousSnapshot
+    ? protocol.cumulativeBorrowUSD.minus(previousSnapshot.cumulativeBorrowUSD)
+    : protocol.cumulativeBorrowUSD;
+  snapshot.cumulativeBorrowUSD = protocol.cumulativeBorrowUSD;
+  snapshot.dailyLiquidateUSD = previousSnapshot
+    ? protocol.cumulativeLiquidateUSD.minus(
+        previousSnapshot.cumulativeLiquidateUSD
+      )
+    : protocol.cumulativeLiquidateUSD;
+  snapshot.cumulativeLiquidateUSD = protocol.cumulativeLiquidateUSD;
+  snapshot.dailyWithdrawUSD = previousSnapshot
+    ? protocol.cumulativeWithdrawUSD.minus(
+        previousSnapshot.cumulativeWithdrawUSD
+      )
+    : protocol.cumulativeWithdrawUSD;
+  snapshot.cumulativeWithdrawUSD = protocol.cumulativeWithdrawUSD;
+  snapshot.dailyRepayUSD = previousSnapshot
+    ? protocol.cumulativeRepayUSD.minus(previousSnapshot.cumulativeRepayUSD)
+    : protocol.cumulativeRepayUSD;
+  snapshot.cumulativeRepayUSD = protocol.cumulativeRepayUSD;
+
+  snapshot.save();
+}
+
+function takeUsageMetricsHourlySnapshot(
+  protocol: LendingProtocol,
+  id: i64,
+  event: ethereum.Event
+): void {
+  const activity = getOrCreateActivityHelper(
+    ActivityInterval.HOURLY.concat("-").concat(id.toString())
+  );
+  const snapshot = new UsageMetricsHourlySnapshot(id.toString());
+  snapshot.protocol = protocol.id;
+  snapshot.blockNumber = event.block.number;
+  snapshot.timestamp = event.block.timestamp;
+
+  snapshot.hourlyActiveUsers = activity.activeUsers;
+  snapshot.cumulativeUniqueUsers = protocol.cumulativeUniqueUsers;
+
+  snapshot.hourlyTransactionCount = activity.transactionCount;
+  snapshot.hourlyDepositCount = activity.depositCount;
+  snapshot.hourlyBorrowCount = activity.borrowCount;
+  snapshot.hourlyLiquidateCount = activity.liquidateCount;
+  snapshot.hourlyWithdrawCount = activity.withdrawCount;
+  snapshot.hourlyRepayCount = activity.repayCount;
+
+  snapshot.save();
+}
+
+function takeUsageMetricsDailySnapshot(
+  protocol: LendingProtocol,
+  id: i64,
+  event: ethereum.Event
+): void {
+  const activity = getOrCreateActivityHelper(
+    ActivityInterval.DAILY.concat("-").concat(id.toString())
+  );
+  const snapshot = new UsageMetricsDailySnapshot(id.toString());
+  snapshot.protocol = protocol.id;
+  snapshot.blockNumber = event.block.number;
+  snapshot.timestamp = event.block.timestamp;
+
+  snapshot.dailyActiveUsers = activity.activeUsers;
+  snapshot.cumulativeUniqueUsers = protocol.cumulativeUniqueUsers;
+  snapshot.dailyActiveDepositors = activity.activeDepositors;
+  snapshot.cumulativeUniqueDepositors = protocol.cumulativeUniqueDepositors;
+  snapshot.dailyActiveBorrowers = activity.activeBorrowers;
+  snapshot.cumulativeUniqueBorrowers = protocol.cumulativeUniqueBorrowers;
+  snapshot.dailyActiveLiquidators = activity.activeLiquidators;
+  snapshot.cumulativeUniqueLiquidators = protocol.cumulativeUniqueLiquidators;
+  snapshot.dailyActiveLiquidatees = activity.activeLiquidatees;
+  snapshot.cumulativeUniqueLiquidatees = protocol.cumulativeUniqueLiquidatees;
+
+  snapshot.dailyTransactionCount = activity.transactionCount;
+  snapshot.dailyDepositCount = activity.depositCount;
+  snapshot.dailyBorrowCount = activity.borrowCount;
+  snapshot.dailyLiquidateCount = activity.liquidateCount;
+  snapshot.dailyWithdrawCount = activity.withdrawCount;
+  snapshot.dailyRepayCount = activity.repayCount;
+
+  snapshot.totalPoolCount = protocol.totalPoolCount;
+
+  snapshot.save();
+}
+
+export function takeMarketSnapshots(
+  marketId: string,
+  event: ethereum.Event
+): void {
+  const market = getMarket(marketId);
+  if (!market) {
+    return;
+  }
+
+  if (
+    market._lastDailySnapshotTimestamp
+      .plus(BigInt.fromI32(SECONDS_PER_DAY))
+      .lt(event.block.timestamp)
+  ) {
+    const dayID = event.block.timestamp.toI64() / SECONDS_PER_DAY;
+    takeMarketDailySnapshot(market, dayID, event);
+
+    market._lastDailySnapshotTimestamp = event.block.timestamp;
+    market.save();
+  }
+  if (
+    market._lastHourlySnapshotTimestamp
+      .plus(BigInt.fromI32(SECONDS_PER_HOUR))
+      .lt(event.block.timestamp)
+  ) {
+    const hourID = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
+    takeMarketHourlySnapshot(market, hourID, event);
+
+    market._lastHourlySnapshotTimestamp = event.block.timestamp;
+    market.save();
+  }
+}
+
+function takeMarketHourlySnapshot(
+  market: Market,
+  id: i64,
+  event: ethereum.Event
+): void {
+  const previousSnapshotID =
+    market._lastHourlySnapshotTimestamp!.toI64() / SECONDS_PER_HOUR;
+  const previousSnapshot = MarketHourlySnapshot.load(
+    previousSnapshotID.toString()
+  );
+  const snapshot = new MarketHourlySnapshot(
+    market.id.concat("-").concat(id.toString())
+  );
+  snapshot.protocol = getOrCreateLendingProtocol().id;
+  snapshot.market = market.id;
+  snapshot.inputTokenBalance = market.inputTokenBalance;
+  snapshot.outputTokenSupply = market.outputTokenSupply;
+  snapshot.outputTokenPriceUSD = market.outputTokenPriceUSD;
+  snapshot.totalValueLockedUSD = market.totalValueLockedUSD;
+  snapshot.totalDepositBalanceUSD = market.totalDepositBalanceUSD;
+  snapshot.cumulativeDepositUSD = market.cumulativeDepositUSD;
+  snapshot.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
+  snapshot.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
+  snapshot.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
+  snapshot.cumulativeWithdrawUSD = market.cumulativeWithdrawUSD;
+  snapshot.cumulativeRepayUSD = market.cumulativeRepayUSD;
+  snapshot.cumulativeTotalRevenueUSD = market.cumulativeTotalRevenueUSD;
+  snapshot.cumulativeSupplySideRevenueUSD =
+    market.cumulativeSupplySideRevenueUSD;
+  snapshot.cumulativeProtocolSideRevenueUSD =
+    market.cumulativeProtocolSideRevenueUSD;
+  snapshot.inputTokenPriceUSD = market.inputTokenPriceUSD;
+  snapshot.exchangeRate = market.exchangeRate;
+  snapshot.rewardTokenEmissionsAmount = market.rewardTokenEmissionsAmount;
+  snapshot.rewardTokenEmissionsUSD = market.rewardTokenEmissionsUSD;
+  snapshot.rates = getSnapshotRates(market.rates, id.toString());
+  snapshot.blockNumber = event.block.number;
+  snapshot.timestamp = event.block.timestamp;
+
+  snapshot.hourlyDepositUSD = previousSnapshot
+    ? market.cumulativeDepositUSD.minus(previousSnapshot.cumulativeDepositUSD)
+    : market.cumulativeDepositUSD;
+  snapshot.hourlyBorrowUSD = previousSnapshot
+    ? market.cumulativeBorrowUSD.minus(previousSnapshot.cumulativeBorrowUSD)
+    : market.cumulativeBorrowUSD;
+  snapshot.hourlyLiquidateUSD = previousSnapshot
+    ? market.cumulativeLiquidateUSD.minus(
+        previousSnapshot.cumulativeLiquidateUSD
+      )
+    : market.cumulativeLiquidateUSD;
+  snapshot.hourlyWithdrawUSD = previousSnapshot
+    ? market.cumulativeWithdrawUSD.minus(previousSnapshot.cumulativeWithdrawUSD)
+    : market.cumulativeWithdrawUSD;
+  snapshot.hourlyRepayUSD = previousSnapshot
+    ? market.cumulativeRepayUSD.minus(previousSnapshot.cumulativeRepayUSD)
+    : market.cumulativeRepayUSD;
+  snapshot.hourlyTotalRevenueUSD = previousSnapshot
+    ? market.cumulativeTotalRevenueUSD.minus(
+        previousSnapshot.cumulativeTotalRevenueUSD
+      )
+    : market.cumulativeTotalRevenueUSD;
+  snapshot.hourlySupplySideRevenueUSD = previousSnapshot
+    ? market.cumulativeSupplySideRevenueUSD.minus(
+        previousSnapshot.cumulativeSupplySideRevenueUSD
+      )
+    : market.cumulativeSupplySideRevenueUSD;
+  snapshot.hourlyProtocolSideRevenueUSD = previousSnapshot
+    ? market.cumulativeProtocolSideRevenueUSD.minus(
+        previousSnapshot.cumulativeProtocolSideRevenueUSD
+      )
+    : market.cumulativeProtocolSideRevenueUSD;
+
+  snapshot.save();
+}
+
+function takeMarketDailySnapshot(
+  market: Market,
+  id: i64,
+  event: ethereum.Event
+): void {
+  const previousSnapshotID =
+    market._lastDailySnapshotTimestamp!.toI64() / SECONDS_PER_DAY;
+  const previousSnapshot = MarketDailySnapshot.load(
+    previousSnapshotID.toString()
+  );
+  const snapshot = new MarketDailySnapshot(
+    market.id.concat("-").concat(id.toString())
+  );
+  snapshot.protocol = getOrCreateLendingProtocol().id;
+  snapshot.market = market.id;
+  snapshot.inputTokenBalance = market.inputTokenBalance;
+  snapshot.outputTokenSupply = market.outputTokenSupply;
+  snapshot.outputTokenPriceUSD = market.outputTokenPriceUSD;
+  snapshot.totalValueLockedUSD = market.totalValueLockedUSD;
+  snapshot.totalDepositBalanceUSD = market.totalDepositBalanceUSD;
+  snapshot.cumulativeDepositUSD = market.cumulativeDepositUSD;
+  snapshot.totalBorrowBalanceUSD = market.totalBorrowBalanceUSD;
+  snapshot.cumulativeBorrowUSD = market.cumulativeBorrowUSD;
+  snapshot.cumulativeLiquidateUSD = market.cumulativeLiquidateUSD;
+  snapshot.cumulativeWithdrawUSD = market.cumulativeWithdrawUSD;
+  snapshot.cumulativeRepayUSD = market.cumulativeRepayUSD;
+  snapshot.cumulativeTotalRevenueUSD = market.cumulativeTotalRevenueUSD;
+  snapshot.cumulativeSupplySideRevenueUSD =
+    market.cumulativeSupplySideRevenueUSD;
+  snapshot.cumulativeProtocolSideRevenueUSD =
+    market.cumulativeProtocolSideRevenueUSD;
+  snapshot.inputTokenPriceUSD = market.inputTokenPriceUSD;
+  snapshot.exchangeRate = market.exchangeRate;
+  snapshot.rewardTokenEmissionsAmount = market.rewardTokenEmissionsAmount;
+  snapshot.rewardTokenEmissionsUSD = market.rewardTokenEmissionsUSD;
+  snapshot.rates = getSnapshotRates(market.rates, id.toString());
+  snapshot.blockNumber = event.block.number;
+  snapshot.timestamp = event.block.timestamp;
+
+  snapshot.dailyDepositUSD = previousSnapshot
+    ? market.cumulativeDepositUSD.minus(previousSnapshot.cumulativeDepositUSD)
+    : market.cumulativeDepositUSD;
+  snapshot.dailyBorrowUSD = previousSnapshot
+    ? market.cumulativeBorrowUSD.minus(previousSnapshot.cumulativeBorrowUSD)
+    : market.cumulativeBorrowUSD;
+  snapshot.dailyLiquidateUSD = previousSnapshot
+    ? market.cumulativeLiquidateUSD.minus(
+        previousSnapshot.cumulativeLiquidateUSD
+      )
+    : market.cumulativeLiquidateUSD;
+  snapshot.dailyWithdrawUSD = previousSnapshot
+    ? market.cumulativeWithdrawUSD.minus(previousSnapshot.cumulativeWithdrawUSD)
+    : market.cumulativeWithdrawUSD;
+  snapshot.dailyRepayUSD = previousSnapshot
+    ? market.cumulativeRepayUSD.minus(previousSnapshot.cumulativeRepayUSD)
+    : market.cumulativeRepayUSD;
+  snapshot.dailyTotalRevenueUSD = previousSnapshot
+    ? market.cumulativeTotalRevenueUSD.minus(
+        previousSnapshot.cumulativeTotalRevenueUSD
+      )
+    : market.cumulativeTotalRevenueUSD;
+  snapshot.dailySupplySideRevenueUSD = previousSnapshot
+    ? market.cumulativeSupplySideRevenueUSD.minus(
+        previousSnapshot.cumulativeSupplySideRevenueUSD
+      )
+    : market.cumulativeSupplySideRevenueUSD;
+  snapshot.dailyProtocolSideRevenueUSD = previousSnapshot
+    ? market.cumulativeProtocolSideRevenueUSD.minus(
+        previousSnapshot.cumulativeProtocolSideRevenueUSD
+      )
+    : market.cumulativeProtocolSideRevenueUSD;
+
+  snapshot.save();
+}

--- a/subgraphs/abracadabra/src/common/snapshots.ts
+++ b/subgraphs/abracadabra/src/common/snapshots.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { BigInt, ethereum } from "@graphprotocol/graph-ts";
 
 import {
   ActivityInterval,
@@ -29,7 +29,7 @@ export function takeProtocolSnapshots(event: ethereum.Event): void {
       .plus(BigInt.fromI32(SECONDS_PER_DAY))
       .lt(event.block.timestamp)
   ) {
-    const dayID = event.block.timestamp.toI32() / SECONDS_PER_DAY;
+    const dayID = event.block.timestamp.toI64() / SECONDS_PER_DAY;
     takeUsageMetricsDailySnapshot(protocol, dayID, event);
     takeFinancialsDailySnapshot(protocol, dayID, event);
 
@@ -41,7 +41,7 @@ export function takeProtocolSnapshots(event: ethereum.Event): void {
       .plus(BigInt.fromI32(SECONDS_PER_HOUR))
       .lt(event.block.timestamp)
   ) {
-    const hourID = event.block.timestamp.toI32() / SECONDS_PER_HOUR;
+    const hourID = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
     takeUsageMetricsHourlySnapshot(protocol, hourID, event);
 
     protocol._lastHourlySnapshotTimestamp = event.block.timestamp;
@@ -51,15 +51,15 @@ export function takeProtocolSnapshots(event: ethereum.Event): void {
 
 function takeFinancialsDailySnapshot(
   protocol: LendingProtocol,
-  id: i32,
+  id: i64,
   event: ethereum.Event
 ): void {
   const previousSnapshotID =
-    protocol._lastDailySnapshotTimestamp!.toI32() / SECONDS_PER_DAY;
+    protocol._lastDailySnapshotTimestamp!.toI64() / SECONDS_PER_DAY;
   const previousSnapshot = FinancialsDailySnapshot.load(
-    Bytes.fromI32(previousSnapshotID)
+    previousSnapshotID.toString()
   );
-  const snapshot = new FinancialsDailySnapshot(Bytes.fromI32(id));
+  const snapshot = new FinancialsDailySnapshot(id.toString());
   snapshot.protocol = protocol.id;
   snapshot.blockNumber = event.block.number;
   snapshot.timestamp = event.block.timestamp;
@@ -122,15 +122,13 @@ function takeFinancialsDailySnapshot(
 
 function takeUsageMetricsHourlySnapshot(
   protocol: LendingProtocol,
-  id: i32,
+  id: i64,
   event: ethereum.Event
 ): void {
   const activity = getOrCreateActivityHelper(
-    Bytes.fromUTF8(ActivityInterval.HOURLY)
-      .concat(Bytes.fromUTF8("-"))
-      .concat(Bytes.fromI32(id))
+    ActivityInterval.HOURLY.concat("-").concat(id.toString())
   );
-  const snapshot = new UsageMetricsHourlySnapshot(Bytes.fromI32(id));
+  const snapshot = new UsageMetricsHourlySnapshot(id.toString());
   snapshot.protocol = protocol.id;
   snapshot.blockNumber = event.block.number;
   snapshot.timestamp = event.block.timestamp;
@@ -150,15 +148,13 @@ function takeUsageMetricsHourlySnapshot(
 
 function takeUsageMetricsDailySnapshot(
   protocol: LendingProtocol,
-  id: i32,
+  id: i64,
   event: ethereum.Event
 ): void {
   const activity = getOrCreateActivityHelper(
-    Bytes.fromUTF8(ActivityInterval.DAILY)
-      .concat(Bytes.fromUTF8("-"))
-      .concat(Bytes.fromI32(id))
+    ActivityInterval.DAILY.concat("-").concat(id.toString())
   );
-  const snapshot = new UsageMetricsDailySnapshot(Bytes.fromI32(id));
+  const snapshot = new UsageMetricsDailySnapshot(id.toString());
   snapshot.protocol = protocol.id;
   snapshot.blockNumber = event.block.number;
   snapshot.timestamp = event.block.timestamp;
@@ -187,7 +183,7 @@ function takeUsageMetricsDailySnapshot(
 }
 
 export function takeMarketSnapshots(
-  marketId: Address,
+  marketId: string,
   event: ethereum.Event
 ): void {
   const market = getMarket(marketId);
@@ -200,7 +196,7 @@ export function takeMarketSnapshots(
       .plus(BigInt.fromI32(SECONDS_PER_DAY))
       .lt(event.block.timestamp)
   ) {
-    const dayID = event.block.timestamp.toI32() / SECONDS_PER_DAY;
+    const dayID = event.block.timestamp.toI64() / SECONDS_PER_DAY;
     takeMarketDailySnapshot(market, dayID, event);
 
     market._lastDailySnapshotTimestamp = event.block.timestamp;
@@ -211,7 +207,7 @@ export function takeMarketSnapshots(
       .plus(BigInt.fromI32(SECONDS_PER_HOUR))
       .lt(event.block.timestamp)
   ) {
-    const hourID = event.block.timestamp.toI32() / SECONDS_PER_HOUR;
+    const hourID = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
     takeMarketHourlySnapshot(market, hourID, event);
 
     market._lastHourlySnapshotTimestamp = event.block.timestamp;
@@ -221,16 +217,16 @@ export function takeMarketSnapshots(
 
 function takeMarketHourlySnapshot(
   market: Market,
-  id: i32,
+  id: i64,
   event: ethereum.Event
 ): void {
   const previousSnapshotID =
-    market._lastHourlySnapshotTimestamp!.toI32() / SECONDS_PER_HOUR;
+    market._lastHourlySnapshotTimestamp!.toI64() / SECONDS_PER_HOUR;
   const previousSnapshot = MarketHourlySnapshot.load(
-    Bytes.fromI32(previousSnapshotID)
+    previousSnapshotID.toString()
   );
   const snapshot = new MarketHourlySnapshot(
-    market.id.concat(Bytes.fromUTF8("-")).concat(Bytes.fromI32(id))
+    market.id.concat("-").concat(id.toString())
   );
   snapshot.protocol = getOrCreateLendingProtocol().id;
   snapshot.market = market.id;
@@ -296,16 +292,16 @@ function takeMarketHourlySnapshot(
 
 function takeMarketDailySnapshot(
   market: Market,
-  id: i32,
+  id: i64,
   event: ethereum.Event
 ): void {
   const previousSnapshotID =
-    market._lastDailySnapshotTimestamp!.toI32() / SECONDS_PER_DAY;
+    market._lastDailySnapshotTimestamp!.toI64() / SECONDS_PER_DAY;
   const previousSnapshot = MarketDailySnapshot.load(
-    Bytes.fromI32(previousSnapshotID)
+    previousSnapshotID.toString()
   );
   const snapshot = new MarketDailySnapshot(
-    market.id.concat(Bytes.fromUTF8("-")).concat(Bytes.fromI32(id))
+    market.id.concat("-").concat(id.toString())
   );
   snapshot.protocol = getOrCreateLendingProtocol().id;
   snapshot.market = market.id;

--- a/subgraphs/abracadabra/src/common/utils/utils.ts
+++ b/subgraphs/abracadabra/src/common/utils/utils.ts
@@ -1,4 +1,4 @@
-import { ethereum, log } from "@graphprotocol/graph-ts";
+import { Bytes, ethereum, log } from "@graphprotocol/graph-ts";
 import { InterestRate } from "../../../generated/schema";
 
 export function readValue<T>(
@@ -10,22 +10,21 @@ export function readValue<T>(
 
 // create separate InterestRate Entities for each market snapshot
 // this is needed to prevent snapshot rates from being pointers to the current rate
-export function getSnapshotRates(
-  rates: string[],
-  timeSuffix: string
-): string[] {
-  const snapshotRates: string[] = [];
+export function getSnapshotRates(rates: Bytes[], timeSuffix: string): Bytes[] {
+  const snapshotRates: Bytes[] = [];
   for (let i = 0; i < rates.length; i++) {
     const rate = InterestRate.load(rates[i]);
     if (!rate) {
       log.warning("[getSnapshotRates] rate {} not found, should not happen", [
-        rates[i],
+        rates[i].toHexString(),
       ]);
       continue;
     }
 
     // create new snapshot rate
-    const snapshotRateId = rates[i].concat("-").concat(timeSuffix);
+    const snapshotRateId = rates[i]
+      .concat(Bytes.fromUTF8("-"))
+      .concat(Bytes.fromUTF8(timeSuffix));
     const snapshotRate = new InterestRate(snapshotRateId);
     snapshotRate.side = rate.side;
     snapshotRate.type = rate.type;

--- a/subgraphs/abracadabra/src/common/utils/utils.ts
+++ b/subgraphs/abracadabra/src/common/utils/utils.ts
@@ -1,4 +1,4 @@
-import { Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { ethereum, log } from "@graphprotocol/graph-ts";
 import { InterestRate } from "../../../generated/schema";
 
 export function readValue<T>(
@@ -10,21 +10,22 @@ export function readValue<T>(
 
 // create separate InterestRate Entities for each market snapshot
 // this is needed to prevent snapshot rates from being pointers to the current rate
-export function getSnapshotRates(rates: Bytes[], timeSuffix: string): Bytes[] {
-  const snapshotRates: Bytes[] = [];
+export function getSnapshotRates(
+  rates: string[],
+  timeSuffix: string
+): string[] {
+  const snapshotRates: string[] = [];
   for (let i = 0; i < rates.length; i++) {
     const rate = InterestRate.load(rates[i]);
     if (!rate) {
       log.warning("[getSnapshotRates] rate {} not found, should not happen", [
-        rates[i].toHexString(),
+        rates[i],
       ]);
       continue;
     }
 
     // create new snapshot rate
-    const snapshotRateId = rates[i]
-      .concat(Bytes.fromUTF8("-"))
-      .concat(Bytes.fromUTF8(timeSuffix));
+    const snapshotRateId = rates[i].concat("-").concat(timeSuffix);
     const snapshotRate = new InterestRate(snapshotRateId);
     snapshotRate.side = rate.side;
     snapshotRate.type = rate.type;

--- a/subgraphs/abracadabra/src/mapping.ts
+++ b/subgraphs/abracadabra/src/mapping.ts
@@ -138,7 +138,7 @@ export function handleLogAddCollateral(event: LogAddCollateral): void {
     event.params.share,
     event
   );
-  updateTVL();
+  updateTVL(event);
   updateUsageMetrics(event, event.params.from, event.params.to);
   takeProtocolSnapshots(event);
   takeMarketSnapshots(Address.fromBytes(market.id), event);
@@ -209,7 +209,7 @@ export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
     event.params.share,
     event
   );
-  updateTVL();
+  updateTVL(event);
   updateUsageMetrics(event, event.params.from, event.params.to);
   takeProtocolSnapshots(event);
   takeMarketSnapshots(Address.fromBytes(market.id), event);
@@ -263,7 +263,7 @@ export function handleLogBorrow(event: LogBorrow): void {
   borrowEvent.save();
 
   updateBorrowAmount(market);
-  updateTotalBorrows();
+  updateTotalBorrows(event);
   updateMarketStats(
     Address.fromBytes(market.id),
     EventType.BORROW,
@@ -472,7 +472,7 @@ export function handleLogRepay(event: LogRepay): void {
   repayEvent.save();
 
   updateBorrowAmount(market);
-  updateTotalBorrows();
+  updateTotalBorrows(event);
   updateMarketStats(
     Address.fromBytes(market.id),
     EventType.REPAY,
@@ -492,7 +492,7 @@ export function handleLogExchangeRate(event: LogExchangeRate): void {
   }
   const token = getOrCreateToken(Address.fromBytes(market.inputToken));
   updateTokenPrice(event.params.rate, token, market, event.block.number);
-  updateTVL();
+  updateTVL(event);
   takeProtocolSnapshots(event);
   takeMarketSnapshots(Address.fromBytes(market.id), event);
 }

--- a/subgraphs/abracadabra/src/mapping.ts
+++ b/subgraphs/abracadabra/src/mapping.ts
@@ -138,7 +138,7 @@ export function handleLogAddCollateral(event: LogAddCollateral): void {
     event.params.share,
     event
   );
-  updateTVL(event);
+  updateTVL();
   updateUsageMetrics(event, event.params.from, event.params.to);
   takeProtocolSnapshots(event);
   takeMarketSnapshots(Address.fromBytes(market.id), event);
@@ -209,7 +209,7 @@ export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
     event.params.share,
     event
   );
-  updateTVL(event);
+  updateTVL();
   updateUsageMetrics(event, event.params.from, event.params.to);
   takeProtocolSnapshots(event);
   takeMarketSnapshots(Address.fromBytes(market.id), event);
@@ -263,7 +263,7 @@ export function handleLogBorrow(event: LogBorrow): void {
   borrowEvent.save();
 
   updateBorrowAmount(market);
-  updateTotalBorrows(event);
+  updateTotalBorrows();
   updateMarketStats(
     Address.fromBytes(market.id),
     EventType.BORROW,
@@ -472,7 +472,7 @@ export function handleLogRepay(event: LogRepay): void {
   repayEvent.save();
 
   updateBorrowAmount(market);
-  updateTotalBorrows(event);
+  updateTotalBorrows();
   updateMarketStats(
     Address.fromBytes(market.id),
     EventType.REPAY,
@@ -492,7 +492,7 @@ export function handleLogExchangeRate(event: LogExchangeRate): void {
   }
   const token = getOrCreateToken(Address.fromBytes(market.inputToken));
   updateTokenPrice(event.params.rate, token, market, event.block.number);
-  updateTVL(event);
+  updateTVL();
   takeProtocolSnapshots(event);
   takeMarketSnapshots(Address.fromBytes(market.id), event);
 }

--- a/subgraphs/abracadabra/src/mapping.ts
+++ b/subgraphs/abracadabra/src/mapping.ts
@@ -31,6 +31,9 @@ import {
   BIGINT_ZERO,
   InterestRateSide,
   PositionSide,
+  SECONDS_PER_HOUR,
+  SECONDS_PER_DAY,
+  ActivityInterval,
 } from "./common/constants";
 import { bigIntToBigDecimal } from "./common/utils/numbers";
 import {
@@ -39,18 +42,13 @@ import {
   getMarket,
   getLiquidateEvent,
   getMIMAddress,
-  getOrCreateUsageMetricsHourlySnapshot,
-  getOrCreateUsageMetricsDailySnapshot,
-  getOrCreateMarketHourlySnapshot,
-  getOrCreateMarketDailySnapshot,
-  getOrCreateFinancials,
+  getOrCreateActivityHelper,
 } from "./common/getters";
 import { Cauldron as CauldronDataSource } from "../generated/templates";
 import {
   updateUsageMetrics,
   updateTVL,
   updateMarketStats,
-  updateMarketMetrics,
   updateFinancials,
   updateTotalBorrows,
   updateBorrowAmount,
@@ -60,6 +58,7 @@ import {
   createLiquidateEvent,
   updateTokenPrice,
 } from "./common/setters";
+import { takeMarketSnapshots, takeProtocolSnapshots } from "./common/snapshots";
 import {
   addAccountToProtocol,
   getLiquidatePosition,
@@ -70,12 +69,11 @@ import {
 export function handleLogDeploy(event: LogDeploy): void {
   const account = event.transaction.from.toHex().toLowerCase();
   if (ABRA_ACCOUNTS.indexOf(account) > NEG_INT_ONE) {
-    createMarket(
-      event.params.cloneAddress.toHexString(),
-      event.block.number,
-      event.block.timestamp
-    );
+    const marketID = event.params.cloneAddress.toHexString();
+    createMarket(marketID, event.block.number, event.block.timestamp);
     CauldronDataSource.create(event.params.cloneAddress);
+    takeProtocolSnapshots(event);
+    takeMarketSnapshots(marketID, event);
   }
 }
 
@@ -141,8 +139,9 @@ export function handleLogAddCollateral(event: LogAddCollateral): void {
     event
   );
   updateTVL(event);
-  updateMarketMetrics(event); // must run updateMarketStats first as updateMarketMetrics uses values updated in updateMarketStats
   updateUsageMetrics(event, event.params.from, event.params.to);
+  takeProtocolSnapshots(event);
+  takeMarketSnapshots(market.id, event);
 }
 
 export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
@@ -211,8 +210,9 @@ export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
     event
   );
   updateTVL(event);
-  updateMarketMetrics(event); // must run updateMarketStats first as updateMarketMetrics uses values updated in updateMarketStats
   updateUsageMetrics(event, event.params.from, event.params.to);
+  takeProtocolSnapshots(event);
+  takeMarketSnapshots(market.id, event);
 }
 
 export function handleLogBorrow(event: LogBorrow): void {
@@ -271,8 +271,9 @@ export function handleLogBorrow(event: LogBorrow): void {
     event.params.amount,
     event
   );
-  updateMarketMetrics(event); // must run updateMarketStats first as updateMarketMetrics uses values updated in updateMarketStats
   updateUsageMetrics(event, event.params.from, event.params.to);
+  takeProtocolSnapshots(event);
+  takeMarketSnapshots(market.id, event);
 }
 
 // Liquidation steps
@@ -308,21 +309,19 @@ export function handleLiquidation(event: LogRepay): void {
   if (!market) {
     return;
   }
-  const usageHourlySnapshot = getOrCreateUsageMetricsHourlySnapshot(event);
-  const usageDailySnapshot = getOrCreateUsageMetricsDailySnapshot(event);
-  const marketHourlySnapshot = getOrCreateMarketHourlySnapshot(
-    event,
-    market.id
+
+  const hourlyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
+  const hourlyActivity = getOrCreateActivityHelper(
+    ActivityInterval.HOURLY.concat("-").concat(hourlyId.toString())
   );
-  const marketDailySnapshot = getOrCreateMarketDailySnapshot(event, market.id);
-  if (!marketHourlySnapshot || !marketDailySnapshot) {
-    return;
-  }
+  const dailyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_DAY;
+  const dailyActivity = getOrCreateActivityHelper(
+    ActivityInterval.DAILY.concat("-").concat(dailyId.toString())
+  );
 
   // update market prices
   updateAllTokenPrices(event.block.number);
 
-  const financialsDailySnapshot = getOrCreateFinancials(event);
   const collateralToken = getOrCreateToken(
     Address.fromString(market.inputToken)
   );
@@ -377,11 +376,11 @@ export function handleLiquidation(event: LogRepay): void {
   );
   liquidateEvent.save();
 
-  usageHourlySnapshot.hourlyLiquidateCount += 1;
-  usageHourlySnapshot.save();
+  hourlyActivity.liquidateCount += 1;
+  hourlyActivity.save();
 
-  usageDailySnapshot.dailyLiquidateCount += 1;
-  usageDailySnapshot.save();
+  dailyActivity.liquidateCount += 1;
+  dailyActivity.save();
 
   liquidateeAccount.liquidateCount = liquidateeAccount.liquidateCount + 1;
   liquidateeAccount.save();
@@ -401,29 +400,18 @@ export function handleLiquidation(event: LogRepay): void {
     protocol
   );
 
-  marketHourlySnapshot.hourlyLiquidateUSD =
-    marketHourlySnapshot.hourlyLiquidateUSD.plus(collateralAmountUSD);
-  marketDailySnapshot.dailyLiquidateUSD =
-    marketDailySnapshot.dailyLiquidateUSD.plus(collateralAmountUSD);
-  financialsDailySnapshot.dailyLiquidateUSD =
-    financialsDailySnapshot.dailyLiquidateUSD.plus(collateralAmountUSD);
-
   const marketCumulativeLiquidateUSD =
     market.cumulativeLiquidateUSD.plus(collateralAmountUSD);
   market.cumulativeLiquidateUSD = marketCumulativeLiquidateUSD;
-  marketHourlySnapshot.cumulativeLiquidateUSD = marketCumulativeLiquidateUSD;
-  marketDailySnapshot.cumulativeLiquidateUSD = marketCumulativeLiquidateUSD;
-  marketHourlySnapshot.save();
-  marketDailySnapshot.save();
   market.save();
 
   const protocolCumulativeLiquidateUSD =
     protocol.cumulativeLiquidateUSD.plus(collateralAmountUSD);
-  financialsDailySnapshot.cumulativeLiquidateUSD =
-    protocolCumulativeLiquidateUSD;
   protocol.cumulativeLiquidateUSD = protocolCumulativeLiquidateUSD;
   protocol.save();
-  financialsDailySnapshot.save();
+
+  takeProtocolSnapshots(event);
+  takeMarketSnapshots(market.id, event);
 }
 
 export function handleLogRepay(event: LogRepay): void {
@@ -494,8 +482,9 @@ export function handleLogRepay(event: LogRepay): void {
     event.params.part,
     event
   ); // smart contract code subs event.params.part from totalBorrow
-  updateMarketMetrics(event); // must run updateMarketStats first as updateMarketMetrics uses values updated in updateMarketStats
   updateUsageMetrics(event, event.params.from, event.params.to);
+  takeProtocolSnapshots(event);
+  takeMarketSnapshots(market.id, event);
 }
 
 export function handleLogExchangeRate(event: LogExchangeRate): void {
@@ -506,9 +495,12 @@ export function handleLogExchangeRate(event: LogExchangeRate): void {
   const token = getOrCreateToken(Address.fromString(market.inputToken));
   updateTokenPrice(event.params.rate, token, market, event.block.number);
   updateTVL(event);
+  takeProtocolSnapshots(event);
+  takeMarketSnapshots(market.id, event);
 }
 
 export function handleLogAccrue(event: LogAccrue): void {
+  const marketID = event.address.toHexString();
   const mimPriceUSD = getOrCreateToken(
     Address.fromString(getMIMAddress(dataSource.network()))
   ).lastPriceUSD;
@@ -516,7 +508,9 @@ export function handleLogAccrue(event: LogAccrue): void {
     event.params.accruedAmount,
     DEFAULT_DECIMALS
   ).times(mimPriceUSD!);
-  updateFinancials(event, feesUSD, event.address.toHexString());
+  updateFinancials(event, feesUSD, marketID);
+  takeProtocolSnapshots(event);
+  takeMarketSnapshots(marketID, event);
 }
 
 // updates all input token prices using the price oracle

--- a/subgraphs/abracadabra/src/mapping.ts
+++ b/subgraphs/abracadabra/src/mapping.ts
@@ -138,7 +138,7 @@ export function handleLogAddCollateral(event: LogAddCollateral): void {
     event.params.share,
     event
   );
-  updateTVL(event);
+  updateTVL();
   updateUsageMetrics(event, event.params.from, event.params.to);
   takeProtocolSnapshots(event);
   takeMarketSnapshots(market.id, event);
@@ -209,7 +209,7 @@ export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
     event.params.share,
     event
   );
-  updateTVL(event);
+  updateTVL();
   updateUsageMetrics(event, event.params.from, event.params.to);
   takeProtocolSnapshots(event);
   takeMarketSnapshots(market.id, event);
@@ -263,7 +263,7 @@ export function handleLogBorrow(event: LogBorrow): void {
   borrowEvent.save();
 
   updateBorrowAmount(market);
-  updateTotalBorrows(event);
+  updateTotalBorrows();
   updateMarketStats(
     market.id,
     EventType.BORROW,
@@ -474,7 +474,7 @@ export function handleLogRepay(event: LogRepay): void {
   repayEvent.save();
 
   updateBorrowAmount(market);
-  updateTotalBorrows(event);
+  updateTotalBorrows();
   updateMarketStats(
     market.id,
     EventType.REPAY,
@@ -494,7 +494,7 @@ export function handleLogExchangeRate(event: LogExchangeRate): void {
   }
   const token = getOrCreateToken(Address.fromString(market.inputToken));
   updateTokenPrice(event.params.rate, token, market, event.block.number);
-  updateTVL(event);
+  updateTVL();
   takeProtocolSnapshots(event);
   takeMarketSnapshots(market.id, event);
 }

--- a/subgraphs/abracadabra/src/mapping.ts
+++ b/subgraphs/abracadabra/src/mapping.ts
@@ -69,7 +69,7 @@ import {
 export function handleLogDeploy(event: LogDeploy): void {
   const account = event.transaction.from.toHex().toLowerCase();
   if (ABRA_ACCOUNTS.indexOf(account) > NEG_INT_ONE) {
-    const marketID = event.params.cloneAddress;
+    const marketID = event.params.cloneAddress.toHexString();
     createMarket(marketID, event.block.number, event.block.timestamp);
     CauldronDataSource.create(event.params.cloneAddress);
     takeProtocolSnapshots(event);
@@ -79,11 +79,11 @@ export function handleLogDeploy(event: LogDeploy): void {
 
 export function handleLogAddCollateral(event: LogAddCollateral): void {
   const depositEvent = new Deposit(
-    event.transaction.hash
-      .concat(Bytes.fromUTF8("-"))
-      .concat(Bytes.fromI32(event.transactionLogIndex.toI32()))
+    event.transaction.hash.toHexString() +
+      "-" +
+      event.transactionLogIndex.toString()
   );
-  const market = getMarket(event.address);
+  const market = getMarket(event.address.toHexString());
   if (!market) {
     return;
   }
@@ -93,7 +93,7 @@ export function handleLogAddCollateral(event: LogAddCollateral): void {
 
   const CauldronContract = Cauldron.bind(event.address);
   const collateralToken = getOrCreateToken(
-    Address.fromBytes(market.inputToken)
+    Address.fromString(market.inputToken)
   );
   const tokenPriceUSD = collateralToken.lastPriceUSD;
   const amountUSD = bigIntToBigDecimal(
@@ -102,7 +102,7 @@ export function handleLogAddCollateral(event: LogAddCollateral): void {
   ).times(tokenPriceUSD!);
 
   const protocol = getOrCreateLendingProtocol();
-  const account = getOrCreateAccount(event.params.to, protocol);
+  const account = getOrCreateAccount(event.params.to.toHexString(), protocol);
 
   depositEvent.hash = event.transaction.hash.toHexString();
   depositEvent.nonce = event.transaction.nonce;
@@ -116,7 +116,7 @@ export function handleLogAddCollateral(event: LogAddCollateral): void {
   // Amount needs to be calculated differently as bentobox deals shares and amounts in a different way.
   // usage of toAmount function converts shares to actual amount based on collateral
   depositEvent.amount = DegenBox.bind(CauldronContract.bentoBox()).toAmount(
-    Address.fromBytes(collateralToken.id),
+    Address.fromString(collateralToken.id),
     event.params.share,
     false
   );
@@ -132,16 +132,16 @@ export function handleLogAddCollateral(event: LogAddCollateral): void {
   depositEvent.save();
 
   updateMarketStats(
-    Address.fromBytes(market.id),
+    market.id,
     EventType.DEPOSIT,
-    Address.fromBytes(collateralToken.id),
+    collateralToken.id,
     event.params.share,
     event
   );
   updateTVL(event);
   updateUsageMetrics(event, event.params.from, event.params.to);
   takeProtocolSnapshots(event);
-  takeMarketSnapshots(Address.fromBytes(market.id), event);
+  takeMarketSnapshots(market.id, event);
 }
 
 export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
@@ -151,11 +151,11 @@ export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
     liquidation = true;
   }
   const withdrawalEvent = new Withdraw(
-    event.transaction.hash
-      .concat(Bytes.fromUTF8("-"))
-      .concat(Bytes.fromI32(event.transactionLogIndex.toI32()))
+    event.transaction.hash.toHexString() +
+      "-" +
+      event.transactionLogIndex.toString()
   );
-  const market = getMarket(event.address);
+  const market = getMarket(event.address.toHexString());
   if (!market) {
     return;
   }
@@ -164,7 +164,7 @@ export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
   updateAllTokenPrices(event.block.number);
 
   const collateralToken = getOrCreateToken(
-    Address.fromBytes(market.inputToken)
+    Address.fromString(market.inputToken)
   );
   const CauldronContract = Cauldron.bind(event.address);
   const tokenPriceUSD = collateralToken.lastPriceUSD;
@@ -174,7 +174,7 @@ export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
   ).times(tokenPriceUSD!);
 
   const protocol = getOrCreateLendingProtocol();
-  const account = getOrCreateAccount(event.params.from, protocol);
+  const account = getOrCreateAccount(event.params.from.toHexString(), protocol);
 
   withdrawalEvent.hash = event.transaction.hash.toHexString();
   withdrawalEvent.nonce = event.transaction.nonce;
@@ -186,7 +186,7 @@ export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
   withdrawalEvent.market = market.id;
   withdrawalEvent.asset = collateralToken.id;
   withdrawalEvent.amount = DegenBox.bind(CauldronContract.bentoBox()).toAmount(
-    Address.fromBytes(collateralToken.id),
+    Address.fromString(collateralToken.id),
     event.params.share,
     false
   );
@@ -203,25 +203,25 @@ export function handleLogRemoveCollateral(event: LogRemoveCollateral): void {
   withdrawalEvent.save();
 
   updateMarketStats(
-    Address.fromBytes(market.id),
+    market.id,
     EventType.WITHDRAW,
-    Address.fromBytes(collateralToken.id),
+    collateralToken.id,
     event.params.share,
     event
   );
   updateTVL(event);
   updateUsageMetrics(event, event.params.from, event.params.to);
   takeProtocolSnapshots(event);
-  takeMarketSnapshots(Address.fromBytes(market.id), event);
+  takeMarketSnapshots(market.id, event);
 }
 
 export function handleLogBorrow(event: LogBorrow): void {
   const borrowEvent = new Borrow(
-    event.transaction.hash
-      .concat(Bytes.fromUTF8("-"))
-      .concat(Bytes.fromI32(event.transactionLogIndex.toI32()))
+    event.transaction.hash.toHexString() +
+      "-" +
+      event.transactionLogIndex.toString()
   );
-  const market = getMarket(event.address);
+  const market = getMarket(event.address.toHexString());
   if (!market) {
     return;
   }
@@ -239,7 +239,7 @@ export function handleLogBorrow(event: LogBorrow): void {
   ).times(mimPriceUSD!);
 
   const protocol = getOrCreateLendingProtocol();
-  const account = getOrCreateAccount(event.params.from, protocol);
+  const account = getOrCreateAccount(event.params.from.toHexString(), protocol);
 
   borrowEvent.hash = event.transaction.hash.toHexString();
   borrowEvent.nonce = event.transaction.nonce;
@@ -265,15 +265,15 @@ export function handleLogBorrow(event: LogBorrow): void {
   updateBorrowAmount(market);
   updateTotalBorrows(event);
   updateMarketStats(
-    Address.fromBytes(market.id),
+    market.id,
     EventType.BORROW,
-    Address.fromString(getMIMAddress(dataSource.network())),
+    getMIMAddress(dataSource.network()),
     event.params.amount,
     event
   );
   updateUsageMetrics(event, event.params.from, event.params.to);
   takeProtocolSnapshots(event);
-  takeMarketSnapshots(Address.fromBytes(market.id), event);
+  takeMarketSnapshots(market.id, event);
 }
 
 // Liquidation steps
@@ -298,36 +298,32 @@ export function handleLiquidation(event: LogRepay): void {
     return;
   }
   const liquidateEvent = new Liquidate(
-    Bytes.fromUTF8("liquidate")
-      .concat(Bytes.fromUTF8("-"))
-      .concat(event.transaction.hash)
-      .concat(Bytes.fromUTF8("-"))
-      .concat(Bytes.fromI32(event.transactionLogIndex.toI32()))
+    "liquidate" +
+      "-" +
+      event.transaction.hash.toHexString() +
+      "-" +
+      event.transactionLogIndex.toString()
   );
   liquidateEvent.amount = liquidateProxy.amount;
-  const market = getMarket(event.address);
+  const market = getMarket(event.address.toHexString());
   if (!market) {
     return;
   }
 
-  const hourlyId = event.block.timestamp.toI32() / SECONDS_PER_HOUR;
+  const hourlyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_HOUR;
   const hourlyActivity = getOrCreateActivityHelper(
-    Bytes.fromUTF8(ActivityInterval.HOURLY)
-      .concat(Bytes.fromUTF8("-"))
-      .concat(Bytes.fromI32(hourlyId))
+    ActivityInterval.HOURLY.concat("-").concat(hourlyId.toString())
   );
-  const dailyId = event.block.timestamp.toI32() / SECONDS_PER_DAY;
+  const dailyId: i64 = event.block.timestamp.toI64() / SECONDS_PER_DAY;
   const dailyActivity = getOrCreateActivityHelper(
-    Bytes.fromUTF8(ActivityInterval.DAILY)
-      .concat(Bytes.fromUTF8("-"))
-      .concat(Bytes.fromI32(dailyId))
+    ActivityInterval.DAILY.concat("-").concat(dailyId.toString())
   );
 
   // update market prices
   updateAllTokenPrices(event.block.number);
 
   const collateralToken = getOrCreateToken(
-    Address.fromBytes(market.inputToken)
+    Address.fromString(market.inputToken)
   );
   const mimToken = getOrCreateToken(
     Address.fromString(getMIMAddress(dataSource.network()))
@@ -335,7 +331,7 @@ export function handleLiquidation(event: LogRepay): void {
   const CauldronContract = Cauldron.bind(event.address);
   const tokenPriceUSD = collateralToken.lastPriceUSD;
   const collateralAmount = DegenBox.bind(CauldronContract.bentoBox()).toAmount(
-    Address.fromBytes(collateralToken.id),
+    Address.fromString(collateralToken.id),
     liquidateEvent.amount,
     false
   );
@@ -352,8 +348,14 @@ export function handleLiquidation(event: LogRepay): void {
       .lastPriceUSD!
   );
 
-  const liquidateeAccount = getOrCreateAccount(event.params.to, protocol);
-  const liquidatorAccount = getOrCreateAccount(event.params.from, protocol);
+  const liquidateeAccount = getOrCreateAccount(
+    event.params.to.toHexString(),
+    protocol
+  );
+  const liquidatorAccount = getOrCreateAccount(
+    event.params.from.toHexString(),
+    protocol
+  );
 
   liquidateEvent.hash = event.transaction.hash.toHexString();
   liquidateEvent.nonce = event.transaction.nonce;
@@ -369,8 +371,8 @@ export function handleLiquidation(event: LogRepay): void {
   liquidateEvent.profitUSD = collateralAmountUSD.minus(mimAmountUSD);
   liquidateEvent.position = getLiquidatePosition(
     InterestRateSide.BORROW,
-    Address.fromBytes(market.id),
-    event.params.to
+    market.id,
+    event.params.to.toHexString()
   );
   liquidateEvent.save();
 
@@ -409,7 +411,7 @@ export function handleLiquidation(event: LogRepay): void {
   protocol.save();
 
   takeProtocolSnapshots(event);
-  takeMarketSnapshots(Address.fromBytes(market.id), event);
+  takeMarketSnapshots(market.id, event);
 }
 
 export function handleLogRepay(event: LogRepay): void {
@@ -429,11 +431,11 @@ export function handleLogRepay(event: LogRepay): void {
   updateAllTokenPrices(event.block.number);
 
   const repayEvent = new Repay(
-    event.transaction.hash
-      .concat(Bytes.fromUTF8("-"))
-      .concat(Bytes.fromI32(event.transactionLogIndex.toI32()))
+    event.transaction.hash.toHexString() +
+      "-" +
+      event.transactionLogIndex.toString()
   );
-  const market = getMarket(event.address);
+  const market = getMarket(event.address.toHexString());
   if (!market) {
     return;
   }
@@ -447,7 +449,7 @@ export function handleLogRepay(event: LogRepay): void {
   ).times(mimPriceUSD!);
 
   const protocol = getOrCreateLendingProtocol();
-  const account = getOrCreateAccount(event.params.to, protocol);
+  const account = getOrCreateAccount(event.params.to.toHexString(), protocol);
 
   repayEvent.hash = event.transaction.hash.toHexString();
   repayEvent.nonce = event.transaction.nonce;
@@ -474,31 +476,31 @@ export function handleLogRepay(event: LogRepay): void {
   updateBorrowAmount(market);
   updateTotalBorrows(event);
   updateMarketStats(
-    Address.fromBytes(market.id),
+    market.id,
     EventType.REPAY,
-    Address.fromString(getMIMAddress(dataSource.network())),
+    getMIMAddress(dataSource.network()),
     event.params.part,
     event
   ); // smart contract code subs event.params.part from totalBorrow
   updateUsageMetrics(event, event.params.from, event.params.to);
   takeProtocolSnapshots(event);
-  takeMarketSnapshots(Address.fromBytes(market.id), event);
+  takeMarketSnapshots(market.id, event);
 }
 
 export function handleLogExchangeRate(event: LogExchangeRate): void {
-  const market = getMarket(event.address);
+  const market = getMarket(event.address.toHexString());
   if (!market) {
     return;
   }
-  const token = getOrCreateToken(Address.fromBytes(market.inputToken));
+  const token = getOrCreateToken(Address.fromString(market.inputToken));
   updateTokenPrice(event.params.rate, token, market, event.block.number);
   updateTVL(event);
   takeProtocolSnapshots(event);
-  takeMarketSnapshots(Address.fromBytes(market.id), event);
+  takeMarketSnapshots(market.id, event);
 }
 
 export function handleLogAccrue(event: LogAccrue): void {
-  const marketID = event.address;
+  const marketID = event.address.toHexString();
   const mimPriceUSD = getOrCreateToken(
     Address.fromString(getMIMAddress(dataSource.network()))
   ).lastPriceUSD;
@@ -506,7 +508,7 @@ export function handleLogAccrue(event: LogAccrue): void {
     event.params.accruedAmount,
     DEFAULT_DECIMALS
   ).times(mimPriceUSD!);
-  updateFinancials(feesUSD, marketID);
+  updateFinancials(event, feesUSD, marketID);
   takeProtocolSnapshots(event);
   takeMarketSnapshots(marketID, event);
 }
@@ -516,16 +518,16 @@ export function handleLogAccrue(event: LogAccrue): void {
 function updateAllTokenPrices(blockNumber: BigInt): void {
   const protocol = getOrCreateLendingProtocol();
   for (let i = 0; i < protocol.marketIDList.length; i++) {
-    const market = getMarket(Address.fromBytes(protocol.marketIDList[i]));
+    const market = getMarket(protocol.marketIDList[i]);
     if (!market) {
       log.warning("[updateAllTokenPrices] Market not found: {}", [
-        protocol.marketIDList[i].toHexString(),
+        protocol.marketIDList[i],
       ]);
       continue;
     }
 
     // check if price was already updated this block
-    const inputToken = getOrCreateToken(Address.fromBytes(market.inputToken));
+    const inputToken = getOrCreateToken(Address.fromString(market.inputToken));
     if (
       inputToken.lastPriceBlockNumber &&
       inputToken.lastPriceBlockNumber!.ge(blockNumber)
@@ -536,7 +538,7 @@ function updateAllTokenPrices(blockNumber: BigInt): void {
     // load PriceOracle contract and get peek (real/current) exchange rate
     if (market.priceOracle === null) {
       log.warning("[updateAllTokenPrices] Market {} has no priceOracle", [
-        market.id.toHexString(),
+        market.id,
       ]);
       continue;
     }
@@ -551,7 +553,7 @@ function updateAllTokenPrices(blockNumber: BigInt): void {
     if (exchangeRateCall.reverted || exchangeRateCall.value == BIGINT_ZERO) {
       log.warning(
         "[updateAllTokenPrices] Market {} priceOracle peekSpot() failed",
-        [market.id.toHexString()]
+        [market.id]
       );
       continue;
     }


### PR DESCRIPTION
- Huge arrays in `abracadabra-money-avalanche` deployment causing issues for other subgraphs in the shard.
- As a [suggested storage optimization](https://docs.google.com/document/d/1xJif1OtgQl0hEEjtK1D71b7eGII_J0CT4Ibqj3RzfR8/edit), we looked to convert large arrays (length>50) as `@derivedFrom` mappings, but on querying it looks like the larger arrays already follow this convention, others do not need to due to very small length. [Reference query](https://api.thegraph.com/subgraphs/id/QmUjj4BbyeAEeBxFtgZeG7e4akyU29Y7fwe4utPN8qYNWX/graphql?query=%7B%0A++lendingProtocols%7B%0A++++mintedTokens%7Bid%7D%0A++++mintedTokenSupplies%0A++++marketIDList%0A++++%0A++++%23%23%23+derived%0A++++%23+dailyUsageMetrics%7Bid%7D%0A++++%23+hourlyUsageMetrics%7Bid%7D%0A++++%23+financialMetrics%7Bid%7D%0A++++%23+markets%7Bid%7D%0A++%7D%0A++financialsDailySnapshots%28first%3A1%2C+orderBy%3AblockNumber%2C+orderDirection%3Adesc%29%7B%0A++++mintedTokenSupplies%0A++%7D%0A++markets%7B%0A++++rewardTokens%7Bid%7D%0A++++rates%7Bid%7D%0A++++rewardTokenEmissionsAmount%0A++++rewardTokenEmissionsUSD%0A++++%0A++++%23+%23%23%23+derived%0A++++%23+positions%7Bid%7D%0A++++%23+dailySnapshots%7Bid%7D%0A++++%23+hourlySnapshots%7Bid%7D%0A++++%23+deposits%7Bid%7D%0A++++%23+withdraws%7Bid%7D%0A++++%23+borrows%7Bid%7D%0A++++%23+repays%7Bid%7D%0A++++%23+liquidates%7Bid%7D%0A++%7D%0A++marketDailySnapshots%28first%3A1%2C+orderBy%3AblockNumber%2C+orderDirection%3Adesc%29%7B%0A++++rates%7Bid%7D%0A++++rewardTokenEmissionsAmount%0A++++rewardTokenEmissionsUSD%0A++%7D%0A++marketHourlySnapshots%28first%3A1%2C+orderBy%3AblockNumber%2C+orderDirection%3Adesc%29%7B%0A++++rates%7Bid%7D%0A++++rewardTokenEmissionsAmount%0A++++rewardTokenEmissionsUSD%0A++%7D%0A++%23+accounts%7B%0A++%23+%09%23%23%23+derived%0A++%23+++positions%7Bid%7D%0A++%23+++deposits%7Bid%7D%0A++%23+++withdraws%7Bid%7D%0A++%23+++borrows%7Bid%7D%0A++%23+++repays%7Bid%7D%0A++%23+++liquidates%7Bid%7D%0A++%23+++liquidations%7Bid%7D%0A++%23+%7D%0A++%23+positions%7B%0A++%23+++%23%23%23+derived%0A++%23+++deposits%7Bid%7D%0A++%23+++withdraws%7Bid%7D%0A++%23+++borrows%7Bid%7D%0A++%23+++repays%7Bid%7D%0A++%23+++liquidations%7Bid%7D%0A++%23+++snapshots%7Bid%7D%0A++%23+%7D%0A%7D); [schema](https://github.com/messari/subgraphs/blob/master/subgraphs/abracadabra/schema.graphql).
- Since most of these large arrays are snapshots and events, we could further make these entities immutable.
- ~~Changed ID fields from strings to Bytes.~~
- Test deployment: https://okgraph.xyz/?q=dhruv-chauhan%2Fabracadabra-money-avalanche