### PR TITLE
[DAT-2663]; Update versions in deployment.json per DN deployment

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -336,7 +336,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.1.0",
-          "subgraph": "2.4.0",
+          "subgraph": "2.4.2",
           "methodology": "1.1.0"
         },
         "files": {
@@ -388,7 +388,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.1.0",
-          "subgraph": "2.4.0",
+          "subgraph": "2.4.1",
           "methodology": "1.1.0"
         },
         "files": {
@@ -514,7 +514,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.1.0",
-          "subgraph": "2.4.0",
+          "subgraph": "2.4.1",
           "methodology": "1.1.0"
         },
         "files": {
@@ -592,7 +592,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.1.0",
-          "subgraph": "1.3.0",
+          "subgraph": "1.3.1",
           "methodology": "1.0.0"
         },
         "files": {


### PR DESCRIPTION
**Context:**

The subgraph studio UI was being pretty buggy, and I thought that some of the deployments got messed up so I incremented the versions. No changes are actually indicated by these version updates, but they will keep the deployment.json up to date with the Arbitrum DN deployments. 