### PR TITLE
[DAT-2640]; Remove apt update & upgrade from monitor dockerfile

### DIFF
--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:20
 
-RUN apt update && apt upgrade --yes
-
 WORKDIR /
 
 COPY package*.json ./


### PR DESCRIPTION
**Context:**

We can safely remove `apt update && apt upgrade --yes`. We don't need to further update packages, they'll be recent on node:20. This change is in an attempt to resolve build error in subgraph monitor deployment