### PR TITLE
add interest revenue/fix ezETH pricing/add usage on tx signers

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -3381,9 +3381,9 @@
         "network": "ethereum",
         "status": "dev",
         "versions": {
-          "schema": "3.1.0",
-          "subgraph": "1.0.0",
-          "methodology": "1.0.0"
+          "schema": "3.2.0",
+          "subgraph": "1.1.0",
+          "methodology": "1.1.0"
         },
         "files": {
           "template": "morpho.blue.template.yaml"

--- a/subgraphs/morpho-blue/schema.graphql
+++ b/subgraphs/morpho-blue/schema.graphql
@@ -1,5 +1,5 @@
 # Subgraph Schema: Lending Protocol
-# Version: 3.1.0
+# Version: 3.2.0
 # See https://github.com/messari/subgraphs/blob/master/docs/SCHEMA.md for details
 
 enum Network {
@@ -345,6 +345,9 @@ interface Protocol {
   " Number of cumulative unique users. e.g. accounts that spent gas to interact with this protocol "
   cumulativeUniqueUsers: Int!
 
+  " Number of cumulative unique users. e.g. accounts that signed transactions to interact with this market "
+  cumulativeUniqueTxSigners: Int!
+
   " Revenue claimed by suppliers to the protocol. LPs on DEXs (e.g. 0.25% of the swap fee in Sushiswap). Depositors on Lending Protocols. NFT sellers on OpenSea. "
   cumulativeSupplySideRevenueUSD: BigDecimal!
 
@@ -436,6 +439,9 @@ type LendingProtocol implements Protocol @entity @regularPolling {
 
   " Number of cumulative liquidatees (accounts that got liquidated) "
   cumulativeUniqueLiquidatees: Int!
+
+  " Number of cumulative unique users. e.g. accounts that signed transactions to interact with this market "
+  cumulativeUniqueTxSigners: Int!
 
   " Current TVL (Total Value Locked) of the entire protocol "
   totalValueLockedUSD: BigDecimal!
@@ -591,6 +597,12 @@ type UsageMetricsDailySnapshot @entity @dailySnapshot {
   " Number of cumulative liquidatees (accounts that got liquidated) "
   cumulativeUniqueLiquidatees: Int!
 
+  " Number of unique daily active users. e.g. accounts that signed transactions to interact with this protocol "
+  dailyActiveTxSigners: Int!
+
+  " Number of cumulative unique users. e.g. accounts that signed transactions to interact with this market "
+  cumulativeUniqueTxSigners: Int!
+
   " Total number of transactions occurred in a day. Transactions include all entities that implement the Event interface. "
   dailyTransactionCount: Int!
 
@@ -649,6 +661,9 @@ type UsageMetricsHourlySnapshot @entity @hourlySnapshot {
 
   " Number of cumulative unique users. e.g. accounts that spent gas to interact with this protocol "
   cumulativeUniqueUsers: Int!
+
+  " Number of cumulative unique users. e.g. accounts that signed transactions to interact with this market "
+  cumulativeUniqueTxSigners: Int!
 
   " Total number of transactions occurred in an hour. Transactions include all entities that implement the Event interface. "
   hourlyTransactionCount: Int!
@@ -968,6 +983,9 @@ type Market @entity @regularPolling {
   " Number of cumulative accounts that performed flashloans "
   cumulativeUniqueFlashloaners: Int!
 
+  " Number of cumulative unique users. e.g. accounts that signed transactions to interact with this market "
+  cumulativeUniqueTxSigners: Int!
+
   ##### Account/Position Data #####
 
   " All positions in this market "
@@ -1226,6 +1244,9 @@ type MarketDailySnapshot @entity @dailySnapshot {
 
   " Number of unique daily accounts that executed a flash loan"
   dailyActiveFlashloaners: Int!
+
+  " Number of unique daily active users. e.g. accounts that signed transaction to interact with this market "
+  dailyActiveTxSigners: Int!
 
   " Total number of deposits in a day "
   dailyDepositCount: Int!
@@ -1628,6 +1649,12 @@ type PositionSnapshot @entity(immutable: true) @hourlySnapshot {
 
 # Helper entity for calculating daily/hourly active users
 type _ActiveAccount @entity(immutable: true) {
+  " { daily/hourly }-{ Address of the account }-{ Optional: Transaction Type }-{ Optional: Market Address }-{ Optional: Days/hours since Unix epoch } "
+  id: ID!
+}
+
+# Helper entity for calculating daily/hourly active users
+type _TxSigner @entity(immutable: true) {
   " { daily/hourly }-{ Address of the account }-{ Optional: Transaction Type }-{ Optional: Market Address }-{ Optional: Days/hours since Unix epoch } "
   id: ID!
 }

--- a/subgraphs/morpho-blue/src/fetchUsdTokenPrice.ts
+++ b/subgraphs/morpho-blue/src/fetchUsdTokenPrice.ts
@@ -69,6 +69,10 @@ const EURe = Address.fromString(
   "0x3231cb76718cdef2155fc47b5286d82e6eda273f",
 ).toHexString();
 
+const ezETH = Address.fromString(
+  "0xbf5495efe5db9ce00f80364c8b423567e58d2110",
+).toHexString();
+
 const usdPriceFeeds = new Map<string, string>()
   .set(
     wbib01,
@@ -113,12 +117,19 @@ const usdPriceFeeds = new Map<string, string>()
     ).toHexString(),
   );
 
-const ethPriceFeeds = new Map<string, string>().set(
-  osETH,
-  Address.fromString(
-    "0x66ac817f997Efd114EDFcccdce99F3268557B32C",
-  ).toHexString(),
-);
+const ethPriceFeeds = new Map<string, string>()
+  .set(
+    osETH,
+    Address.fromString(
+      "0x66ac817f997Efd114EDFcccdce99F3268557B32C",
+    ).toHexString(),
+  )
+  .set(
+    ezETH,
+    Address.fromString(
+      "0xF4a3e183F59D2599ee3DF213ff78b1B3b1923696",
+    ).toHexString(),
+  );
 
 const eurPriceFeeds = new Map<string, string>().set(
   wbc3m,

--- a/subgraphs/morpho-blue/src/initializers/markets.ts
+++ b/subgraphs/morpho-blue/src/initializers/markets.ts
@@ -108,6 +108,7 @@ export function createMarket(
   market.cumulativeUniqueLiquidatees = INT_ZERO;
   market.cumulativeUniqueTransferrers = INT_ZERO;
   market.cumulativeUniqueFlashloaners = INT_ZERO;
+  market.cumulativeUniqueTxSigners = INT_ZERO;
 
   market.positionCount = INT_ZERO;
   market.openPositionCount = INT_ZERO;

--- a/subgraphs/morpho-blue/src/initializers/protocol.ts
+++ b/subgraphs/morpho-blue/src/initializers/protocol.ts
@@ -48,6 +48,7 @@ function initBlue(): LendingProtocol {
   protocol.cumulativeUniqueBorrowers = INT_ZERO;
   protocol.cumulativeUniqueLiquidators = INT_ZERO;
   protocol.cumulativeUniqueLiquidatees = INT_ZERO;
+  protocol.cumulativeUniqueTxSigners = INT_ZERO;
 
   protocol.totalValueLockedUSD = BigDecimal.zero();
   protocol.cumulativeSupplySideRevenueUSD = BigDecimal.zero();

--- a/subgraphs/morpho-blue/src/sdk/constants.ts
+++ b/subgraphs/morpho-blue/src/sdk/constants.ts
@@ -1,6 +1,6 @@
 import { BigDecimal, BigInt, Bytes } from "@graphprotocol/graph-ts";
 
-import { _ActiveAccount } from "../../generated/schema";
+import { _ActiveAccount, _TxSigner } from "../../generated/schema";
 
 ////////////////////////
 ///// Schema Enums /////
@@ -177,7 +177,7 @@ export const BIGDECIMAL_ONE = new BigDecimal(BIGINT_ONE);
 export const BIGDECIMAL_HUNDRED = new BigDecimal(BigInt.fromI32(100));
 
 export const BIGDECIMAL_WAD = new BigDecimal(
-  BigInt.fromString("1000000000000000000"),
+  BigInt.fromString("1000000000000000000")
 );
 
 /////////////////////
@@ -220,7 +220,7 @@ export function bigDecimalToBigInt(x: BigDecimal): BigInt {
 export function BDChangeDecimals(
   x: BigDecimal,
   from: i32,
-  to: i32,
+  to: i32
 ): BigDecimal {
   if (to > from) {
     // increase number of decimals
@@ -239,7 +239,7 @@ export function BDChangeDecimals(
 export function insert<Type>(
   arr: Array<Type>,
   value: Type,
-  index: i32 = -1,
+  index: i32 = -1
 ): Array<Type> {
   if (arr.length == 0) {
     return [value];
@@ -265,7 +265,7 @@ export function activityCounter(
   transactionType: string,
   useTransactionType: boolean,
   intervalID: i32, // 0 = no intervalID
-  marketID: Bytes | null = null,
+  marketID: Bytes | null = null
 ): i32 {
   let activityID = account
     .toHexString()
@@ -290,5 +290,23 @@ export function activityCounter(
     return INT_ONE;
   }
 
+  return INT_ZERO;
+}
+
+export function txSignerCounter(
+  signer: Bytes,
+  intervalID: i32,
+  marketID: Bytes | null = null
+): i32 {
+  let id = signer.concat(Bytes.fromUTF8("-")).concat(Bytes.fromI32(intervalID));
+  if (marketID) id = id.concat(Bytes.fromUTF8("-")).concat(marketID);
+
+  let txSigner = _TxSigner.load(id.toHexString());
+  if (!txSigner) {
+    txSigner = new _TxSigner(id.toHexString());
+    txSigner.save();
+
+    return INT_ONE;
+  }
   return INT_ZERO;
 }


### PR DESCRIPTION
- Changes:
  - Adds interest based revenues for markets and protocol
  - Adds pricefeed for ezETH, fixing market: `0x49bb2d114be9041a787432952927f6f144f05ad3e83196a7d062f374ee11d0ee`'s TVL
  - Adds usage based on tx signers
- Deployment: https://okgraph.xyz/?q=dhruv-chauhan%2Fmorpho-blue-ethereum