### PR TITLE
Add Uniswap V2 Swap Ethereum query ID for Arbitrum Decentralized Network

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -6164,6 +6164,10 @@
           "hosted-service": {
             "slug": "uniswap-v2-swap-ethereum",
             "query-id": "uniswap-v2-swap-ethereum"
+          },
+          "decentralized-network": {
+            "slug": "uniswap-v2-swap-ethereum",
+            "query-id": "3onEbd9MLfXTTWAfP91yqsKr7C68VCT2ZiF7EoQiQAFj"
           }
         }
       }


### PR DESCRIPTION
**Context**

Uniswap V2 Swap Ethereum subgraph has already been deployed to the Arbitrum Decentralize Network. Here I am just adding the query ID to the deployment.json.