### PR TITLE
[DAT-2579]; Uniswap V3 Base; Blacklist Some Tokens To Fix TVL

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -4074,7 +4074,7 @@
         "status": "prod",
         "versions": {
           "schema": "4.0.1",
-          "subgraph": "1.0.1",
+          "subgraph": "1.0.2",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-base/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-base/configurations.ts
@@ -77,7 +77,13 @@ export class UniswapV3BaseConfigurations implements Configurations {
     return stringToBytesList([]);
   }
   getUntrackedTokens(): Bytes[] {
-    return stringToBytesList([]);
+    return stringToBytesList([
+      '0x391ef60db8e7677c32d2c547ea1a009159558419', // Penguin
+      '0x6eeb5859e32225cb61434dca63bca84bb0e735a7', // Magic Internet Memes
+      '0x0d3031225f4471eafdb1707db807cbb00eb561cc', // Floating Point
+      '0x18f377990e7ccecd8956a30603c9c17f5de9580d', // Belphin
+      '0x0e1b2c65508b1cd9939cf90337fcefa647936a98', // 1155f0
+    ]);
   }
   getMinimumLiquidityThreshold(): BigDecimal {
     return BigDecimal.fromString("10000");

--- a/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-base/configurations.ts
+++ b/subgraphs/uniswap-v3-forks/protocols/uniswap-v3/config/deployments/uniswap-v3-base/configurations.ts
@@ -83,6 +83,7 @@ export class UniswapV3BaseConfigurations implements Configurations {
       '0x0d3031225f4471eafdb1707db807cbb00eb561cc', // Floating Point
       '0x18f377990e7ccecd8956a30603c9c17f5de9580d', // Belphin
       '0x0e1b2c65508b1cd9939cf90337fcefa647936a98', // 1155f0
+      '0x0a7df211de68b10e9a833a42d8d30b9f0358ab6d', // Base Trade
     ]);
   }
   getMinimumLiquidityThreshold(): BigDecimal {


### PR DESCRIPTION
# Summary

This PR Blacklists a set of 5 tokens that are currently throwing off the TVL in the Uniswap V3 Base subgraph

<img width="544" alt="Screenshot 2024-04-15 at 11 35 07 AM" src="https://github.com/messari/subgraphs/assets/56660047/8f6d00bb-16e0-47b6-848f-39c734488297">

<img width="973" alt="Screenshot 2024-04-15 at 11 35 31 AM" src="https://github.com/messari/subgraphs/assets/56660047/c052710e-0fc2-428f-bbb6-abb2c6d125be">

<img width="1094" alt="Screenshot 2024-04-15 at 11 36 05 AM" src="https://github.com/messari/subgraphs/assets/56660047/15ee066b-ed46-4af8-b889-e403652fcbb0">
