### PR TITLE
fix(#patch); lido; Fix protocol side revenue

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -2848,7 +2848,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.4.0",
-          "subgraph": "1.0.7",
+          "subgraph": "1.0.8",
           "methodology": "1.0.0"
         },
         "files": {

--- a/subgraphs/lido/protocols/lido/config/deployments/lido-ethereum/configurations.json
+++ b/subgraphs/lido/protocols/lido/config/deployments/lido-ethereum/configurations.json
@@ -1,5 +1,5 @@
 {
   "graftEnabled": false,
-  "subgraphId": "",
-  "graftStartBlock": 0
+  "subgraphId": "QmYh4s6bVHBrZftuqNsMrMyVqHUUUQiZhuaGhXgnx8ydZJ",
+  "graftStartBlock": 17266004
 }

--- a/subgraphs/lido/src/mappings/Lido.ts
+++ b/subgraphs/lido/src/mappings/Lido.ts
@@ -95,27 +95,23 @@ export function handleTransfer(event: Transfer): void {
     fromZeros && recipient == Address.fromString(PROTOCOL_TREASURY_ID);
   let isMintToNodeOperators = false;
 
-  if (event.block.number < LIDO_V2_UPGRADE_BLOCK) {
-    // get node operators
-    let nodeOperators: Address[] = [];
-    const nodeOperatorsRegistry = NodeOperatorsRegistry.bind(
-      Address.fromString(PROTOCOL_NODE_OPERATORS_REGISTRY_ID)
-    );
-    const getRewardsDistributionCallResult =
-      nodeOperatorsRegistry.try_getRewardsDistribution(BIGINT_ZERO);
-    if (getRewardsDistributionCallResult.reverted) {
-      log.info("NodeOperatorsRegistry call reverted", []);
-    } else {
-      nodeOperators = getRewardsDistributionCallResult.value.getRecipients();
-    }
-
-    isMintToNodeOperators =
-      fromZeros && (nodeOperators.includes(recipient) as boolean);
+  // get node operators
+  let nodeOperators: Address[] = [];
+  const nodeOperatorsRegistry = NodeOperatorsRegistry.bind(
+    Address.fromString(PROTOCOL_NODE_OPERATORS_REGISTRY_ID)
+  );
+  const getRewardsDistributionCallResult =
+    nodeOperatorsRegistry.try_getRewardsDistribution(BIGINT_ZERO);
+  if (getRewardsDistributionCallResult.reverted) {
+    log.info("NodeOperatorsRegistry call reverted", []);
   } else {
-    isMintToNodeOperators =
-      fromZeros &&
-      recipient == Address.fromString(PROTOCOL_NODE_OPERATORS_REGISTRY_ID);
+    nodeOperators = getRewardsDistributionCallResult.value.getRecipients();
   }
+
+  isMintToNodeOperators =
+    fromZeros &&
+    ((nodeOperators.includes(recipient) as boolean) ||
+      recipient == Address.fromString(PROTOCOL_NODE_OPERATORS_REGISTRY_ID));
 
   // update metrics
   if (isMintToTreasury || isMintToNodeOperators) {


### PR DESCRIPTION
- In Lido V2 (after withdrawals were activated), reward distribution to nodes was changed (earlier directly, now via the node registry). In the early migration phase, rewards appear to be distributed in both ways. The subgraph had an if/else switch that did not account for this overlap.
- Deployment: https://okgraph.xyz/?q=dhruv-chauhan%2Flido-ethereum