### PR TITLE
fix(#patch); goldfinch; failing assert on burned PoolToken

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2638,7 +2638,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.0.1",
-          "subgraph": "1.4.2",
+          "subgraph": "1.4.3",
           "methodology": "1.0.1"
         },
         "files": {

--- a/subgraphs/goldfinch/protocols/goldfinch/config/deployments/goldfinch-ethereum/configurations.json
+++ b/subgraphs/goldfinch/protocols/goldfinch/config/deployments/goldfinch-ethereum/configurations.json
@@ -1,5 +1,5 @@
 {
-  "graftEnabled": true,
-  "subgraphId": "QmXvJdFRqsshkWBBnNxWA8FbK5S5ymBqCKx5HERtVX83kc",
-  "graftStartBlock": 18039280
+  "graftEnabled": false,
+  "subgraphId": "QmXqV9qTKftqeMFsJqkjXXR3hipAjHxNqFb79ta5qyrhJw",
+  "graftStartBlock": 18816052
 }

--- a/subgraphs/goldfinch/src/entities/tranched_pool.ts
+++ b/subgraphs/goldfinch/src/entities/tranched_pool.ts
@@ -602,7 +602,10 @@ export function updatePoolRewardsClaimable(
   );
   const poolTokenIds = tranchedPool.tokens;
   for (let i = 0; i < poolTokenIds.length; i++) {
-    const poolToken = assert(PoolToken.load(poolTokenIds[i]));
+    const poolToken = PoolToken.load(poolTokenIds[i]);
+    if (!poolToken) {
+      continue;
+    }
     poolToken.rewardsClaimable =
       backerRewardsContract.poolTokenClaimableRewards(
         BigInt.fromString(poolToken.id)
@@ -624,7 +627,10 @@ export function updatePoolTokensRedeemable(tranchedPool: TranchedPool): void {
   );
   const poolTokenIds = tranchedPool.tokens;
   for (let i = 0; i < poolTokenIds.length; i++) {
-    const poolToken = assert(PoolToken.load(poolTokenIds[i]));
+    const poolToken = PoolToken.load(poolTokenIds[i]);
+    if (!poolToken) {
+      continue;
+    }
     const availableToWithdrawResult =
       tranchedPoolContract.try_availableToWithdraw(
         BigInt.fromString(poolToken.id)


### PR DESCRIPTION
- Issue: `assert(PoolToken.load(poolTokenIds[i]))` fails since some PoolToken was removed from store [here](https://github.com/messari/subgraphs/blob/master/subgraphs/goldfinch/src/mappings/pool_tokens.ts#L25) on `TokenBurned`. `tranchedPool.tokens` stores reference to PoolToken. Iterating over this array in code still shows the removed token Id.
- Previously seen: https://github.com/messari/subgraphs/pull/2369
- Deployment: https://okgraph.xyz/?q=dhruv-chauhan%2Fgoldfinch-ethereum