### PR TITLE
fix(#patch); currentHolderCount in erc20 subgraph

### DIFF
--- a/subgraphs/erc20/src/mappings/token.ts
+++ b/subgraphs/erc20/src/mappings/token.ts
@@ -320,20 +320,15 @@ function handleTransferEvent(
     if (isNewAccount(destination)) {
       // It means the receiver is a new holder
       toAddressIsNewHolderNum = BIGINT_ONE;
-    } else {
-      balance = getOrCreateAccountBalance(
-        getOrCreateAccount(destination),
-        token
-      );
-      if (balance.amount == BIGINT_ONE) {
-        // It means the receiver's token balance is 0 before transferal.
-        toBalanceIsZeroNum = BIGINT_ONE;
-      }
+    }
+    balance = getOrCreateAccountBalance(getOrCreateAccount(destination),token);
+    if (balance.amount == BIGINT_ZERO) {
+      // It means the receiver's token balance is 0 before transferal.
+      toBalanceIsZeroNum = BIGINT_ONE;
     }
 
     token.currentHolderCount = token.currentHolderCount
       .minus(FromBalanceToZeroNum)
-      .plus(toAddressIsNewHolderNum)
       .plus(toBalanceIsZeroNum);
     token.cumulativeHolderCount = token.cumulativeHolderCount.plus(
       toAddressIsNewHolderNum
@@ -343,7 +338,6 @@ function handleTransferEvent(
     let dailySnapshot = getOrCreateTokenDailySnapshot(token, event.block);
     dailySnapshot.currentHolderCount = dailySnapshot.currentHolderCount
       .minus(FromBalanceToZeroNum)
-      .plus(toAddressIsNewHolderNum)
       .plus(toBalanceIsZeroNum);
     dailySnapshot.cumulativeHolderCount =
       dailySnapshot.cumulativeHolderCount.plus(toAddressIsNewHolderNum);
@@ -357,7 +351,6 @@ function handleTransferEvent(
     let hourlySnapshot = getOrCreateTokenHourlySnapshot(token, event.block);
     hourlySnapshot.currentHolderCount = hourlySnapshot.currentHolderCount
       .minus(FromBalanceToZeroNum)
-      .plus(toAddressIsNewHolderNum)
       .plus(toBalanceIsZeroNum);
     hourlySnapshot.cumulativeHolderCount =
       hourlySnapshot.cumulativeHolderCount.plus(toAddressIsNewHolderNum);

--- a/subgraphs/erc20/src/mappings/token.ts
+++ b/subgraphs/erc20/src/mappings/token.ts
@@ -321,7 +321,7 @@ function handleTransferEvent(
       // It means the receiver is a new holder
       toAddressIsNewHolderNum = BIGINT_ONE;
     }
-    balance = getOrCreateAccountBalance(getOrCreateAccount(destination),token);
+    balance = getOrCreateAccountBalance(getOrCreateAccount(destination), token);
     if (balance.amount == BIGINT_ZERO) {
       // It means the receiver's token balance is 0 before transferal.
       toBalanceIsZeroNum = BIGINT_ONE;


### PR DESCRIPTION
@nemani @dhruv-chauhan @melotik 

Fix: `currentHolderCount` value turns negative for some tokens.

Eg. arbitrum (0x9e20461bc2c4c980f62f1B279D71734207a6A356)

Before fix:
<img width="1470" alt="Screenshot 2024-01-20 at 8 13 50 PM" src="https://github.com/messari/subgraphs/assets/42722188/609eef95-ffcc-40ef-b544-d80c5493f630">

After fix:
<img width="1470" alt="Screenshot 2024-01-20 at 9 00 18 PM" src="https://github.com/messari/subgraphs/assets/42722188/5e7e1dcf-dc5f-4468-a857-ca81dfde1294">

