### PR TITLE
Subgraphs.xyz charting quick fix

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -65,6 +65,12 @@ function App() {
           })
           .then(function (json) {
             setLoading(false);
+            // Hacky fix for the subgraph status API returning an error response, setting protocols to empty object.
+            // Status Page Will Not Load With This Condition, but the charting will work.
+            if (JSON.stringify(Object.keys(json)) == JSON.stringify(['error', 'data'])) {
+              console.log("Error Response from Messari Subgraph Status API. Setting protocols to empty object.");
+              json = {};
+            }
             setProtocolsToQuery(json);
           })
           .catch((err) => {

--- a/dashboard/src/common/DashboardVersion.tsx
+++ b/dashboard/src/common/DashboardVersion.tsx
@@ -11,7 +11,7 @@ const DashboardTag = styled("div")`
   z-index: 2;
 `;
 
-export const dashboardVersion = "v2.4.0";
+export const dashboardVersion = "v2.5.0";
 
 export const DashboardVersion = () => {
   return <DashboardTag>{dashboardVersion}</DashboardTag>;


### PR DESCRIPTION
# Summary

Subgraphs.xyz has been unstable because of errors returned from the subgraph status service. This has been causing the entire app to crash. This is a quick fix for the charting feature while the status service is being fixed that prevents the app from crashing when the status service returns an error. 

## Before 
<img width="1458" alt="Screenshot 2024-07-05 at 12 01 20 PM" src="https://github.com/messari/subgraphs/assets/56660047/de8c9e79-f1d6-473b-83fa-604fce67b6c4">