### PR TITLE
fix(#patch); convex-finance; fix div by zero

### DIFF
--- a/deployment/deployment.json
+++ b/deployment/deployment.json
@@ -1072,7 +1072,7 @@
         "status": "prod",
         "versions": {
           "schema": "1.3.0",
-          "subgraph": "1.3.0",
+          "subgraph": "1.4.0",
           "methodology": "1.0.0"
         },
         "files": {
@@ -1089,7 +1089,7 @@
           },
           "decentralized-network": {
             "slug": "convex-finance-ethereum",
-            "query-id": "7rFZ2x6aLQ7EZsNx8F5yenk4xcqwqR3Dynf9rdixCSME"
+            "query-id": "todo"
           }
         }
       }

--- a/subgraphs/convex-finance/protocols/convex-finance/config/deployments/convex-finance-ethereum/configurations.json
+++ b/subgraphs/convex-finance/protocols/convex-finance/config/deployments/convex-finance-ethereum/configurations.json
@@ -1,5 +1,5 @@
 {
   "graft": false,
-  "base": "",
-  "block": 0
+  "base": "QmTZozrLfSy3WtcbFcUFu9iruKYeBMaEdrsw1MnCZjVfLX",
+  "block": 21510541
 }

--- a/subgraphs/convex-finance/src/prices/common/utils.ts
+++ b/subgraphs/convex-finance/src/prices/common/utils.ts
@@ -179,3 +179,11 @@ export function averagePrice(prices: CustomPriceType[]): CustomPriceType {
     constants.DEFAULT_USDC_DECIMALS
   );
 }
+
+export function safeDiv(amount0: BigDecimal, amount1: BigDecimal): BigDecimal {
+  if (amount1.equals(constants.BIGDECIMAL_ZERO)) {
+    return constants.BIGDECIMAL_ZERO;
+  } else {
+    return amount0.div(amount1);
+  }
+}

--- a/subgraphs/convex-finance/src/prices/routers/CurveRouter.ts
+++ b/subgraphs/convex-finance/src/prices/routers/CurveRouter.ts
@@ -203,13 +203,14 @@ export function cryptoPoolLpPriceUsdc(
   const totalSupply = utils.getTokenSupply(lpAddress);
 
   const totalValueUsdc = cryptoPoolLpTotalValueUsdc(lpAddress, block);
-  const priceUsdc = totalValueUsdc
-    .times(
+  const priceUsdc = utils.safeDiv(
+    totalValueUsdc.times(
       constants.BIGINT_TEN.pow(
         constants.DEFAULT_DECIMALS.toI32() as u8
       ).toBigDecimal()
-    )
-    .div(totalSupply.toBigDecimal());
+    ),
+    totalSupply.toBigDecimal()
+  );
 
   return CustomPriceType.initialize(
     priceUsdc,

--- a/subgraphs/convex-finance/yarn.lock
+++ b/subgraphs/convex-finance/yarn.lock
@@ -1640,6 +1640,11 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
+"fsevents@~2.3.2":
+  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  "version" "2.3.2"
+
 "get-iterator@^1.0.2":
   "integrity" "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
   "resolved" "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz"


### PR DESCRIPTION
- Fixes: https://okgraph.xyz/?q=QmTZozrLfSy3WtcbFcUFu9iruKYeBMaEdrsw1MnCZjVfLX
```
A determinstic fatal error occured at block 21510542: transaction e5442e46853efb25d4034b943861d99ad6c29412e6c447139ee934197f79a82d: error while executing at wasm backtrace: 0: 0x62c2 - <unknown>!~lib/@graphprotocol/graph-ts/common/numbers/BigDecimal#div 1: 0x92e6 - <unknown>!src/prices/routers/CurveRouter/getCurvePriceUsdc 2: 0xc0cb - <unknown>!src/prices/index/getUsdPricePerToken 3: 0xef8f - <unknown>!src/modules/Withdraw/withdraw 4: 0xf2e1 - <unknown>!src/mappings/boosterMappings/handleWithdrawn: attempted to divide BigDecimal `0` by zero in handler `handleWithdrawn` at block #21510542 (c2b4fcfe4546b8d6af479c63609fa0b3525fcbfe8aa743ee69b4cd6ffd18df41)
```
- Deployment: https://okgraph.xyz/?q=QmXfmRi6GfuTPJX779SK3b769rtVCrVpeRqJEaCC5JWQNZ