### PR TITLE
[DAT-2888] Deploy Subgraphs To Decentralized Network

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -540,7 +540,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.1.0",
-          "subgraph": "1.4.0",
+          "subgraph": "1.4.1",
           "methodology": "1.1.0"
         },
         "files": {
@@ -669,7 +669,7 @@
           },
           "decentralized-network": {
             "slug": "seamless-protocol-base",
-            "query-id": "todo"
+            "query-id": "2u4mWUV4xS19ef1MbnxZHWLLMwdPxtVifH46JbonXwXP"
           }
         }
       }
@@ -2135,7 +2135,7 @@
           },
           "decentralized-network": {
             "slug": "moonwell-base",
-            "query-id": "todo"
+            "query-id": "33ex1ExmYQtwGVwri1AP3oMFPGSce6YbocBP7fWbsBrg"
           }
         }
       }
@@ -2426,7 +2426,7 @@
         "status": "prod",
         "versions": {
           "schema": "3.1.0",
-          "subgraph": "1.1.0",
+          "subgraph": "2.2.3",
           "methodology": "1.0.0"
         },
         "files": {
@@ -2712,7 +2712,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.0.2",
+          "subgraph": "1.1.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -3503,7 +3503,7 @@
           },
           "decentralized-network": {
             "slug": "morpho-aave-v3-ethereum",
-            "query-id": "TODO"
+            "query-id": "FKe6ANnWmGPE6hajGLoTgPrVF2jYPHiRu2Jwcg9ZmG9A"
           }
         }
       }
@@ -7798,7 +7798,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.4.0",
-          "subgraph": "1.0.3",
+          "subgraph": "1.0.4",
           "methodology": "1.0.0"
         },
         "services": {
@@ -10473,7 +10473,7 @@
     "deployments": {
       "stader-ethereum": {
         "network": "mainnet",
-        "status": "dev",
+        "status": "prod",
         "versions": {
           "schema": "3.0.0",
           "subgraph": "1.0.0",
@@ -10493,7 +10493,7 @@
           },
           "decentralized-network": {
             "slug": "stader-ethereum",
-            "query-id": "TODO"
+            "query-id": "2RLAUqUMvGGFygtuJfmTyeo62zFSJswDZSRMTcu28fSa"
           }
         }
       }
@@ -10527,7 +10527,7 @@
           },
           "decentralized-network": {
             "slug": "etherfi-ethereum",
-            "query-id": "TODO"
+            "query-id": "GPwCNqJ5aroTtkk48Y57pBjFHVkeYmMzmBpE1a7WF7Hc"
           }
         }
       }
@@ -10561,7 +10561,7 @@
           },
           "decentralized-network": {
             "slug": "frax-ether-staking-ethereum",
-            "query-id": "TODO"
+            "query-id": "FeKHrGeNxVctN6EeAhba2Kv78xNxuEhbRKNECLfVH8z2"
           }
         }
       },
@@ -10587,7 +10587,7 @@
           },
           "decentralized-network": {
             "slug": "frax-ether-staking-arbitrum",
-            "query-id": "TODO"
+            "query-id": "FSafXUhkuwqARZNNe82isspkjQJcPK2PrSjQLvNXuakU"
           }
         }
       },
@@ -10613,7 +10613,7 @@
           },
           "decentralized-network": {
             "slug": "frax-ether-staking-bsc",
-            "query-id": "TODO"
+            "query-id": "A113zHKpiXzugLyKDVknAxjQ6qFSPQwfiGK7rjiuqbcq"
           }
         }
       },
@@ -10639,7 +10639,7 @@
           },
           "decentralized-network": {
             "slug": "frax-ether-staking-fantom",
-            "query-id": "TODO"
+            "query-id": "Ba52AgUJfCmWQpBJEwRvygC45iGr9uqnrehpymN2Xmx4"
           }
         }
       },
@@ -10665,7 +10665,7 @@
           },
           "decentralized-network": {
             "slug": "frax-ether-staking-moonbeam",
-            "query-id": "TODO"
+            "query-id": "FhaAErF9146bnqJsQD34zPHNC11quKTuk9HBA7RdGrjz"
           }
         }
       },
@@ -10691,7 +10691,7 @@
           },
           "decentralized-network": {
             "slug": "frax-ether-staking-optimism",
-            "query-id": "TODO"
+            "query-id": "G9nDvQw6S7LkzNxj7oGFZUsahe3ebpAtEww716kWkfZd"
           }
         }
       },
@@ -10717,7 +10717,7 @@
           },
           "decentralized-network": {
             "slug": "frax-ether-staking-polygon",
-            "query-id": "TODO"
+            "query-id": "FMkrjPgSyGm2UBFrMqpJVwWgGHLek8U39W1M4R9TfP1T"
           }
         }
       }
@@ -10751,7 +10751,7 @@
           },
           "decentralized-network": {
             "slug": "mantle-staked-eth-ethereum",
-            "query-id": "todo"
+            "query-id": "VVKZagj4XUyamqXysVBniarN8HMz87DnwkTChuXH18Z"
           }
         }
       }
@@ -10785,7 +10785,7 @@
           },
           "decentralized-network": {
             "slug": "swell-liquid-staking-ethereum",
-            "query-id": "todo"
+            "query-id": "F8nUFWAC9vE1gHcUj5ZHXSt53eXo9vRqf2SuCcYVs93S"
           }
         }
       }
@@ -10819,7 +10819,7 @@
           },
           "decentralized-network": {
             "slug": "puffer-finance-ethereum",
-            "query-id": "TODO"
+            "query-id": "F8nUFWAC9vE1gHcUj5ZHXSt53eXo9vRqf2SuCcYVs93S"
           }
         }
       }

--- a/subgraphs/ellipsis-finance/src/common/constants.ts
+++ b/subgraphs/ellipsis-finance/src/common/constants.ts
@@ -6,9 +6,6 @@ import { Address, BigDecimal, BigInt } from "@graphprotocol/graph-ts";
 
 export const PROTOCOL_NAME = "Ellipsis Finance";
 export const PROTOCOL_SLUG = "ellipses-finance";
-export const PROTOCOL_SCHEMA_VERSION = "1.3.0";
-export const PROTOCOL_SUBGRAPH_VERSION = "1.0.1";
-export const PROTOCOL_METHODOLOGY_VERSION = "1.0.0";
 
 ////////////////////////
 ///// Schema Enums /////

--- a/subgraphs/ellipsis-finance/src/common/initializers.ts
+++ b/subgraphs/ellipsis-finance/src/common/initializers.ts
@@ -18,6 +18,7 @@ import { LpToken as LPTokenContract } from "../../generated/Factory/LpToken";
 import { Address, ethereum, BigDecimal, BigInt } from "@graphprotocol/graph-ts";
 import { ERC20 as ERC20Contract } from "../../generated/templates/PoolTemplate/ERC20";
 import { PoolTemplate } from "../../generated/templates";
+import { Versions } from "../versions";
 
 export function getOrCreateLiquidityPool(
   address: Address,
@@ -96,9 +97,9 @@ export function getOrCreateDexAmmProtocol(): DexAmmProtocol {
     protocol = new DexAmmProtocol(constants.REGISTRY_ADDRESS.toHexString());
     protocol.name = constants.PROTOCOL_NAME;
     protocol.slug = constants.PROTOCOL_SLUG;
-    protocol.schemaVersion = constants.PROTOCOL_SCHEMA_VERSION;
-    protocol.subgraphVersion = constants.PROTOCOL_SUBGRAPH_VERSION;
-    protocol.methodologyVersion = constants.PROTOCOL_METHODOLOGY_VERSION;
+    protocol.schemaVersion = Versions.getSchemaVersion();
+    protocol.subgraphVersion = Versions.getSubgraphVersion();
+    protocol.methodologyVersion = Versions.getMethodologyVersion();
     protocol.network = constants.Network.BSC;
     protocol.type = constants.ProtocolType.EXCHANGE;
 

--- a/subgraphs/uniswap-forks/protocols/ubeswap/config/deployments/ubeswap-celo/configurations.json
+++ b/subgraphs/uniswap-forks/protocols/ubeswap/config/deployments/ubeswap-celo/configurations.json
@@ -5,7 +5,7 @@
   "startBlock": 5272596,
   "poolManagerAddress": "0x9Ee3600543eCcc85020D6bc77EB553d1747a65D2",
   "poolManagerStartBlock": 6234663,
-  "graftEnabled": true,
+  "graftEnabled": false,
   "subgraphId": "QmXUSNNZBCoKFZRA6rU76VgCbnymh7uxmbFMH5uEA5sqyg",
   "graftStartBlock": 15279205
 }


### PR DESCRIPTION
# Context

The purpose of this PR is to:
1. Deploy new subgraphs to the decentralized network and add query IDs to the deployment.json
2. Make other corresponding changes to updating OOS decentralized network deployments.

## New Decentralize Network Subgraphs
- Mantle Staked Ethereum
- Moonwell Base
- Seamless
- Morpho Aave V3 Ethereum
- Etherfi
- Puffer Swell Liquid Staking
- Stader
- Frax Ether Staking

## Changes
- Add query ids for new decentralized network deployments to the deployment.json
- Update Ubeswap Celo to set graft = false to fix DN deployment
- Update ellipsis finance to have versions propagated from the deployment.json
- Update version for TC Ethereum, Aave V3 Base, Compound V3 Base, and Ellipsis BSC to fix bug in DN deployment. 