### PR TITLE
fix(#major); eigenlayer; index completed withdrawals of multiple tokens

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -10124,7 +10124,7 @@
         "status": "prod",
         "versions": {
           "schema": "2.1.1",
-          "subgraph": "1.2.0",
+          "subgraph": "1.3.0",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/eigenlayer/src/common/events.ts
+++ b/subgraphs/eigenlayer/src/common/events.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
 
 import { BIGDECIMAL_ZERO, BIGINT_ZERO, ZERO_ADDRESS } from "./constants";
 import { getOrCreateAccount, getOrCreateToken } from "./getters";
@@ -114,10 +114,6 @@ export function getWithdraw(
     }
   }
 
-  log.warning(
-    "[getWithdraw] queued withdraw transaction not found for depositor: {} and withdrawalRoot: {}",
-    [accountAddress.toHexString(), withdrawalRoot.toHexString()]
-  );
   return null;
 }
 

--- a/subgraphs/eigenlayer/src/mappings/handlers.ts
+++ b/subgraphs/eigenlayer/src/mappings/handlers.ts
@@ -304,101 +304,113 @@ export function handleWithdrawalCompleted(event: WithdrawalCompleted): void {
   const depositorAddress = event.params.depositor;
   const withdrawalRoot = event.params.withdrawalRoot;
 
-  const withdraw = getWithdraw(depositorAddress, withdrawalRoot);
-  if (!withdraw) return;
+  let withdraw = getWithdraw(depositorAddress, withdrawalRoot);
 
-  const withdrawID = withdraw.id;
-  const poolID = withdraw.pool;
-  const tokenID = withdraw.token;
-  const accountID = withdraw.depositor;
+  if (!withdraw) {
+    log.warning(
+      "[getWithdraw] queued withdraw transaction not found for depositor: {} and withdrawalRoot: {}",
+      [depositorAddress.toHexString(), withdrawalRoot.toHexString()]
+    );
 
-  let amount = BIGINT_ZERO;
-  const receipt = event.receipt;
-  if (!receipt) {
-    log.error("[handleWithdrawalCompleted] No event receipt. Tx: {}", [
-      event.transaction.hash.toHexString(),
-    ]);
-    return;
-  }
-  const logs = receipt.logs;
-  if (!logs) {
-    log.error("[handleWithdrawalCompleted] No logs for event receipt. Tx: {}", [
-      event.transaction.hash.toHexString(),
-    ]);
     return;
   }
 
-  for (let i = 0; i < logs.length; i++) {
-    const thisLog = logs.at(i);
-    const logTopicSignature = thisLog.topics.at(INT_ZERO);
+  do {
+    const withdrawID = withdraw!.id;
+    const poolID = withdraw!.pool;
+    const tokenID = withdraw!.token;
+    const accountID = withdraw!.depositor;
 
-    if (logTopicSignature.equals(TRANSFER_SIGNATURE)) {
-      const logTopicFrom = ethereum
-        .decode("address", thisLog.topics.at(INT_ONE))!
-        .toAddress();
+    const receipt = event.receipt;
+    if (!receipt) {
+      log.error("[handleWithdrawalCompleted] No event receipt. Tx: {}", [
+        event.transaction.hash.toHexString(),
+      ]);
+      return;
+    }
+    const logs = receipt.logs;
+    if (!logs) {
+      log.error(
+        "[handleWithdrawalCompleted] No logs for event receipt. Tx: {}",
+        [event.transaction.hash.toHexString()]
+      );
+      return;
+    }
 
-      if (logTopicFrom.equals(Address.fromBytes(poolID))) {
-        const decoded = ethereum.decode(TRANSFER_DATA_TYPE, thisLog.data);
-        if (!decoded) continue;
+    let amount = BIGINT_ZERO;
 
-        const logData = decoded.toTuple();
-        amount = logData[INT_ZERO].toBigInt();
-        break;
+    for (let i = 0; i < logs.length; i++) {
+      const thisLog = logs.at(i);
+      const logTopicSignature = thisLog.topics.at(INT_ZERO);
+
+      if (logTopicSignature.equals(TRANSFER_SIGNATURE)) {
+        const logTopicFrom = ethereum
+          .decode("address", thisLog.topics.at(INT_ONE))!
+          .toAddress();
+
+        if (logTopicFrom.equals(Address.fromBytes(poolID))) {
+          const decoded = ethereum.decode(TRANSFER_DATA_TYPE, thisLog.data);
+          if (!decoded) continue;
+
+          const logData = decoded.toTuple();
+          amount = logData[INT_ZERO].toBigInt();
+          break;
+        }
       }
     }
-  }
 
-  updateUsage(
-    Address.fromBytes(poolID),
-    Address.fromBytes(tokenID),
-    Address.fromBytes(accountID),
-    false,
-    amount,
-    withdrawID,
-    event
-  );
+    updateUsage(
+      Address.fromBytes(poolID),
+      Address.fromBytes(tokenID),
+      Address.fromBytes(accountID),
+      false,
+      amount,
+      withdrawID,
+      event
+    );
 
-  const poolBalance = getPoolBalance(Address.fromBytes(poolID));
+    const poolBalance = getPoolBalance(Address.fromBytes(poolID));
 
-  updateTVL(
-    Address.fromBytes(poolID),
-    Address.fromBytes(tokenID),
-    poolBalance,
-    event
-  );
-  updateVolume(
-    Address.fromBytes(poolID),
-    Address.fromBytes(tokenID),
-    false,
-    amount,
-    event
-  );
-  updatePoolHourlySnapshot(Address.fromBytes(poolID), event);
-  updatePoolDailySnapshot(
-    Address.fromBytes(poolID),
-    Address.fromBytes(tokenID),
-    false,
-    amount,
-    event
-  );
-  updateUsageMetricsHourlySnapshot(Address.fromBytes(accountID), event);
-  updateUsageMetricsDailySnapshot(
-    Address.fromBytes(accountID),
-    false,
-    withdrawID,
-    event
-  );
-  updateFinancialsDailySnapshot(
-    Address.fromBytes(tokenID),
-    false,
-    amount,
-    event
-  );
-  updateWithdraw(
-    Address.fromBytes(accountID),
-    Address.fromBytes(tokenID),
-    withdrawID,
-    amount,
-    event
-  );
+    updateTVL(
+      Address.fromBytes(poolID),
+      Address.fromBytes(tokenID),
+      poolBalance,
+      event
+    );
+    updateVolume(
+      Address.fromBytes(poolID),
+      Address.fromBytes(tokenID),
+      false,
+      amount,
+      event
+    );
+    updatePoolHourlySnapshot(Address.fromBytes(poolID), event);
+    updatePoolDailySnapshot(
+      Address.fromBytes(poolID),
+      Address.fromBytes(tokenID),
+      false,
+      amount,
+      event
+    );
+    updateUsageMetricsHourlySnapshot(Address.fromBytes(accountID), event);
+    updateUsageMetricsDailySnapshot(
+      Address.fromBytes(accountID),
+      false,
+      withdrawID,
+      event
+    );
+    updateFinancialsDailySnapshot(
+      Address.fromBytes(tokenID),
+      false,
+      amount,
+      event
+    );
+    updateWithdraw(
+      Address.fromBytes(accountID),
+      Address.fromBytes(tokenID),
+      withdrawID,
+      amount,
+      event
+    );
+  } while ((withdraw = getWithdraw(depositorAddress, withdrawalRoot)));
 }

--- a/subgraphs/eigenlayer/src/mappings/handlers.ts
+++ b/subgraphs/eigenlayer/src/mappings/handlers.ts
@@ -305,13 +305,11 @@ export function handleWithdrawalCompleted(event: WithdrawalCompleted): void {
   const withdrawalRoot = event.params.withdrawalRoot;
 
   let withdraw = getWithdraw(depositorAddress, withdrawalRoot);
-
   if (!withdraw) {
     log.warning(
-      "[getWithdraw] queued withdraw transaction not found for depositor: {} and withdrawalRoot: {}",
+      "[handleWithdrawalCompleted] queued withdraw transaction not found for depositor: {} and withdrawalRoot: {}",
       [depositorAddress.toHexString(), withdrawalRoot.toHexString()]
     );
-
     return;
   }
 


### PR DESCRIPTION
Fixes #2485

Fix: indexing of withdrawals containing multiple tokens

Before fix [query](https://api.thegraph.com/subgraphs/name/messari/eigenlayer-ethereum/graphql?query=query+MyQuery+%7B++%0A++withdraws%28%0A++++where%3A+%7Bwithdrawer%3A+%220x991c468AbcE2b4DD627a6210C145373EbABdd186%22%2C+nonce%3A+3%7D%0A++%29+%7B%0A++++token+%7B%0A++++++symbol%0A++++%7D%0A++++hash%0A++++nonce%0A++++blockNumber%0A++++completed%0A++++hashCompleted%0A++++blockNumberCompleted%0A++%7D%0A%7D#):
<img width="1786" alt="image" src="https://github.com/messari/subgraphs/assets/51637671/7f1256d3-0807-46ad-a34a-f920a3fbec06">

After fix [query](https://query.thegraph.kiln.fi/subgraphs/name/eigenlayer-test/graphql?query=query+MyQuery+%7B%0A++_meta+%7B%0A++++block+%7B%0A++++++number%0A++++%7D%0A++++deployment%0A++%7D%0A++withdraws%28%0A++++where%3A+%7Bwithdrawer%3A+%220x991c468AbcE2b4DD627a6210C145373EbABdd186%22%2C+nonce%3A+3%7D%0A++%29+%7B%0A++++token+%7B%0A++++++symbol%0A++++%7D%0A++++hash%0A++++nonce%0A++++blockNumber%0A++++completed%0A++++hashCompleted%0A++++blockNumberCompleted%0A++%7D%0A%7D):
<img width="1807" alt="image" src="https://github.com/messari/subgraphs/assets/51637671/738e4b1f-4224-4dc8-a400-55ef967d4ee7">

Test subgraph:
- https://query.thegraph.kiln.fi/subgraphs/name/eigenlayer-test/graphql