### PR TITLE
fix(#patch); uniswap-v3; failed deployment for tokens with unverified ABI

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3868,7 +3868,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.1",
-          "subgraph": "1.5.1",
+          "subgraph": "1.5.2",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3990,7 +3990,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.1",
-          "subgraph": "1.5.1",
+          "subgraph": "1.5.2",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4016,7 +4016,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.1",
-          "subgraph": "1.5.1",
+          "subgraph": "1.5.2",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4372,7 +4372,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.0",
-          "subgraph": "1.0.1",
+          "subgraph": "1.0.2",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-v3-forks-swap/protocols/uniswap-v3-swap/config/deployments/uniswap-v3-swap-optimism/configurations.json
+++ b/subgraphs/uniswap-v3-forks-swap/protocols/uniswap-v3-swap/config/deployments/uniswap-v3-swap-optimism/configurations.json
@@ -6,6 +6,6 @@
   "nonFungiblePositionManagerAddressStartBlock": 0,
   "deployment": "UNISWAP_V3_OPTIMISM",
   "graftEnabled": false,
-  "subgraphId": "",
-  "graftStartBlock": 0
+  "subgraphId": "QmbeFnzYbtGagCVpHUvKK81gKfDA9PY9sfZkeyYyjJoNZg",
+  "graftStartBlock": 115331325
 }

--- a/subgraphs/uniswap-v3-forks-swap/protocols/uniswap-v3-swap/config/deployments/uniswap-v3-swap-optimism/configurations.ts
+++ b/subgraphs/uniswap-v3-forks-swap/protocols/uniswap-v3-swap/config/deployments/uniswap-v3-swap-optimism/configurations.ts
@@ -89,6 +89,10 @@ export class UniswapV3OptimismConfigurations implements Configurations {
     return BigDecimal.fromString("100000");
   }
   getBrokenERC20Tokens(): Bytes[] {
-    return stringToBytesList(["0x000000000000be0ab658f92dddac29d6df19a3be"]);
+    return stringToBytesList([
+      "0x000000000000be0ab658f92dddac29d6df19a3be",
+      "0x000000000000b91b6956fead1dda24c66aa6b972",
+      "0x0000000000e586517bccb5ec52e70119299d2c9c",
+    ]);
   }
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.json
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.json
@@ -6,6 +6,6 @@
   "nonFungiblePositionManagerAddressStartBlock": 172,
   "deployment": "UNISWAP_V3_ARBITRUM",
   "graftEnabled": false,
-  "subgraphId": "QmTftg7pdUQ21m2RSmYxXYmhUqYtsvD1QNMJFUJWWANxFm",
-  "graftStartBlock": 50045501
+  "subgraphId": "QmNNZNoaL5Wgafgcsqiyzivp6a1s3fYzwFUUK7oHZ3bCfQ",
+  "graftStartBlock": 174340924
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.ts
@@ -92,6 +92,9 @@ export class UniswapV3ArbitrumConfigurations implements Configurations {
     return BigDecimal.fromString("100000");
   }
   getBrokenERC20Tokens(): Bytes[] {
-    return stringToBytesList([]);
+    return stringToBytesList([
+      "0x000000000000b91b6956fead1dda24c66aa6b972",
+      "0x0000000000e586517bccb5ec52e70119299d2c9c",
+    ]);
   }
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-optimism/configurations.json
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-optimism/configurations.json
@@ -6,6 +6,6 @@
   "nonFungiblePositionManagerAddressStartBlock": 0,
   "deployment": "UNISWAP_V3_OPTIMISM",
   "graftEnabled": false,
-  "subgraphId": "QmUsSW7yQjJNBekt3JobbwdCvXTA2Mj56sLFpUz5GvYp3M",
-  "graftStartBlock": 5340706
+  "subgraphId": "QmaiNqUk1diAk6bkU4dFqEAee1dJFZyC9z35H8jJTPXkxa",
+  "graftStartBlock": 115331325
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-optimism/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-optimism/configurations.ts
@@ -89,6 +89,10 @@ export class UniswapV3OptimismConfigurations implements Configurations {
     return BigDecimal.fromString("100000");
   }
   getBrokenERC20Tokens(): Bytes[] {
-    return stringToBytesList(["0x000000000000be0ab658f92dddac29d6df19a3be"]);
+    return stringToBytesList([
+      "0x000000000000be0ab658f92dddac29d6df19a3be",
+      "0x000000000000b91b6956fead1dda24c66aa6b972",
+      "0x0000000000e586517bccb5ec52e70119299d2c9c",
+    ]);
   }
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-polygon/configurations.json
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-polygon/configurations.json
@@ -6,6 +6,6 @@
   "nonFungiblePositionManagerAddressStartBlock": 14582231,
   "deployment": "UNISWAP_V3_POLYGON",
   "graftEnabled": false,
-  "subgraphId": "QmbQ249g9w4Bhv2rcyvCtaMdFx2ESuYWUP4Tp4zx6QJwar",
-  "graftStartBlock": 32674299
+  "subgraphId": "Qmdri6LtxNJ4EmsQyJNHumEL23ynoVZ9DSgjfiFijUBsnm",
+  "graftStartBlock": 52770143
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-polygon/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-polygon/configurations.ts
@@ -93,6 +93,9 @@ export class UniswapV3MaticConfigurations implements Configurations {
     return BigDecimal.fromString("100000");
   }
   getBrokenERC20Tokens(): Bytes[] {
-    return stringToBytesList([]);
+    return stringToBytesList([
+      "0x000000000000b91b6956fead1dda24c66aa6b972",
+      "0x0000000000e586517bccb5ec52e70119299d2c9c",
+    ]);
   }
 }


### PR DESCRIPTION
- Issue: uniswap-v3 / uniswap-v3-swap deployments are failing with message: `overflow converting 0x... to i32` inside `getOrCreateToken()` method.
- This is due to tokens with unverified ABIs
  - Arbitrum: [token](https://arbiscan.io/address/0x000000000000b91b6956fead1dda24c66aa6b972) and [token](https://arbiscan.io/address/0x0000000000e586517bccb5ec52e70119299d2c9c)
  - Polygon: [token](https://polygonscan.com/address/0x000000000000b91b6956fead1dda24c66aa6b972) and [token](https://polygonscan.com/address/0x0000000000e586517bccb5ec52e70119299d2c9c)
  - Optimism: [token](https://optimistic.etherscan.io/address/0x000000000000b91b6956fead1dda24c66aa6b972) and [token](https://optimistic.etherscan.io/address/0x0000000000e586517bccb5ec52e70119299d2c9c)
- Previously seen: #2341 & #2445 
- Deployments:
  - uniswap-v3-arbitrum: https://okgraph.xyz/?q=dhruv-chauhan%2Funiswap-v3-arbitrum
  - uniswap-v3-polygon: https://okgraph.xyz/?q=dhruv-chauhan%2Funiswap-v3-polygon
  - uniswap-v3-optimism: https://okgraph.xyz/?q=dhruv-chauhan%2Funiswap-v3-optimism
  - uniswap-v3-swap-optimism: https://okgraph.xyz/?q=dhruv-chauhan%2Funiswap-v3-swap-optimism