### PR TITLE
[DAT-2562]; Update node version to address security vulnerability

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,7 +1,5 @@
 # pull the base image
-FROM node:lts-alpine
-
-RUN apk update && apk upgrade
+FROM node:20
 
 # set the working direction
 WORKDIR /app


### PR DESCRIPTION
**Context:**
We want to see if pushing through an update of the node version to node:20 will resolve the security vulnerability issues we are facing in the subgraph monitor. 

The Dashboard is still up and functional after this update when run locally with docker as shown in the images below.

<img width="1440" alt="Screenshot 2024-04-29 at 5 24 46 PM" src="https://github.com/messari/subgraphs/assets/56660047/9f4b30a8-4103-43f5-9f59-32cc9d98aa2f">

<img width="1426" alt="Screenshot 2024-04-29 at 5 25 05 PM" src="https://github.com/messari/subgraphs/assets/56660047/569e35bd-4187-4801-a2c1-9d28c848f94d">
