### PR TITLE
chore(); bump spookyswap-fantom from dev to prod

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -5171,7 +5171,7 @@
     "deployments": {
       "spookyswap-fantom": {
         "network": "fantom",
-        "status": "dev",
+        "status": "prod",
         "versions": {
           "schema": "1.3.2",
           "subgraph": "1.1.12",


### PR DESCRIPTION
In the internal Messari Subgraph service, we only sync subgraphs marked as "prod" to our internal Snowflake. Bumping spookyswap-fantom to prod to enable this sync.