### PR TITLE
fix(#patch); pancakeswap-v2-swap-bsc; add broken ERC20 tokens

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -5552,7 +5552,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.2",
-          "subgraph": "1.1.0",
+          "subgraph": "1.1.1",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.json
+++ b/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.json
@@ -6,6 +6,6 @@
     "startBlock": 6809737
   },
   "graftEnabled": false,
-  "subgraphId": "",
-  "graftStartBlock": 0
+  "subgraphId": "QmW18hJ4KCnfH3DHnZ8NH4sjh2qFmzW7paMLbhimCALHmf",
+  "graftStartBlock": 28431787
 }

--- a/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.ts
+++ b/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.ts
@@ -33,6 +33,6 @@ export class PancakeswapV2BscConfigurations implements Configurations {
     return "0xca143ce32fe78f1f7019d7d551a6402fc5350c73";
   }
   getBrokenERC20Tokens(): string[] {
-    return [];
+    return ["0xfbbd78a1bf76e43d5fc8f1f880f72718040acbe5"];
   }
 }

--- a/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.ts
+++ b/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.ts
@@ -33,6 +33,9 @@ export class PancakeswapV2BscConfigurations implements Configurations {
     return "0xca143ce32fe78f1f7019d7d551a6402fc5350c73";
   }
   getBrokenERC20Tokens(): string[] {
-    return ["0xfbbd78a1bf76e43d5fc8f1f880f72718040acbe5"];
+    return [
+      "0xfbbd78a1bf76e43d5fc8f1f880f72718040acbe5", // 1
+      "0x14111b627d35d3d54505247b4ef1a0754eb02eb7", // ZGLDao
+    ];
   }
 }

--- a/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.ts
+++ b/subgraphs/uniswap-forks-swap/protocols/pancakeswap-v2-swap/config/deployments/pancakeswap-v2-swap-bsc/configurations.ts
@@ -36,6 +36,7 @@ export class PancakeswapV2BscConfigurations implements Configurations {
     return [
       "0xfbbd78a1bf76e43d5fc8f1f880f72718040acbe5", // 1
       "0x14111b627d35d3d54505247b4ef1a0754eb02eb7", // ZGLDao
+      "0x5285d9d9f784bce2aa7b82cf318d632d423c1047", // Magic
     ];
   }
 }


### PR DESCRIPTION
- Issues: 
  - pancakeswap-v2-swap-bsc deployment is failing with messages: 
    - `overflow converting 0xa9f551de0f330654f37bcd89128d8828e4f820f000 to i32` inside `getOrCreateToken()` method. 
  This is due to [token](https://bscscan.com/address/0xFBBd78a1Bf76E43D5FC8f1f880F72718040ACbE5#readContract) with it's decimals = `1370893090329243333764287979126883543363385161129` which overflows i32 when trying to bind the token to an ERC20 abi.
    - `overflow converting 0x000064a7b3b6e00d to i32`, due to unverified [token](https://bscscan.com/address/0x5285d9d9f784bce2aA7b82CF318D632d423C1047#code) contract.
  - Another similar occurance at tx: https://bscscan.com/tx/0x6580a2c83d60ef7794896c4f11a37ecabbc7871d0a98ed1ed1c4346f04f90d5d, due to unverified token contract: https://bscscan.com/address/0x14111b627d35D3d54505247b4ef1a0754eb02eb7#code
- Previously seen: #2341 and #2445 
- Deployments:
  - (grafted) pancakeswap-v2-swap-bsc: https://okgraph.xyz/?q=dhruv-chauhan%2Fpancakeswap-v2-swap-bsc-3