### PR TITLE
fix(#patch); uniswap-v3; indexing error due to token with unverified ABI

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -4048,7 +4048,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.1",
-          "subgraph": "1.5.2",
+          "subgraph": "1.5.3",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4100,7 +4100,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.1",
-          "subgraph": "1.5.1",
+          "subgraph": "1.5.2",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4152,7 +4152,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.0",
-          "subgraph": "1.6.1",
+          "subgraph": "1.6.2",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4178,7 +4178,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.1",
-          "subgraph": "1.5.2",
+          "subgraph": "1.5.3",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4204,7 +4204,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.1",
-          "subgraph": "1.5.2",
+          "subgraph": "1.5.3",
           "methodology": "1.0.0"
         },
         "files": {
@@ -4564,7 +4564,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.0",
-          "subgraph": "1.0.2",
+          "subgraph": "1.0.3",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-v3-forks-swap/protocols/uniswap-v3-swap/config/deployments/uniswap-v3-swap-optimism/configurations.json
+++ b/subgraphs/uniswap-v3-forks-swap/protocols/uniswap-v3-swap/config/deployments/uniswap-v3-swap-optimism/configurations.json
@@ -6,6 +6,6 @@
   "nonFungiblePositionManagerAddressStartBlock": 0,
   "deployment": "UNISWAP_V3_OPTIMISM",
   "graftEnabled": false,
-  "subgraphId": "QmbeFnzYbtGagCVpHUvKK81gKfDA9PY9sfZkeyYyjJoNZg",
-  "graftStartBlock": 115331325
+  "subgraphId": "Qmb7svNQjNGiQwEGDfgPCykc1ZA7755xuCVngPEogPndmA",
+  "graftStartBlock": 117657499
 }

--- a/subgraphs/uniswap-v3-forks-swap/protocols/uniswap-v3-swap/config/deployments/uniswap-v3-swap-optimism/configurations.ts
+++ b/subgraphs/uniswap-v3-forks-swap/protocols/uniswap-v3-swap/config/deployments/uniswap-v3-swap-optimism/configurations.ts
@@ -93,6 +93,7 @@ export class UniswapV3OptimismConfigurations implements Configurations {
       "0x000000000000be0ab658f92dddac29d6df19a3be",
       "0x000000000000b91b6956fead1dda24c66aa6b972",
       "0x0000000000e586517bccb5ec52e70119299d2c9c",
+      "0x0000000000958ec6667eb97e2f64f6909073e6b7",
     ]);
   }
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.json
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.json
@@ -6,6 +6,6 @@
   "nonFungiblePositionManagerAddressStartBlock": 172,
   "deployment": "UNISWAP_V3_ARBITRUM",
   "graftEnabled": false,
-  "subgraphId": "QmNNZNoaL5Wgafgcsqiyzivp6a1s3fYzwFUUK7oHZ3bCfQ",
-  "graftStartBlock": 174340924
+  "subgraphId": "QmWQubpffSaCZ8CAG6x9Luwzgoq8xzJg4bkkisBsemiKxq",
+  "graftStartBlock": 192237169
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-arbitrum/configurations.ts
@@ -95,6 +95,7 @@ export class UniswapV3ArbitrumConfigurations implements Configurations {
     return stringToBytesList([
       "0x000000000000b91b6956fead1dda24c66aa6b972",
       "0x0000000000e586517bccb5ec52e70119299d2c9c",
+      "0x0000000000958ec6667eb97e2f64f6909073e6b7",
     ]);
   }
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-bsc/configurations.json
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-bsc/configurations.json
@@ -6,6 +6,6 @@
   "nonFungiblePositionManagerAddressStartBlock": 26324045,
   "deployment": "UNISWAP_V3_BSC",
   "graftEnabled": false,
-  "subgraphId": "QmTftg7pdUQ21m2RSmYxXYmhUqYtsvD1QNMJFUJWWANxFm",
-  "graftStartBlock": 50045501
+  "subgraphId": "Qmc1CDP1vMCQerhgbbXE2PVLwcEdVGgq9JEgz9VtyWzoZ1",
+  "graftStartBlock": 37126348
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-bsc/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-bsc/configurations.ts
@@ -90,6 +90,6 @@ export class UniswapV3BSCConfigurations implements Configurations {
     return BigDecimal.fromString("25000");
   }
   getBrokenERC20Tokens(): Bytes[] {
-    return stringToBytesList([]);
+    return stringToBytesList(["0x0000000000958ec6667eb97e2f64f6909073e6b7"]);
   }
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-ethereum/configurations.json
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-ethereum/configurations.json
@@ -6,6 +6,6 @@
   "nonFungiblePositionManagerAddressStartBlock": 12369650,
   "deployment": "UNISWAP_V3_ETHEREUM",
   "graftEnabled": false,
-  "subgraphId": "QmQq7Rud6cDbQjMser5N1xNaKcPv4AiDmXBNnqrNPgPVHm",
-  "graftStartBlock": 17127000
+  "subgraphId": "QmQAAtYdKrwQeQWQdM71U5vSDCrTHzNRCfbZUGE7huCw7G",
+  "graftStartBlock": 19473884
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-ethereum/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-ethereum/configurations.ts
@@ -105,6 +105,6 @@ export class UniswapV3MainnetConfigurations implements Configurations {
     return BigDecimal.fromString("200000");
   }
   getBrokenERC20Tokens(): Bytes[] {
-    return stringToBytesList([]);
+    return stringToBytesList(["0x0000000000958ec6667eb97e2f64f6909073e6b7"]);
   }
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-optimism/configurations.json
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-optimism/configurations.json
@@ -6,6 +6,6 @@
   "nonFungiblePositionManagerAddressStartBlock": 0,
   "deployment": "UNISWAP_V3_OPTIMISM",
   "graftEnabled": false,
-  "subgraphId": "QmaiNqUk1diAk6bkU4dFqEAee1dJFZyC9z35H8jJTPXkxa",
-  "graftStartBlock": 115331325
+  "subgraphId": "Qmb7svNQjNGiQwEGDfgPCykc1ZA7755xuCVngPEogPndmA",
+  "graftStartBlock": 117657499
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-optimism/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-optimism/configurations.ts
@@ -93,6 +93,7 @@ export class UniswapV3OptimismConfigurations implements Configurations {
       "0x000000000000be0ab658f92dddac29d6df19a3be",
       "0x000000000000b91b6956fead1dda24c66aa6b972",
       "0x0000000000e586517bccb5ec52e70119299d2c9c",
+      "0x0000000000958ec6667eb97e2f64f6909073e6b7",
     ]);
   }
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-polygon/configurations.json
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-polygon/configurations.json
@@ -6,6 +6,6 @@
   "nonFungiblePositionManagerAddressStartBlock": 14582231,
   "deployment": "UNISWAP_V3_POLYGON",
   "graftEnabled": false,
-  "subgraphId": "Qmdri6LtxNJ4EmsQyJNHumEL23ynoVZ9DSgjfiFijUBsnm",
-  "graftStartBlock": 52770143
+  "subgraphId": "QmcvpxzFtg5qnDB9EsMAT4vACzfpuXrpBg5DMVAcwUxvEK",
+  "graftStartBlock": 54868189
 }

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-polygon/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-polygon/configurations.ts
@@ -96,6 +96,7 @@ export class UniswapV3MaticConfigurations implements Configurations {
     return stringToBytesList([
       "0x000000000000b91b6956fead1dda24c66aa6b972",
       "0x0000000000e586517bccb5ec52e70119299d2c9c",
+      "0x0000000000958ec6667eb97e2f64f6909073e6b7",
     ]);
   }
 }


### PR DESCRIPTION
- Issue: uniswap-v3 / uniswap-v3-swap deployments are failing with message: `overflow converting 0x... to i32` inside `getOrCreateToken()` method due to bad decimal value returned. The ABI for the token contract is unverified.
- Previously seen: #2470, #2341 & #2445 
- Deployed to Messari hosted service, will take some considerable time to graft:
  - uniswap-v3-arbitrum: https://okgraph.xyz/?q=messari%2Funiswap-v3-arbitrum
  - uniswap-v3-bsc: https://okgraph.xyz/?q=messari%2Funiswap-v3-bsc
  - uniswap-v3-ethereum: https://okgraph.xyz/?q=messari%2Funiswap-v3-ethereum
  - uniswap-v3-optimism: https://okgraph.xyz/?q=messari%2Funiswap-v3-optimism
  - uniswap-v3-polygon: https://okgraph.xyz/?q=messari%2Funiswap-v3-polygon
  - uniswap-v3-swap-optimism: https://okgraph.xyz/?q=messari%2Funiswap-v3-swap-optimism